### PR TITLE
Custom offset

### DIFF
--- a/VSRAD.DebugServer/Handlers/FetchResultRangeHandler.cs
+++ b/VSRAD.DebugServer/Handlers/FetchResultRangeHandler.cs
@@ -43,7 +43,7 @@ namespace VSRAD.DebugServer.Handlers
             using (var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read, _bufferSize, FileOptions.SequentialScan))
             {
                 byte[] buffer = new byte[_command.ByteCount];
-                stream.Seek(_command.ByteOffset, SeekOrigin.Begin);
+                stream.Seek(_command.ByteOffset + _command.OutputOffset, SeekOrigin.Begin);
                 int read = await stream.ReadAsync(buffer, 0, _command.ByteCount);
                 byte[] data = new byte[read];
                 Array.Copy(buffer, data, read);
@@ -56,7 +56,8 @@ namespace VSRAD.DebugServer.Handlers
             using (var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read, _bufferSize, FileOptions.SequentialScan))
             using (var reader = new StreamReader(stream))
             {
-                reader.ReadLine();
+                for (int i = 0; i < _command.OutputOffset; i++)
+                    reader.ReadLine();
 
                 var values = new List<uint>();
                 var offset = (_command.ByteOffset % 4 == 0)

--- a/VSRAD.DebugServer/Handlers/FetchResultRangeHandler.cs
+++ b/VSRAD.DebugServer/Handlers/FetchResultRangeHandler.cs
@@ -59,7 +59,9 @@ namespace VSRAD.DebugServer.Handlers
                 reader.ReadLine();
 
                 var values = new List<uint>();
-                var offset = (_command.ByteOffset % 4 == 0) ? 0 : _command.ByteOffset - (4 - _command.ByteOffset % 4);
+                var offset = (_command.ByteOffset % 4 == 0)
+                    ? _command.ByteOffset
+                    : _command.ByteOffset - (4 - _command.ByteOffset % 4);
                 var read = 0;
                 for (; read < offset + _command.ByteCount; read += 4)
                 {

--- a/VSRAD.DebugServer/IPC/Commands.cs
+++ b/VSRAD.DebugServer/IPC/Commands.cs
@@ -115,6 +115,7 @@ namespace VSRAD.DebugServer.IPC.Commands
         public int ByteOffset { get; set; }
 
         public int ByteCount { get; set; }
+        public int OutputOffset { get; set; }
 
         public override string ToString() => string.Join(Environment.NewLine, new[]
         {
@@ -122,7 +123,8 @@ namespace VSRAD.DebugServer.IPC.Commands
             $"FilePath = {string.Join(", ", FilePath)}",
             $"BinaryOutput = {BinaryOutput}",
             $"ByteOffset = {ByteOffset}",
-            $"ByteCount = {ByteCount}"
+            $"ByteCount = {ByteCount}",
+            $"OutputOffset = {OutputOffset}"
         });
 
         public static FetchResultRange Deserialize(IPCReader reader) => new FetchResultRange
@@ -130,7 +132,8 @@ namespace VSRAD.DebugServer.IPC.Commands
             FilePath = reader.ReadLengthPrefixedStringArray(),
             BinaryOutput = reader.ReadBoolean(),
             ByteOffset = reader.ReadInt32(),
-            ByteCount = reader.ReadInt32()
+            ByteCount = reader.ReadInt32(),
+            OutputOffset = reader.ReadInt32()
         };
 
         public void Serialize(IPCWriter writer)
@@ -139,6 +142,7 @@ namespace VSRAD.DebugServer.IPC.Commands
             writer.Write(BinaryOutput);
             writer.Write(ByteOffset);
             writer.Write(ByteCount);
+            writer.Write(OutputOffset);
         }
     }
 

--- a/VSRAD.Package/Options/DefaultOptionValues.cs
+++ b/VSRAD.Package/Options/DefaultOptionValues.cs
@@ -23,6 +23,7 @@ namespace VSRAD.Package.Options
         public const string DebuggerValidWatchesFilePath = "";
         public const bool DebuggerRunAsAdmin = false;
         public const int DebuggerTimeoutSecs = 0;
+        public const int OutputOffset = 0;
         #endregion
         #region Disassembler
         public const string DisassemblerExecutable = "";

--- a/VSRAD.Package/Options/ProfileOptions.cs
+++ b/VSRAD.Package/Options/ProfileOptions.cs
@@ -132,6 +132,9 @@ namespace VSRAD.Package.Options
         [Description("Debugger Timeout (seconds), 0 - timeout disabled"), DisplayName("Timeout")]
         [DefaultValue(DefaultOptionValues.DebuggerTimeoutSecs)]
         public int TimeoutSecs { get; }
+        [Description("")]
+        [DefaultValue(DefaultOptionValues.OutputOffset)]
+        public int OutputOffset { get; }
 
         [JsonIgnore]
         public OutputFile RemoteOutputFile => new OutputFile(WorkingDirectory, OutputPath, BinaryOutput);
@@ -144,13 +147,14 @@ namespace VSRAD.Package.Options
                 arguments: await macroEvaluator.GetMacroValueAsync(RadMacros.DebuggerArguments),
                 workingDirectory: await macroEvaluator.GetMacroValueAsync(RadMacros.DebuggerWorkingDirectory),
                 outputPath: await macroEvaluator.GetMacroValueAsync(RadMacros.DebuggerOutputPath),
+                outputOffset: OutputOffset,
                 binaryOutput: BinaryOutput,
                 runAsAdmin: RunAsAdmin,
                 timeoutSecs: TimeoutSecs,
                 parseValidWatches: ParseValidWatches,
                 validWatchesFilePath: ValidWatchesFilePath);
 
-        public DebuggerProfileOptions(string executable = null, string arguments = null, string workingDirectory = DefaultOptionValues.DebuggerWorkingDirectory, string outputPath = DefaultOptionValues.DebuggerOutputPath, bool binaryOutput = DefaultOptionValues.DebuggerBinaryOutput, bool runAsAdmin = DefaultOptionValues.DebuggerRunAsAdmin, int timeoutSecs = DefaultOptionValues.DebuggerTimeoutSecs, bool parseValidWatches = DefaultOptionValues.DebuggerParseValidWatches, string validWatchesFilePath = DefaultOptionValues.DebuggerValidWatchesFilePath)
+        public DebuggerProfileOptions(string executable = null, string arguments = null, string workingDirectory = DefaultOptionValues.DebuggerWorkingDirectory, string outputPath = DefaultOptionValues.DebuggerOutputPath, bool binaryOutput = DefaultOptionValues.DebuggerBinaryOutput, bool runAsAdmin = DefaultOptionValues.DebuggerRunAsAdmin, int timeoutSecs = DefaultOptionValues.DebuggerTimeoutSecs, bool parseValidWatches = DefaultOptionValues.DebuggerParseValidWatches, string validWatchesFilePath = DefaultOptionValues.DebuggerValidWatchesFilePath, int outputOffset = 0)
         {
             Executable = executable ?? DefaultOptionValues.DebuggerExecutable;
             Arguments = arguments ?? DefaultOptionValues.DebuggerArguments;
@@ -161,6 +165,7 @@ namespace VSRAD.Package.Options
             TimeoutSecs = timeoutSecs;
             ParseValidWatches = parseValidWatches;
             ValidWatchesFilePath = validWatchesFilePath;
+            OutputOffset = outputOffset;
         }
     }
 

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -40,8 +40,9 @@ namespace VSRAD.Package.Server
         private readonly uint _outputDwordCount;
         private readonly uint _recordSize;
         private readonly ICommunicationChannel _channel;
+        private readonly int _outputOffset;
 
-        public BreakState(Options.OutputFile outputFile, DateTime outputTimestamp, uint outputByteCount, ReadOnlyCollection<string> watches, ICommunicationChannel channel)
+        public BreakState(Options.OutputFile outputFile, DateTime outputTimestamp, uint outputByteCount, int outputOffset, ReadOnlyCollection<string> watches, ICommunicationChannel channel)
         {
             _outputFile = outputFile;
             _outputTimestamp = outputTimestamp;
@@ -49,6 +50,7 @@ namespace VSRAD.Package.Server
             _recordSize = 1 /* hidden */ + (uint)watches.Count;
             Watches = watches;
             _channel = channel;
+            _outputOffset = outputOffset;
         }
 
         public uint[] System { get; } = new uint[512];
@@ -107,7 +109,7 @@ namespace VSRAD.Package.Server
 
         private async Task<uint[]> FetchGroupAsync(uint groupIndex)
         {
-            int byteOffset = (int)(4 * groupIndex * GroupSize * _recordSize);
+            int byteOffset = (int)((4 * groupIndex * GroupSize * _recordSize) + _outputOffset);
             int byteCount = (int)(4 * GroupSize * _recordSize);
             var response = await _channel.SendWithReplyAsync<DebugServer.IPC.Responses.ResultRangeFetched>(
                 new DebugServer.IPC.Commands.FetchResultRange

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -109,7 +109,7 @@ namespace VSRAD.Package.Server
 
         private async Task<uint[]> FetchGroupAsync(uint groupIndex)
         {
-            int byteOffset = (int)((4 * groupIndex * GroupSize * _recordSize) + _outputOffset);
+            int byteOffset = (int)(4 * groupIndex * GroupSize * _recordSize);
             int byteCount = (int)(4 * GroupSize * _recordSize);
             var response = await _channel.SendWithReplyAsync<DebugServer.IPC.Responses.ResultRangeFetched>(
                 new DebugServer.IPC.Commands.FetchResultRange
@@ -117,7 +117,8 @@ namespace VSRAD.Package.Server
                     FilePath = _outputFile.Path,
                     BinaryOutput = _outputFile.BinaryOutput,
                     ByteOffset = byteOffset,
-                    ByteCount = byteCount
+                    ByteCount = byteCount,
+                    OutputOffset = _outputOffset
                 }).ConfigureAwait(false);
 
             if (response.Status != DebugServer.IPC.Responses.FetchStatus.Successful)

--- a/VSRAD.Package/Server/DebugSession.cs
+++ b/VSRAD.Package/Server/DebugSession.cs
@@ -192,6 +192,7 @@ namespace VSRAD.Package.Server
                 return new BreakState(outputFile,
                     metadataResponse.Timestamp,
                     (uint)metadataResponse.ByteCount,
+                    _project.Options.Profile.Debugger.OutputOffset,
                     watches, _channel);
             }
             await VSPackage.TaskFactory.SwitchToMainThreadAsync();

--- a/VSRAD.PackageTests/Server/BreakStateTests.cs
+++ b/VSRAD.PackageTests/Server/BreakStateTests.cs
@@ -19,7 +19,7 @@ namespace VSRAD.PackageTests.Server
             var channel = new MockCommunicationChannel();
 
             var breakState = new BreakState(new Package.Options.OutputFile("/home/kyubey/projects", "log.tar", true),
-                default, outputByteCount: 4096, watches: new ReadOnlyCollection<string>(new[] { "h" }), channel.Object);
+                default, outputByteCount: 4096, outputOffset: 0, watches: new ReadOnlyCollection<string>(new[] { "h" }), channel.Object);
 
             channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful },
             (command) =>


### PR DESCRIPTION
* Added custom offset property (`Profile edit->Debugger`)
* When output mode is `binary` indicates amount of bytes to skip
* When output mode is `text` indicates amount of lines to skip
* Fixed text offset bug