### PR TITLE
Environment macros

### DIFF
--- a/VSRAD.DebugServer/Dispatcher.cs
+++ b/VSRAD.DebugServer/Dispatcher.cs
@@ -20,6 +20,8 @@ namespace VSRAD.DebugServer
                     return new FetchResultRangeHandler(fetchResultRange).RunAsync();
                 case Deploy deploy:
                     return new DeployHandler(deploy).RunAsync();
+                case ListEnvironmentVariables listEnvironmentVariables:
+                    return new ListEnvironmentVariablesHandler(listEnvironmentVariables).RunAsync();
                 default:
                     throw new ArgumentException($"Unknown command type {command.GetType()}");
             }

--- a/VSRAD.DebugServer/Handlers/ListEnvironmentVariablesHandler.cs
+++ b/VSRAD.DebugServer/Handlers/ListEnvironmentVariablesHandler.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using System.Threading.Tasks;
+using VSRAD.DebugServer.IPC.Responses;
+
+namespace VSRAD.DebugServer.Handlers
+{
+    public sealed class ListEnvironmentVariablesHandler : IHandler
+    {
+        public ListEnvironmentVariablesHandler(IPC.Commands.ListEnvironmentVariables _) { }
+
+        public Task<IResponse> RunAsync()
+        {
+            var variables = Environment.GetEnvironmentVariables()
+                .Cast<DictionaryEntry>()
+                .ToDictionary((e) => (string)e.Key, (e) => (string)e.Value);
+
+            return Task.FromResult<IResponse>(new EnvironmentVariablesListed { Variables = variables });
+        }
+    }
+
+}

--- a/VSRAD.DebugServer/IPC/Commands.cs
+++ b/VSRAD.DebugServer/IPC/Commands.cs
@@ -14,6 +14,7 @@ namespace VSRAD.DebugServer.IPC.Commands
                 case 1: return FetchMetadata.Deserialize(reader);
                 case 2: return FetchResultRange.Deserialize(reader);
                 case 3: return Deploy.Deserialize(reader);
+                case 4: return ListEnvironmentVariables.Deserialize(reader);
             }
             throw new InvalidDataException($"Unexpected command type byte: {commandType}");
         }
@@ -27,6 +28,7 @@ namespace VSRAD.DebugServer.IPC.Commands
                 case FetchMetadata _: commandType = 1; break;
                 case FetchResultRange _: commandType = 2; break;
                 case Deploy _: commandType = 3; break;
+                case ListEnvironmentVariables _: commandType = 4; break;
                 default: throw new ArgumentException($"Unable to serialize {command.GetType()}");
             }
             writer.Write(commandType);
@@ -165,5 +167,14 @@ namespace VSRAD.DebugServer.IPC.Commands
             writer.WriteLengthPrefixedBlob(Data);
             writer.Write(Destination);
         }
+    }
+
+    public sealed class ListEnvironmentVariables : ICommand
+    {
+        public override string ToString() => "ListEnvironmentVariables";
+
+        public static ListEnvironmentVariables Deserialize(IPCReader _) => new ListEnvironmentVariables();
+
+        public void Serialize(IPCWriter _) { }
     }
 }

--- a/VSRAD.DebugServer/IPC/IPCSerialization.cs
+++ b/VSRAD.DebugServer/IPC/IPCSerialization.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System;
 using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
 namespace VSRAD.DebugServer.IPC
 {
@@ -18,6 +19,16 @@ namespace VSRAD.DebugServer.IPC
         {
             Write7BitEncodedInt(data.Length);
             Write(data);
+        }
+
+        public void WriteLengthPrefixedDict(IReadOnlyDictionary<string, string> dictionary)
+        {
+            Write7BitEncodedInt(dictionary.Count);
+            foreach (var (key, value) in dictionary)
+            {
+                Write(key);
+                Write(value);
+            }
         }
 
         public void Write(DateTime timestamp) =>
@@ -42,6 +53,15 @@ namespace VSRAD.DebugServer.IPC
         {
             var length = Read7BitEncodedInt();
             return ReadBytes(length);
+        }
+
+        public Dictionary<string, string> ReadLengthPrefixedStringDict()
+        {
+            var count = Read7BitEncodedInt();
+            var dict = new Dictionary<string, string>(count);
+            for (int i = 0; i < count; ++i)
+                dict[ReadString()] = ReadString();
+            return dict;
         }
 
         public DateTime ReadDateTime() =>

--- a/VSRAD.DebugServer/IPC/IPCSerialization.cs
+++ b/VSRAD.DebugServer/IPC/IPCSerialization.cs
@@ -24,10 +24,10 @@ namespace VSRAD.DebugServer.IPC
         public void WriteLengthPrefixedDict(IReadOnlyDictionary<string, string> dictionary)
         {
             Write7BitEncodedInt(dictionary.Count);
-            foreach (var (key, value) in dictionary)
+            foreach (var entry in dictionary)
             {
-                Write(key);
-                Write(value);
+                Write(entry.Key);
+                Write(entry.Value);
             }
         }
 

--- a/VSRAD.DebugServer/IPC/Responses.cs
+++ b/VSRAD.DebugServer/IPC/Responses.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace VSRAD.DebugServer.IPC.Responses
@@ -133,6 +134,25 @@ namespace VSRAD.DebugServer.IPC.Responses
             writer.Write(Timestamp);
             writer.Write((byte)Status);
         }
+    }
+
+    public sealed class EnvironmentVariablesListed : IResponse
+    {
+        public IReadOnlyDictionary<string, string> Variables { get; set; }
+
+        public override string ToString() => string.Join(Environment.NewLine, new[]
+        {
+            "EnvironmentVariablesListed",
+            $"Variables = <{Variables.Count} items>",
+        });
+
+        public static EnvironmentVariablesListed Deserialize(IPCReader reader) => new EnvironmentVariablesListed
+        {
+            Variables = reader.ReadLengthPrefixedStringDict()
+        };
+
+        public void Serialize(IPCWriter writer) =>
+            writer.WriteLengthPrefixedDict(Variables);
     }
 
     public enum ExecutionStatus : byte

--- a/VSRAD.DebugServer/IPC/Responses.cs
+++ b/VSRAD.DebugServer/IPC/Responses.cs
@@ -14,6 +14,7 @@ namespace VSRAD.DebugServer.IPC.Responses
                 case 0: return ExecutionCompleted.Deserialize(reader);
                 case 1: return MetadataFetched.Deserialize(reader);
                 case 2: return ResultRangeFetched.Deserialize(reader);
+                case 3: return EnvironmentVariablesListed.Deserialize(reader);
             }
             throw new InvalidDataException($"Unexpected response type byte: {responseType}");
         }
@@ -26,6 +27,7 @@ namespace VSRAD.DebugServer.IPC.Responses
                 case ExecutionCompleted _: responseType = 0; break;
                 case MetadataFetched _: responseType = 1; break;
                 case ResultRangeFetched _: responseType = 2; break;
+                case EnvironmentVariablesListed _: responseType = 3; break;
                 default: throw new ArgumentException($"Unable to serialize {response.GetType()}");
             }
             writer.Write(responseType);

--- a/VSRAD.DebugServerTests/Handlers/ExecuteHandlerTest.cs
+++ b/VSRAD.DebugServerTests/Handlers/ExecuteHandlerTest.cs
@@ -51,6 +51,16 @@ namespace VSRAD.DebugServerTests.Handlers
             Assert.Equal(ExecutionStatus.Completed, response.Status);
             Assert.Equal(0, response.ExitCode);
             Assert.Equal("pilot name: ShinjiIkari\r\n", response.Stdout);
+
+            response = await Helper.DispatchCommandAsync<Execute, ExecutionCompleted>(
+                new Execute
+                {
+                    Executable = "python.exe",
+                    Arguments = $"-c \"print('pilot name: $ENVR(I_DONT_EXIST)')\""
+                });
+            Assert.Equal(ExecutionStatus.Completed, response.Status);
+            Assert.Equal(0, response.ExitCode);
+            Assert.Equal("pilot name: \r\n", response.Stdout);
         }
 
         [Fact]

--- a/VSRAD.DebugServerTests/Handlers/ExecuteHandlerTest.cs
+++ b/VSRAD.DebugServerTests/Handlers/ExecuteHandlerTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using VSRAD.DebugServer.IPC.Commands;
 using VSRAD.DebugServer.IPC.Responses;
 using Xunit;
@@ -34,6 +35,22 @@ namespace VSRAD.DebugServerTests.Handlers
 
             var tmpContents = File.ReadAllText(tmpFile);
             Assert.Equal("command ran successfully\r\n", tmpContents);
+        }
+
+        [Fact]
+        public async void RunCommandWithEnvVariable()
+        {
+            Environment.SetEnvironmentVariable("PILOT_NAME", "ShinjiIkari");
+
+            var response = await Helper.DispatchCommandAsync<Execute, ExecutionCompleted>(
+                new Execute
+                {
+                    Executable = "python.exe",
+                    Arguments = $"-c \"print('pilot name: $ENVR(PILOT_NAME)')\""
+                });
+            Assert.Equal(ExecutionStatus.Completed, response.Status);
+            Assert.Equal(0, response.ExitCode);
+            Assert.Equal("pilot name: ShinjiIkari\r\n", response.Stdout);
         }
 
         [Fact]

--- a/VSRAD.DebugServerTests/Handlers/ListEnvironmentVariablesHandlerTest.cs
+++ b/VSRAD.DebugServerTests/Handlers/ListEnvironmentVariablesHandlerTest.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections;
+using VSRAD.DebugServer.IPC.Commands;
+using VSRAD.DebugServer.IPC.Responses;
+using Xunit;
+
+namespace VSRAD.DebugServerTests.Handlers
+{
+    public class ListEnvironmentVariablesHandlerTest
+    {
+        [Fact]
+        public async void EnvironmentVariablesTest()
+        {
+            var envVars = Environment.GetEnvironmentVariables();
+
+            // Verify that the command is dispatched correctly
+            var response = await Helper.DispatchCommandAsync<ListEnvironmentVariables, EnvironmentVariablesListed>(
+                new ListEnvironmentVariables());
+
+            // Ensure that serialization/deserialization works as expected
+            Assert.Equal(envVars.Count, response.Variables.Count);
+            foreach (DictionaryEntry e in envVars)
+                Assert.Equal((string)e.Value, response.Variables[(string)e.Key]);
+        }
+    }
+}

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEditManager.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEditManager.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.Shell;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using VSRAD.Package.Server;
+using VSRAD.Package.Utils;
+
+namespace VSRAD.Package.ProjectSystem.Macros
+{
+    [Export]
+    [AppliesTo(Constants.ProjectCapability)]
+    public sealed class MacroEditManager
+    {
+        private readonly UnconfiguredProject _unconfiguredProject;
+        private readonly IProject _project;
+        private readonly ICommunicationChannel _channel;
+
+        [ImportingConstructor]
+        public MacroEditManager(UnconfiguredProject unconfiguredProject, IProject project, ICommunicationChannel channel)
+        {
+            _unconfiguredProject = unconfiguredProject;
+            _project = project;
+            _channel = channel;
+        }
+
+        public async Task<string> EditAsync(string macroName, string currentValue, Options.ProfileOptions profileOptions)
+        {
+            var configuredProject = await _unconfiguredProject.GetSuggestedConfiguredProjectAsync();
+            var propertiesProvider = configuredProject.GetService<IProjectPropertiesProvider>("ProjectPropertiesProvider");
+            var projectProperties = propertiesProvider.GetCommonProperties();
+
+            var evaluator = new MacroEvaluator(_project, projectProperties,
+                values: new MacroEvaluatorTransientValues(activeSourceFile: ("<current source file>", 0)),
+                profileOptionsOverride: profileOptions);
+
+            await VSPackage.TaskFactory.SwitchToMainThreadAsync();
+
+            var editor = new MacroEditor(macroName, currentValue, evaluator);
+            editor.LoadPreviewListInBackground(projectProperties, _channel);
+
+            var editorWindow = new MacroEditorWindow(editor);
+            editorWindow.ShowDialog();
+
+            return editor.MacroValue;
+        }
+    }
+}

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEditor.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEditor.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
@@ -53,6 +55,9 @@ namespace VSRAD.Package.ProjectSystem.Macros
 
             foreach (var macroName in vsMacroNames.Union(radMacroNames))
                 macros["$(" + macroName + ")"] = await evaluator.GetMacroValueAsync(macroName);
+
+            foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+                macros["$ENV(" + (string)entry.Key + ")"] = (string)entry.Value;
 
             return macros;
         }

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEditor.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEditor.cs
@@ -1,63 +1,79 @@
-﻿using Microsoft.VisualStudio.ProjectSystem;
-using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.Shell;
+﻿using Microsoft.VisualStudio.ProjectSystem.Properties;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
+using VSRAD.Package.Server;
 using VSRAD.Package.Utils;
 
 namespace VSRAD.Package.ProjectSystem.Macros
 {
-    [Export]
-    [AppliesTo(Constants.ProjectCapability)]
-    public sealed class MacroEditor
+    public sealed class MacroEditor : DefaultNotifyPropertyChanged
     {
-        private readonly UnconfiguredProject _unconfiguredProject;
-        private readonly IProject _project;
+        public string MacroName { get; }
 
-        [ImportingConstructor]
-        public MacroEditor(UnconfiguredProject unconfiguredProject, IProject project)
+        private string _macroValue;
+        public string MacroValue
         {
-            _unconfiguredProject = unconfiguredProject;
-            _project = project;
+            get => _macroValue;
+            set
+            {
+                SetField(ref _macroValue, value);
+                RaisePropertyChanged(nameof(EvaluatedValue));
+            }
         }
 
-        public async Task<string> EditAsync(string macroName, string currentValue, Options.ProfileOptions profileOptions)
+        public string EvaluatedValue => VSPackage.TaskFactory.Run(() => _evaluator.GetMacroValueAsync(_macroValue));
+
+        public Dictionary<string, string> MacroPreviewList { get; set; } = new Dictionary<string, string>();
+
+        private string _macroPreviewFilter;
+        public string MacroPreviewFilter
         {
-            var configuredProject = await _unconfiguredProject.GetSuggestedConfiguredProjectAsync();
-            var propertiesProvider = configuredProject.GetService<IProjectPropertiesProvider>("ProjectPropertiesProvider");
-            var projectProperties = propertiesProvider.GetCommonProperties();
-
-            var evaluator = new MacroEvaluator(_project, projectProperties,
-                values: new MacroEvaluatorTransientValues(activeSourceFile: ("<current source file>", 0)),
-                profileOptionsOverride: profileOptions);
-            var environmentMacros = await GetEnvironmentMacrosAsync(projectProperties, evaluator);
-
-            string evaluatorDelegate(string value) => VSPackage.TaskFactory.Run(() => evaluator.EvaluateAsync(value));
-
-            await VSPackage.TaskFactory.SwitchToMainThreadAsync();
-
-            var editorWindow = new MacroEditorWindow(macroName, currentValue, environmentMacros, evaluatorDelegate);
-            editorWindow.ShowDialog();
-
-            return editorWindow.Value;
+            get => _macroPreviewFilter;
+            set => SetField(ref _macroPreviewFilter, value);
         }
 
-        private async Task<Dictionary<string, string>> GetEnvironmentMacrosAsync(IProjectProperties properties, MacroEvaluator evaluator)
-        {
-            var macros = new Dictionary<string, string>();
+        private readonly IMacroEvaluator _evaluator;
 
-            var vsMacroNames = await properties.GetPropertyNamesAsync();
+        public MacroEditor(string macroName, string macroValue, IMacroEvaluator evaluator)
+        {
+            MacroName = macroName;
+            MacroValue = macroValue;
+            _evaluator = evaluator;
+        }
+
+        public void LoadPreviewListInBackground(IProjectProperties projectProperties, ICommunicationChannel channel) =>
+            VSPackage.TaskFactory.RunAsync(async () =>
+            {
+                MacroPreviewList = await GetEnvironmentMacrosAsync(projectProperties, channel);
+                await VSPackage.TaskFactory.SwitchToMainThreadAsync();
+                RaisePropertyChanged(nameof(MacroPreviewList));
+            });
+
+        private async Task<Dictionary<string, string>> GetEnvironmentMacrosAsync(IProjectProperties properties, ICommunicationChannel channel)
+        {
+            var vsMacroNames = await properties.GetPropertyNamesAsync().ConfigureAwait(false);
             var radMacroNames = typeof(RadMacros).GetConstantValues<string>();
 
+            var macros = new Dictionary<string, string>();
+
             foreach (var macroName in vsMacroNames.Union(radMacroNames))
-                macros["$(" + macroName + ")"] = await evaluator.GetMacroValueAsync(macroName);
+                macros["$(" + macroName + ")"] = await _evaluator.GetMacroValueAsync(macroName).ConfigureAwait(false);
 
             foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
                 macros["$ENV(" + (string)entry.Key + ")"] = (string)entry.Value;
+
+            try
+            {
+                var remoteEnv = await channel.SendWithReplyAsync<DebugServer.IPC.Responses.EnvironmentVariablesListed>(
+                    new DebugServer.IPC.Commands.ListEnvironmentVariables()).ConfigureAwait(false);
+
+                foreach (var entry in remoteEnv.Variables)
+                    macros["$ENVR(" + entry.Key + ")"] = entry.Value;
+            }
+            catch (Exception) { } // Ignore remote environment fetch failures
 
             return macros;
         }

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEditorWindow.xaml
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEditorWindow.xaml
@@ -19,10 +19,10 @@
                  VerticalAlignment="Stretch" HorizontalAlignment="Stretch"/>
         <TextBox Grid.Column="1" Margin="10,10,10,10" Height="27"
                  VerticalAlignment="Top" HorizontalAlignment="Stretch"
-                 Text="{Binding MacroFilter, UpdateSourceTrigger=PropertyChanged}"
+                 Text="{Binding MacroPreviewFilter, UpdateSourceTrigger=PropertyChanged}"
                  TextChanged="MacroFilterChanged"/>
         <ListView Grid.Column="1" x:Name="listMacros"
-                  ItemsSource="{Binding EnvironmentMacros}"
+                  ItemsSource="{Binding MacroPreviewList}"
                   ScrollViewer.CanContentScroll="True" Margin="10,44,10,10">
             <ListView.View>
                 <GridView>

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEditorWindow.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEditorWindow.xaml.cs
@@ -2,74 +2,37 @@
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Input;
-using VSRAD.Package.Utils;
 
 namespace VSRAD.Package.ProjectSystem.Macros
 {
     public partial class MacroEditorWindow : Window
     {
-        public sealed class Context : DefaultNotifyPropertyChanged
+        private MacroEditor Editor => (MacroEditor)DataContext;
+
+        public MacroEditorWindow(MacroEditor macroEditor)
         {
-            public string MacroName { get; set; }
-
-            private string _macroValue;
-            public string MacroValue
-            {
-                get => _macroValue;
-                set
-                {
-                    SetField(ref _macroValue, value);
-                    RaisePropertyChanged(nameof(EvaluatedValue));
-                }
-            }
-
-            public string EvaluatedValue => _evaluateMacro(_macroValue);
-            public Dictionary<string, string> EnvironmentMacros { get; set; }
-
-            private string _macroFilter;
-            public string MacroFilter
-            {
-                get => _macroFilter;
-                set => SetField(ref _macroFilter, value);
-            }
-
-            private readonly EvaluateMacroDelegate _evaluateMacro;
-
-            public Context(EvaluateMacroDelegate evaluateMacro) => _evaluateMacro = evaluateMacro;
-        }
-
-        public delegate string EvaluateMacroDelegate(string unevaluatedValue);
-
-        public string Value => ((Context)DataContext).MacroValue;
-
-        public MacroEditorWindow(
-            string macroName,
-            string macroValue,
-            Dictionary<string, string> environmentMacros,
-            EvaluateMacroDelegate evaluateMacro)
-        {
-            DataContext = new Context(evaluateMacro) { MacroName = macroName, MacroValue = macroValue, EnvironmentMacros = environmentMacros };
+            DataContext = macroEditor;
             InitializeComponent();
 
             listMacros.MouseDoubleClick += InsertMacro;
             ((CollectionView)CollectionViewSource.GetDefaultView(listMacros.ItemsSource)).Filter = FilterMacro;
-            ((Context)DataContext).MacroFilter = "rad";
+            Editor.MacroPreviewFilter = "rad";
         }
 
         private void InsertMacro(object sender, MouseButtonEventArgs e)
         {
             var macro = (listMacros.SelectedItem as KeyValuePair<string, string>?)?.Key;
             if (macro != null)
-                ((Context)DataContext).MacroValue = ((Context)DataContext).MacroValue.Insert(textCommand.CaretIndex, macro);
+                Editor.MacroValue = Editor.MacroValue.Insert(textCommand.CaretIndex, macro);
         }
 
         private bool FilterMacro(object macro)
         {
-            if (string.IsNullOrEmpty(((Context)DataContext).MacroFilter)) return true;
+            if (string.IsNullOrEmpty(Editor.MacroPreviewFilter)) return true;
 
             var macroData = ((KeyValuePair<string, string>)macro);
-            return macroData.Key.IndexOf(((Context)DataContext).MacroFilter, System.StringComparison.OrdinalIgnoreCase) != -1
-                || macroData.Value.IndexOf(((Context)DataContext).MacroFilter, System.StringComparison.OrdinalIgnoreCase) != -1;
+            return macroData.Key.IndexOf(Editor.MacroPreviewFilter, System.StringComparison.OrdinalIgnoreCase) != -1
+                || macroData.Value.IndexOf(Editor.MacroPreviewFilter, System.StringComparison.OrdinalIgnoreCase) != -1;
         }
 
         private void MacroFilterChanged(object sender, System.Windows.Controls.TextChangedEventArgs e) =>

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
@@ -1,9 +1,10 @@
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using VSRAD.Package.Utils;
+using Task = System.Threading.Tasks.Task;
 
 namespace VSRAD.Package.ProjectSystem.Macros
 {
@@ -65,6 +66,8 @@ namespace VSRAD.Package.ProjectSystem.Macros
 
     public sealed class MacroEvaluator : IMacroEvaluator
     {
+        private static readonly Regex _macroRegex = new Regex(@"\$(ENVR?)?\(([^()]+)\)", RegexOptions.Compiled);
+
         private readonly IProject _project;
         private readonly IProjectProperties _projectProperties;
 
@@ -144,62 +147,23 @@ namespace VSRAD.Package.ProjectSystem.Macros
             return value;
         }
 
-        public string GetEnvironmentMacroValue(string name)
-        {
-            return Environment.GetEnvironmentVariable(name);
-        }
-
         public Task<string> EvaluateAsync(string src) => EvaluateAsync(src, null);
 
-        public async Task<string> EvaluateAsync(string src, string recursionStartName)
+        private Task<string> EvaluateAsync(string src, string recursionStartName) =>
+            _macroRegex.ReplaceAsync(src, (m) => ReplaceMacroMatchAsync(m, recursionStartName));
+
+        private Task<string> ReplaceMacroMatchAsync(Match macroMatch, string recursionStartName)
         {
-            var evaluated = new StringBuilder();
-
-            // https://dotnetfiddle.net/4YG3Ox
-            int c = 0;
-            while (c < src.Length)
+            var macroName = macroMatch.Groups[2].Value;
+            switch (macroMatch.Groups[1].Value)
             {
-                var macroStart = src.IndexOf('$', c, src.Length - c - 1);
-                if (macroStart == -1 || src.Length - macroStart <= 3)
-                {
-                    evaluated.Append(src, c, src.Length - c);
-                    break;
-                }
-
-                var isEnvironment = string.CompareOrdinal(src, macroStart + 1, "ENV", 0, 3) == 0
-                    && src.Length - macroStart > 6;
-
-                var macroEnd = isEnvironment
-                    ? src[macroStart + 4] == '(' ? src.IndexOf(')', macroStart + 6) : -1
-                    : src[macroStart + 1] == '(' ? src.IndexOf(')', macroStart + 3) : -1;
-                if (macroEnd == -1)
-                {
-                    evaluated.Append(src, c, macroStart + 1 - c);
-                    c = macroStart + 1;
-                    continue;
-                }
-
-                var macroNameStart = macroStart + (isEnvironment ? 5 : 2); // skip $(
-                var macroNameLength = macroEnd - macroNameStart;
-
-                var imbalancedMacroStart = src.IndexOf('$', macroNameStart, macroNameLength);
-                if (imbalancedMacroStart != -1)
-                {
-                    evaluated.Append(src, c, imbalancedMacroStart - c);
-                    c = imbalancedMacroStart;
-                    continue;
-                }
-
-                var macroName = src.Substring(macroNameStart, macroNameLength);
-                var macroValue = isEnvironment 
-                    ? GetEnvironmentMacroValue(macroName) 
-                    : await GetMacroValueAsync(macroName, recursionStartName);
-                evaluated.Append(src, c, macroStart - c);
-                evaluated.Append(macroValue);
-                c = macroEnd + 1;
+                case "ENV":
+                    return Task.FromResult(Environment.GetEnvironmentVariable(macroName));
+                case "ENVR":
+                    return Task.FromResult(macroMatch.Value); // TODO: Fetch remote environment variables from server and display them in macro editor
+                default:
+                    return GetMacroValueAsync(macroName, recursionStartName);
             }
-
-            return evaluated.ToString();
         }
     }
 }

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
@@ -60,6 +60,7 @@ namespace VSRAD.Package.ProjectSystem.Macros
     {
         Task<string> GetMacroValueAsync(string name);
         Task<string> EvaluateAsync(string src);
+        void SetRemoteMacroPreviewList(IReadOnlyDictionary<string, string> macros);
     }
 
     public sealed class MacroEvaluationException : Exception { public MacroEvaluationException(string message) : base(message) { } }
@@ -73,6 +74,8 @@ namespace VSRAD.Package.ProjectSystem.Macros
 
         private readonly Options.ProfileOptions _profileOptions;
         private readonly Dictionary<string, string> _macroCache;
+
+        private IReadOnlyDictionary<string, string> _remoteMacroPreviewList;
 
         public MacroEvaluator(
             IProject project,
@@ -160,10 +163,17 @@ namespace VSRAD.Package.ProjectSystem.Macros
                 case "ENV":
                     return Task.FromResult(Environment.GetEnvironmentVariable(macroName));
                 case "ENVR":
-                    return Task.FromResult(macroMatch.Value); // TODO: Fetch remote environment variables from server and display them in macro editor
+                    if (_remoteMacroPreviewList != null && _remoteMacroPreviewList.TryGetValue(macroName, out var macroValue))
+                        return Task.FromResult(macroValue);
+                    return Task.FromResult(macroMatch.Value);
                 default:
                     return GetMacroValueAsync(macroName, recursionStartName);
             }
+        }
+
+        public void SetRemoteMacroPreviewList(IReadOnlyDictionary<string, string> macros)
+        {
+            _remoteMacroPreviewList = macros;
         }
     }
 }

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml.cs
@@ -57,7 +57,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             }
         }
 
-        public ProfileOptionsWindow(Macros.MacroEditor macroEditor, ProjectOptions projectOptions)
+        public ProfileOptionsWindow(Macros.MacroEditManager macroEditor, ProjectOptions projectOptions)
         {
             _projectOptions = projectOptions;
             DataContext = new Context(_projectOptions, SaveChanges, RemoveProfile);

--- a/VSRAD.Package/ProjectSystem/Profiles/PropertyPageEditorWrapper.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/PropertyPageEditorWrapper.cs
@@ -13,7 +13,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
         public delegate void ProfileNameChangedDelegate();
 
         private readonly Grid _propertyPageGrid;
-        private readonly Macros.MacroEditor _macroEditor;
+        private readonly Macros.MacroEditManager _macroEditor;
         private readonly GetPropertyValueDelegate _getValue;
         private readonly SetPropertyValueDelegate _setValue;
         private readonly UpdateDescriptionDelegate _updateDescription;
@@ -28,7 +28,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 
         public PropertyPageEditorWrapper(
             Grid propertyPageGrid,
-            Macros.MacroEditor macroEditor,
+            Macros.MacroEditManager macroEditor,
             GetPropertyValueDelegate getValue,
             SetPropertyValueDelegate setValue,
             UpdateDescriptionDelegate updateDescription,
@@ -134,17 +134,8 @@ namespace VSRAD.Package.ProjectSystem.Profiles
         private FrameworkElement EditorWithMacroButton(TextBox editor, string macro)
         {
             var macroButton = new Button { Content = "Edit..." };
-            macroButton.Click += async (sender, args) =>
-            {
-                try
-                {
-                    editor.Text = await _macroEditor.EditAsync(macro, editor.Text, _getProfileOptions());
-                }
-                catch (Macros.MacroEvaluationException e)
-                {
-                    Errors.ShowWarning(e.Message);
-                }
-            };
+            macroButton.Click += (sender, args) => VSPackage.TaskFactory.RunAsyncWithErrorHandling(async () =>
+                editor.Text = await _macroEditor.EditAsync(macro, editor.Text, _getProfileOptions()));
 
             var grid = new Grid();
             grid.RowDefinitions.Add(new RowDefinition());

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
@@ -46,12 +46,12 @@ namespace VSRAD.Package.ToolWindows
         }
 
         private readonly ProjectOptions _projectOptions;
-        private readonly MacroEditor _macroEditor;
+        private readonly MacroEditManager _macroEditor;
 
         public OptionsControl(IToolWindowIntegration integration)
         {
             _projectOptions = integration.ProjectOptions;
-            _macroEditor = integration.GetExport<MacroEditor>();
+            _macroEditor = integration.GetExport<MacroEditManager>();
             DataContext = new Context(integration.ProjectOptions, integration.GetExport<ICommunicationChannelManager>());
             InitializeComponent();
             ColoringRegionsGrid.PreviewMouseWheel += (s, e) =>

--- a/VSRAD.Package/Utils/RegexUtils.cs
+++ b/VSRAD.Package/Utils/RegexUtils.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace VSRAD.Package.Utils
+{
+    public static class RegexUtils
+    {
+        // https://stackoverflow.com/a/33017336
+        public static async Task<string> ReplaceAsync(this Regex regex, string input, Func<Match, Task<string>> evaluator)
+        {
+            var sb = new StringBuilder();
+            var lastIndex = 0;
+
+            foreach (Match match in regex.Matches(input))
+            {
+                sb.Append(input, lastIndex, match.Index - lastIndex)
+                  .Append(await evaluator(match).ConfigureAwait(false));
+
+                lastIndex = match.Index + match.Length;
+            }
+
+            sb.Append(input, lastIndex, input.Length - lastIndex);
+            return sb.ToString();
+        }
+    }
+}

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Utils\ProjectSystemExtensions.cs" />
     <Compile Include="Utils\ReflectionUtils.cs" />
     <Compile Include="Utils\DeployUtils.cs" />
+    <Compile Include="Utils\RegexUtils.cs" />
     <Compile Include="Utils\StringUtils.cs" />
     <Compile Include="Utils\Win32Control.cs" />
     <Compile Include="Utils\WpfDelegateCommand.cs" />

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -148,6 +148,7 @@
     <Compile Include="DebugVisualizer\VisualizerTableHost.cs" />
     <Compile Include="DebugVisualizer\Watch.cs" />
     <Compile Include="Options\DefaultOptionValues.cs" />
+    <Compile Include="ProjectSystem\Macros\MacroEditor.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -172,7 +173,7 @@
     <Compile Include="Options\ProfileOptions.cs" />
     <Compile Include="Options\ProjectOptions.cs" />
     <Compile Include="ProjectSystem\ActiveCodeEditor.cs" />
-    <Compile Include="ProjectSystem\Macros\MacroEditor.cs" />
+    <Compile Include="ProjectSystem\Macros\MacroEditManager.cs" />
     <Compile Include="ProjectSystem\OutputWindow.cs" />
     <Compile Include="ProjectSystem\Profiles\PropertyPageEditorWrapper.cs" />
     <Compile Include="ProjectSystem\Profiles\ProfileNameWindow.xaml.cs">


### PR DESCRIPTION
This PR adds support for local and remote environment macros. In addition to the existing `$(...)` syntax, the following forms are now recognized:
* `$ENV(...)`: substituted with the value of a local environment variable
* `$ENVR(...)`: substituted with the value of an environment variable on the remote machine

Both local and remote environment variables can be previewed in Macro Editor.