### PR TITLE
Build: use preprocessed source to map lines in error messages

### DIFF
--- a/VSRAD.BuildTools/IPCBuildResult.cs
+++ b/VSRAD.BuildTools/IPCBuildResult.cs
@@ -12,6 +12,7 @@ namespace VSRAD.BuildTools
         public string Stdout { get; set; }
         public string Stderr { get; set; }
         public string ServerError { get; set; }
+        public string PreprocessedSource { get; set; } = "";
 
         public static IPCBuildResult Read(Stream stream)
         {
@@ -22,7 +23,8 @@ namespace VSRAD.BuildTools
                     {
                         ExitCode = reader.ReadInt32(),
                         Stdout = reader.ReadString(),
-                        Stderr = reader.ReadString()
+                        Stderr = reader.ReadString(),
+                        PreprocessedSource = reader.ReadString()
                     };
                 else
                     return new IPCBuildResult
@@ -43,6 +45,7 @@ namespace VSRAD.BuildTools
                     writer.Write(ExitCode);
                     writer.Write(Stdout);
                     writer.Write(Stderr);
+                    writer.Write(PreprocessedSource);
                 }
                 else
                 {

--- a/VSRAD.BuildTools/RemoteBuildStderrParser.cs
+++ b/VSRAD.BuildTools/RemoteBuildStderrParser.cs
@@ -38,15 +38,17 @@ namespace VSRAD.BuildTools
         {
             var lines = preprocessed.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             int[] result = new int[lines.Length];
-            int originalSourceLine = 0;
+            int originalSourceLine = 1;
             for (int i = 0; i < lines.Length; i++)
             {
                 var line = lines[i];
+                
                 if (line.StartsWith("#") || line.StartsWith("//#"))
+                {
                     originalSourceLine = int.Parse(LineNumRegex.Match(line).Value);
-                else
-                    originalSourceLine++;
-                result[i] = originalSourceLine;
+                    continue;
+                }
+                result[i] = originalSourceLine++;
             }
             return result;
         }

--- a/VSRAD.BuildTools/RemoteBuildStderrParser.cs
+++ b/VSRAD.BuildTools/RemoteBuildStderrParser.cs
@@ -34,7 +34,7 @@ namespace VSRAD.BuildTools
             public int Column { get; set; }
         }
 
-        private static int[] MapLines(string preprocessed)
+        public static int[] MapLines(string preprocessed)
         {
             var lines = preprocessed.Split(Environment.NewLine.ToCharArray());
             int[] result = new int[lines.Length];

--- a/VSRAD.BuildTools/RemoteBuildStderrParser.cs
+++ b/VSRAD.BuildTools/RemoteBuildStderrParser.cs
@@ -38,7 +38,7 @@ namespace VSRAD.BuildTools
         {
             var lines = preprocessed.Split(Environment.NewLine.ToCharArray());
             int[] result = new int[lines.Length];
-            int curr_iterator = 0;
+            int curr_iterator = 1;
             for (int i = 0; i < lines.Length; i++)
             {
                 var line = lines[i];
@@ -85,7 +85,7 @@ namespace VSRAD.BuildTools
 
             foreach (var message in messages)
             {
-                // change line
+                message.Line = ppLines[message.Line - 1];
             }
 
             return messages;

--- a/VSRAD.BuildTools/RemoteBuildTask.cs
+++ b/VSRAD.BuildTools/RemoteBuildTask.cs
@@ -41,7 +41,7 @@ namespace VSRAD.BuildTools
                 return false;
             }
 
-            foreach (var message in RemoteBuildStderrParser.ExtractMessages(result.Stderr))
+            foreach (var message in RemoteBuildStderrParser.ExtractMessages(result.Stderr, result.PreprocessedSource))
                 switch (message.Kind)
                 {
                     case RemoteBuildStderrParser.MessageKind.Error:

--- a/VSRAD.BuildToolsTests/RemoteBuildStderrParserTests.cs
+++ b/VSRAD.BuildToolsTests/RemoteBuildStderrParserTests.cs
@@ -71,7 +71,7 @@ int main() {
         public void PreprocessMapLinesTest()
         {
             var lineMapping = MapLines(Preprocessed);
-            Assert.Equal(new int[] { 1, 2, 3, 16, 17, 55, 56 }, lineMapping);
+            Assert.Equal(new int[] { 1, 2, 3, 4, 0, 16, 17, 0, 55, 56, 57 }, lineMapping);
         }
     }
 }

--- a/VSRAD.BuildToolsTests/RemoteBuildStderrParserTests.cs
+++ b/VSRAD.BuildToolsTests/RemoteBuildStderrParserTests.cs
@@ -22,7 +22,7 @@ host.c:4:2: note: include the header<stdio.h> or explicitly provide a declaratio
         [Fact]
         public void ClangErrorTest()
         {
-            var messages = ExtractMessages(ClangErrorString).ToList();
+            var messages = ExtractMessages(ClangErrorString, "").ToList();
 
             Assert.Equal(MessageKind.Error, messages[0].Kind);
             Assert.Equal(27, messages[0].Column);

--- a/VSRAD.BuildToolsTests/RemoteBuildStderrParserTests.cs
+++ b/VSRAD.BuildToolsTests/RemoteBuildStderrParserTests.cs
@@ -19,6 +19,18 @@ host.c:4:2: warning: implicitly declaring library function 'printf' with type 'i
 host.c:4:2: note: include the header<stdio.h> or explicitly provide a declaration for 'printf'
 ";
 
+        public const string Preprocessed = @"
+int main() {
+    int a = 1 + 1;
+    int b = 2 + 2;
+# 16 'source.c'
+    int c = 3 + 3;
+    int d = 4 + 4;
+# 55 'source.c'
+    int f = 0xDEAD;
+}
+";
+
         [Fact]
         public void ClangErrorTest()
         {
@@ -53,6 +65,13 @@ host.c:4:2: note: include the header<stdio.h> or explicitly provide a declaratio
             Assert.Equal(2, messages[3].Column);
             Assert.Equal("host.c", messages[3].SourceFile);
             Assert.Equal(@"include the header<stdio.h> or explicitly provide a declaration for 'printf'", messages[3].Text);
+        }
+
+        [Fact]
+        public void PreprocessMapLinesTest()
+        {
+            var lineMapping = MapLines(Preprocessed);
+            Assert.Equal(new int[] { 1, 2, 3, 16, 17, 55, 56 }, lineMapping);
         }
     }
 }

--- a/VSRAD.Package/Commands/DisassemblyCommand.cs
+++ b/VSRAD.Package/Commands/DisassemblyCommand.cs
@@ -49,8 +49,9 @@ namespace VSRAD.Package.Commands
                 var executor = new RemoteCommandExecutor("Disassembly", _channel, _outputWindow);
                 var result = await executor.ExecuteWithResultAsync(command, options.RemoteOutputFile);
 
-                if (!result.TryGetResult(out var data, out var error))
+                if (!result.TryGetResult(out var execResult, out var error))
                     throw new System.Exception(error.Message);
+                var (_, data) = execResult;
 
                 File.WriteAllBytes(options.LocalOutputCopyPath, data);
                 OpenFileInEditor(options.LocalOutputCopyPath, options.LineMarker);

--- a/VSRAD.Package/Commands/EvaluateSelectedCommand.cs
+++ b/VSRAD.Package/Commands/EvaluateSelectedCommand.cs
@@ -94,8 +94,9 @@ namespace VSRAD.Package.Commands
             var byteCount = 2 /* system + watch */ * 512 * 4 /* dwords -> bytes */;
             var result = await executor.ExecuteWithResultAsync(command, options.RemoteOutputFile, byteCount).ConfigureAwait(false);
 
-            if (!result.TryGetResult(out var data, out var error))
+            if (!result.TryGetResult(out var execResult, out var error))
                 throw new Exception(error.Message);
+            var (_, data) = execResult;
 
             var bytesFetched = new uint[1024];
             Buffer.BlockCopy(data, 0, bytesFetched, 0, data.Length);

--- a/VSRAD.Package/Commands/ProfileCommand.cs
+++ b/VSRAD.Package/Commands/ProfileCommand.cs
@@ -48,8 +48,9 @@ namespace VSRAD.Package.Commands
 
                 var result = await executor.ExecuteWithResultAsync(command, options.RemoteOutputFile);
 
-                if (!result.TryGetResult(out var data, out var error))
+                if (!result.TryGetResult(out var execResult, out var error))
                     throw new System.Exception(error.Message);
+                var (_, data) = execResult;
 
                 File.WriteAllBytes(options.LocalOutputCopyPath, data);
 

--- a/VSRAD.Package/Options/DefaultOptionValues.cs
+++ b/VSRAD.Package/Options/DefaultOptionValues.cs
@@ -24,7 +24,6 @@ namespace VSRAD.Package.Options
         public const bool DebuggerRunAsAdmin = false;
         public const int DebuggerTimeoutSecs = 0;
         public const int OutputOffset = 0;
-        public const string PreprocessedSource = "";
         #endregion
         #region Disassembler
         public const string DisassemblerExecutable = "";
@@ -48,6 +47,7 @@ namespace VSRAD.Package.Options
         public const string BuildExecutable = "";
         public const string BuildArguments = "";
         public const string BuildWorkingDirectory = "";
+        public const string BuildPreprocessedSource = "preprocessed_source.build.tmp";
         #endregion
     }
 }

--- a/VSRAD.Package/Options/DefaultOptionValues.cs
+++ b/VSRAD.Package/Options/DefaultOptionValues.cs
@@ -24,6 +24,7 @@ namespace VSRAD.Package.Options
         public const bool DebuggerRunAsAdmin = false;
         public const int DebuggerTimeoutSecs = 0;
         public const int OutputOffset = 0;
+        public const string PreprocessedSource = "";
         #endregion
         #region Disassembler
         public const string DisassemblerExecutable = "";

--- a/VSRAD.Package/Options/ProfileOptions.cs
+++ b/VSRAD.Package/Options/ProfileOptions.cs
@@ -38,7 +38,6 @@ namespace VSRAD.Package.Options
         public DebuggerProfileOptions Debugger { get; }
         public DisassemblerProfileOptions Disassembler { get; }
         public ProfilerProfileOptions Profiler { get; }
-
         public BuildProfileOptions Build { get; }
 
         public ProfileOptions(GeneralProfileOptions general = null, DebuggerProfileOptions debugger = null, DisassemblerProfileOptions disassembler = null, ProfilerProfileOptions profiler = null, BuildProfileOptions build = null)
@@ -307,11 +306,13 @@ namespace VSRAD.Package.Options
         [DefaultValue(DefaultOptionValues.BuildWorkingDirectory)]
         public string WorkingDirectory { get; }
 
-        [Macro(RadMacros.BuildPreprocessedSource)]
-        [Description(@"Path of preprocessed source on a target machine. Used to map line numbers in the compiler's output to original sources. Linemarkers should start with '//# ' or '# '")]
-        [DisplayName("Preprocessed Source")]
-        [DefaultValue(DefaultOptionValues.PreprocessedSource)]
+        [Macro(RadMacros.BuildPreprocessedSource), DisplayName("Preprocessed Source")]
+        [Description(@"Path to the preprocessed source on the remote machine. Used to map line numbers in the compiler's output to original sources. Linemarkers should start with '//# ' or '# '")]
+        [DefaultValue(DefaultOptionValues.BuildPreprocessedSource)]
         public string PreprocessedSource { get; }
+
+        [JsonIgnore]
+        public OutputFile PreprocessedSourceFile => new OutputFile(WorkingDirectory, PreprocessedSource, binaryOutput: true);
 
         public async Task<BuildProfileOptions> EvaluateAsync(IMacroEvaluator macroEvaluator) =>
             new BuildProfileOptions(
@@ -321,7 +322,7 @@ namespace VSRAD.Package.Options
                 preprocessedSource: await macroEvaluator.GetMacroValueAsync(RadMacros.BuildPreprocessedSource)
             );
 
-        public BuildProfileOptions(string executable = DefaultOptionValues.BuildExecutable, string arguments = DefaultOptionValues.BuildArguments, string workingDirectory = DefaultOptionValues.BuildWorkingDirectory, string preprocessedSource = DefaultOptionValues.PreprocessedSource)
+        public BuildProfileOptions(string executable = DefaultOptionValues.BuildExecutable, string arguments = DefaultOptionValues.BuildArguments, string workingDirectory = DefaultOptionValues.BuildWorkingDirectory, string preprocessedSource = DefaultOptionValues.BuildPreprocessedSource)
         {
             Executable = executable;
             Arguments = arguments;

--- a/VSRAD.Package/Options/ProfileOptions.cs
+++ b/VSRAD.Package/Options/ProfileOptions.cs
@@ -307,18 +307,26 @@ namespace VSRAD.Package.Options
         [DefaultValue(DefaultOptionValues.BuildWorkingDirectory)]
         public string WorkingDirectory { get; }
 
+        [Macro(RadMacros.BuildPreprocessedSource)]
+        [Description(@"Path of preprocessed source on a target machine. Used to map line numbers in the compiler's output to original sources. Linemarkers should start with '//# ' or '# '")]
+        [DisplayName("Preprocessed Source")]
+        [DefaultValue(DefaultOptionValues.PreprocessedSource)]
+        public string PreprocessedSource { get; }
+
         public async Task<BuildProfileOptions> EvaluateAsync(IMacroEvaluator macroEvaluator) =>
             new BuildProfileOptions(
                 executable: await macroEvaluator.GetMacroValueAsync(RadMacros.BuildExecutable),
                 arguments: await macroEvaluator.GetMacroValueAsync(RadMacros.BuildArguments),
-                workingDirectory: await macroEvaluator.GetMacroValueAsync(RadMacros.BuildWorkingDirectory)
+                workingDirectory: await macroEvaluator.GetMacroValueAsync(RadMacros.BuildWorkingDirectory),
+                preprocessedSource: await macroEvaluator.GetMacroValueAsync(RadMacros.BuildPreprocessedSource)
             );
 
-        public BuildProfileOptions(string executable = DefaultOptionValues.BuildExecutable, string arguments = DefaultOptionValues.BuildArguments, string workingDirectory = DefaultOptionValues.BuildWorkingDirectory)
+        public BuildProfileOptions(string executable = DefaultOptionValues.BuildExecutable, string arguments = DefaultOptionValues.BuildArguments, string workingDirectory = DefaultOptionValues.BuildWorkingDirectory, string preprocessedSource = DefaultOptionValues.PreprocessedSource)
         {
             Executable = executable;
             Arguments = arguments;
             WorkingDirectory = workingDirectory;
+            PreprocessedSource = preprocessedSource;
         }
     }
 

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
@@ -58,6 +58,7 @@ namespace VSRAD.Package.ProjectSystem.Macros
         public const string BuildExecutable = "RadBuildExe";
         public const string BuildArguments = "RadBuildArgs";
         public const string BuildWorkingDirectory = "RadBuildWorkDir";
+        public const string BuildPreprocessedSource = "RadBuildPpSource";
     }
 
     public interface IMacroEvaluator
@@ -147,6 +148,7 @@ namespace VSRAD.Package.ProjectSystem.Macros
                 case RadMacros.BuildExecutable: unevaluated = _profileOptions.Build.Executable; break;
                 case RadMacros.BuildArguments: unevaluated = _profileOptions.Build.Arguments; break;
                 case RadMacros.BuildWorkingDirectory: unevaluated = _profileOptions.Build.WorkingDirectory; break;
+                case RadMacros.BuildPreprocessedSource: unevaluated = _profileOptions.Build.PreprocessedSource; break;
             }
 
             if (unevaluated != null)

--- a/VSRAD.Package/Server/RemoteCommandExecutor.cs
+++ b/VSRAD.Package/Server/RemoteCommandExecutor.cs
@@ -8,16 +8,11 @@ namespace VSRAD.Package.Server
 {
     public sealed class RemoteCommandExecutor
     {
-        public const string ErrorTimedOut =
-            "Execution timeout has been exceeded. The process is terminated.";
-        public const string ErrorFileHasNotChanged =
-            "Output file has not changed as a result of running the command.";
-        public const string ErrorFileNotCreated =
-            "Output file could not be found after executing the command.";
-        public const string ErrorCouldNotLaunch =
-            "The process could not be started. Make sure the path to the executable is specified correctly.";
-        public static string ErrorNonZeroExitCode(int exitCode) =>
-            $"The process has exited with a non-zero code ({exitCode}).";
+        public const string ErrorTimedOut = "Execution timeout has been exceeded. The process is terminated.";
+        public const string ErrorFileUnchanged = "Output file is unchanged after running the command.";
+        public const string ErrorFileNotCreated = "Output file is missing.";
+        public const string ErrorCouldNotLaunch = "The process could not be started. Make sure the path to the executable is specified correctly.";
+        public static string ErrorNonZeroExitCode(int exitCode) => $"The process has exited with a non-zero code ({exitCode}).";
 
         private readonly ICommunicationChannel _channel;
         private readonly IOutputWindowWriter _outputWriter;
@@ -30,22 +25,22 @@ namespace VSRAD.Package.Server
             _outputWriter = outputWindow.GetExecutionResultPane();
         }
 
-        public async Task<Result<(ExecutionCompleted, byte[])>> ExecuteWithResultAsync(Execute command, Options.OutputFile output, int byteCount = 0)
+        public async Task<Result<(ExecutionCompleted, byte[])>> ExecuteWithResultAsync(Execute command, Options.OutputFile output, int byteCount = 0, bool checkExitCode = true)
         {
             var initialMetadata = await _channel.SendWithReplyAsync<MetadataFetched>(
                 new FetchMetadata { FilePath = output.Path, BinaryOutput = output.BinaryOutput }).ConfigureAwait(false);
             var initialTimestamp = initialMetadata.Timestamp;
 
-            var executionResult = await ExecuteAsync(command).ConfigureAwait(false);
+            var executionResult = await ExecuteAsync(command, checkExitCode).ConfigureAwait(false);
             if (!executionResult.TryGetResult(out var execution, out var error))
                 return error;
 
             var dataResult = await _channel.SendWithReplyAsync<ResultRangeFetched>(
                 new FetchResultRange { FilePath = output.Path, BinaryOutput = output.BinaryOutput, ByteCount = byteCount }).ConfigureAwait(false);
             if (dataResult.Status != FetchStatus.Successful)
-                return new Error(ErrorFileNotCreated);
+                return new Error(ErrorFileNotCreated, title: "RAD " + _outputTag);
             if (dataResult.Timestamp == initialTimestamp)
-                return new Error(ErrorFileHasNotChanged);
+                return new Error(ErrorFileUnchanged, title: "RAD " + _outputTag);
 
             return (execution, dataResult.Data);
         }

--- a/VSRAD.PackageTests/BuildTools/BuildToolsServerTest.cs
+++ b/VSRAD.PackageTests/BuildTools/BuildToolsServerTest.cs
@@ -1,6 +1,8 @@
 ﻿using Moq;
+using System;
 using System.Collections.Generic;
 using System.IO.Pipes;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using VSRAD.DebugServer.IPC.Commands;
@@ -13,10 +15,11 @@ using Xunit;
 
 namespace VSRAD.Package.BuildTools
 {
+    [Collection("Sequential")]
     public class BuildToolsServerTest
     {
         [Fact]
-        public async Task BuildTestAsync()
+        public async Task SuccessfulBuildTestAsync()
         {
             TestHelper.InitializePackageTaskFactory();
             var project = TestHelper.MakeProjectWithProfile(new Dictionary<string, string>()
@@ -24,8 +27,7 @@ namespace VSRAD.Package.BuildTools
                 { RadMacros.BuildExecutable, "nemu" },
                 { RadMacros.BuildArguments, "--sleep 10" },
                 { RadMacros.BuildWorkingDirectory, "/old/home" }
-            },
-            projectRoot: @"C:\Users\CFF");
+            }, projectRoot: @"C:\Users\CFF");
             var channel = new MockCommunicationChannel();
             var output = new Mock<IOutputWindowManager>();
             var deployManager = new Mock<IFileSynchronizationManager>();
@@ -48,6 +50,81 @@ namespace VSRAD.Package.BuildTools
                 Assert.Equal("/old/home", command.WorkingDirectory);
             });
 
+            var message = await FetchResultOnClientAsync(server);
+            deployManager.Verify((d) => d.SynchronizeRemoteAsync(), Times.Once);
+
+            Assert.Null(message.ServerError);
+            Assert.Equal(0, message.ExitCode);
+            Assert.Equal("day of flight", message.Stdout);
+            Assert.Equal("coming soon", message.Stderr);
+        }
+
+        [Fact]
+        public async Task PreprocessorTestAsync()
+        {
+            TestHelper.InitializePackageTaskFactory();
+            var project = TestHelper.MakeProjectWithProfile(new Dictionary<string, string>() {
+                { RadMacros.BuildExecutable, "kuu" },
+                { RadMacros.BuildWorkingDirectory, "/home/old" },
+                { RadMacros.BuildPreprocessedSource, "preprocessed_source.build.tmp" }
+            }, projectRoot: @"C:\Users\CFF\Preprocess");
+            var channel = new MockCommunicationChannel();
+            var output = new Mock<IOutputWindowManager>();
+            var deployManager = new Mock<IFileSynchronizationManager>();
+            output.Setup((w) => w.GetExecutionResultPane()).Returns(new Mock<IOutputWindowWriter>().Object);
+
+            var server = new BuildToolsServer(channel.Object, output.Object, deployManager.Object);
+            server.SetProjectOnLoad(project); // starts the server
+
+            var timestamp = DateTime.Now;
+            channel.ThenRespond<FetchMetadata, MetadataFetched>(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = timestamp }, (command) =>
+            {
+                Assert.Equal("/home/old", command.FilePath[0]);
+                Assert.Equal("preprocessed_source.build.tmp", command.FilePath[1]);
+            });
+            channel.ThenRespond<Execute, ExecutionCompleted>(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0 }, (_) => { });
+            channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched
+            { Timestamp = timestamp.AddSeconds(1), Status = FetchStatus.Successful, Data = Encoding.UTF8.GetBytes("#define H") }, (_) => { });
+
+            var message = await FetchResultOnClientAsync(server);
+            Assert.Null(message.ServerError);
+            Assert.Equal("#define H", message.PreprocessedSource);
+        }
+
+        [Fact]
+        public async Task PreprocessorErrorTestAsync()
+        {
+            TestHelper.InitializePackageTaskFactory();
+            var project = TestHelper.MakeProjectWithProfile(new Dictionary<string, string>() {
+                { RadMacros.BuildExecutable, "kuu" },
+                { RadMacros.BuildPreprocessedSource, "preprocessed_source.build.tmp" }
+            }, projectRoot: @"C:\Users\CFF\Errors");
+            var channel = new MockCommunicationChannel();
+            var output = new Mock<IOutputWindowManager>();
+            var deployManager = new Mock<IFileSynchronizationManager>();
+            output.Setup((w) => w.GetExecutionResultPane()).Returns(new Mock<IOutputWindowWriter>().Object);
+
+            var server = new BuildToolsServer(channel.Object, output.Object, deployManager.Object);
+            server.SetProjectOnLoad(project); // starts the server
+
+            var timestamp = DateTime.Now;
+            channel.ThenRespond<FetchMetadata, MetadataFetched>(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = timestamp }, (_) => { });
+            channel.ThenRespond<Execute, ExecutionCompleted>(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0 }, (_) => { });
+            channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful, Timestamp = timestamp }, (_) => { });
+
+            var message = await FetchResultOnClientAsync(server);
+            Assert.Equal(BuildToolsServer.ErrorPreprocessorFileUnchanged, message.ServerError);
+
+            channel.ThenRespond<FetchMetadata, MetadataFetched>(new MetadataFetched { Status = FetchStatus.FileNotFound }, (_) => { });
+            channel.ThenRespond<Execute, ExecutionCompleted>(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0 }, (_) => { });
+            channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.FileNotFound }, (_) => { });
+
+            message = await FetchResultOnClientAsync(server);
+            Assert.Equal(BuildToolsServer.ErrorPreprocessorFileNotCreated, message.ServerError);
+        }
+
+        private static async Task<VSRAD.BuildTools.IPCBuildResult> FetchResultOnClientAsync(BuildToolsServer server)
+        {
             VSRAD.BuildTools.IPCBuildResult message = null;
             var tcs = new TaskCompletionSource<bool>();
 
@@ -61,12 +138,7 @@ namespace VSRAD.Package.BuildTools
             }).Start();
 
             await tcs.Task;
-            deployManager.Verify((d) => d.SynchronizeRemoteAsync(), Times.Once);
-
-            Assert.Null(message.ServerError);
-            Assert.Equal(0, message.ExitCode);
-            Assert.Equal("day of flight", message.Stdout);
-            Assert.Equal("coming soon", message.Stderr);
+            return message;
         }
     }
 }

--- a/VSRAD.PackageTests/Server/RemoteCommandExecutorTests.cs
+++ b/VSRAD.PackageTests/Server/RemoteCommandExecutorTests.cs
@@ -99,7 +99,7 @@ namespace VSRAD.PackageTests.Server
             channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.Successful, Timestamp = timestamp });
             result = await executor.ExecuteWithResultAsync(new Execute(), new OutputFile(@"F:\Is\Pressed\For", "Us"));
             Assert.False(result.TryGetResult(out _, out error));
-            Assert.Equal(RemoteCommandExecutor.ErrorFileHasNotChanged, error.Message);
+            Assert.Equal(RemoteCommandExecutor.ErrorFileUnchanged, error.Message);
 
             Assert.True(channel.AllInteractionsHandled);
         }

--- a/VSRAD.PackageTests/Server/RemoteCommandExecutorTests.cs
+++ b/VSRAD.PackageTests/Server/RemoteCommandExecutorTests.cs
@@ -39,7 +39,8 @@ namespace VSRAD.PackageTests.Server
 
             var result = await executor.ExecuteWithResultAsync(new Execute { Executable = "exec", Arguments = "args" }, new OutputFile("file", "path"));
             Assert.True(result.TryGetResult(out var resultData, out _));
-            Assert.Equal(data, resultData);
+            Assert.Equal(data, resultData.Item2);
+            Assert.Equal("test stdout", resultData.Item1.Stdout);
 
             outputWriterMock.Verify((w) => w.PrintMessageAsync(
                 "[Test] Captured stdout", "test stdout"), Times.Once);


### PR DESCRIPTION
When using a separate preprocessing step, compiler error messages may refer to incorrect line numbers in the original source file.

This PR adds a new option, **Preprocessed Source** (**Build**). When specified, error locations are updated based on the [`#` linemarkers](https://gcc.gnu.org/onlinedocs/cpp/Preprocessor-Output.html) in the preprocessed source.