### PR TITLE
Build: alternative error format

### DIFF
--- a/VSRAD.BuildTools/Errors/LineMapper.cs
+++ b/VSRAD.BuildTools/Errors/LineMapper.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace VSRAD.BuildTools.Errors
+{
+    public static class LineMapper
+    {
+        private static readonly Regex LineNumRegex = new Regex(@"\d+", RegexOptions.Compiled);
+
+        public static int[] MapLines(string preprocessed)
+        {
+            var lines = preprocessed.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            int[] result = new int[lines.Length];
+            int originalSourceLine = 1;
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+
+                if (line.StartsWith("#") || line.StartsWith("//#"))
+                {
+                    originalSourceLine = int.Parse(LineNumRegex.Match(line).Value);
+                    continue;
+                }
+                result[i] = originalSourceLine++;
+            }
+            return result;
+        }
+    }
+}

--- a/VSRAD.BuildTools/Errors/Message.cs
+++ b/VSRAD.BuildTools/Errors/Message.cs
@@ -1,0 +1,13 @@
+﻿namespace VSRAD.BuildTools.Errors
+{
+    public enum MessageKind { Error, Warning, Note }
+
+    public sealed class Message
+    {
+        public MessageKind Kind { get; set; }
+        public string Text { get; set; }
+        public string SourceFile { get; set; }
+        public int Line { get; set; }
+        public int Column { get; set; }
+    }
+}

--- a/VSRAD.BuildTools/Errors/Parser.cs
+++ b/VSRAD.BuildTools/Errors/Parser.cs
@@ -7,15 +7,13 @@ namespace VSRAD.BuildTools.Errors
 {
     public static class Parser
     {
-        private static readonly Regex LineNumRegex = new Regex(@"\d+", RegexOptions.Compiled);
-
         public static IEnumerable<Message> ExtractMessages(string stderr, string preprocessed)
         {
             var messages = ParseStderr(stderr);
 
             if (messages.Count > 0 && !string.IsNullOrEmpty(preprocessed))
             {
-                var ppLines = MapLines(preprocessed);
+                var ppLines = LineMapper.MapLines(preprocessed);
 
                 foreach (var message in messages)
                     message.Line = ppLines[message.Line - 1];
@@ -54,25 +52,6 @@ namespace VSRAD.BuildTools.Errors
                 }
             }
             return messages;
-        }
-
-        public static int[] MapLines(string preprocessed)
-        {
-            var lines = preprocessed.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
-            int[] result = new int[lines.Length];
-            int originalSourceLine = 1;
-            for (int i = 0; i < lines.Length; i++)
-            {
-                var line = lines[i];
-
-                if (line.StartsWith("#") || line.StartsWith("//#"))
-                {
-                    originalSourceLine = int.Parse(LineNumRegex.Match(line).Value);
-                    continue;
-                }
-                result[i] = originalSourceLine++;
-            }
-            return result;
         }
 
         private static readonly Regex ClangErrorRegex = new Regex(

--- a/VSRAD.BuildTools/Errors/Parser.cs
+++ b/VSRAD.BuildTools/Errors/Parser.cs
@@ -3,22 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 
-namespace VSRAD.BuildTools
+namespace VSRAD.BuildTools.Errors
 {
-    public static class RemoteBuildStderrParser
+    public static class Parser
     {
         private static readonly Regex LineNumRegex = new Regex(@"\d+", RegexOptions.Compiled);
-
-        public enum MessageKind { Error, Warning, Note }
-
-        public sealed class Message
-        {
-            public MessageKind Kind { get; set; }
-            public string Text { get; set; }
-            public string SourceFile { get; set; }
-            public int Line { get; set; }
-            public int Column { get; set; }
-        }
 
         public static IEnumerable<Message> ExtractMessages(string stderr, string preprocessed)
         {

--- a/VSRAD.BuildTools/RemoteBuildStderrParser.cs
+++ b/VSRAD.BuildTools/RemoteBuildStderrParser.cs
@@ -7,23 +7,9 @@ namespace VSRAD.BuildTools
 {
     public static class RemoteBuildStderrParser
     {
-        private static readonly Regex ClangErrorRegex = new Regex(
-            @"(?<file>[^:]+):(?<line>\d+):(?<col>\d+):\s*(?<kind>error|warning|note):\s(?<text>.+)", RegexOptions.Compiled);
-
         private static readonly Regex LineNumRegex = new Regex(@"\d+", RegexOptions.Compiled);
 
         public enum MessageKind { Error, Warning, Note }
-
-        public static MessageKind MessageKindFromString(string kind)
-        {
-            switch (kind)
-            {
-                case "error": return MessageKind.Error;
-                case "warning": return MessageKind.Warning;
-                case "note": return MessageKind.Note;
-                default: throw new ArgumentException();
-            }
-        }
 
         public sealed class Message
         {
@@ -32,50 +18,6 @@ namespace VSRAD.BuildTools
             public string SourceFile { get; set; }
             public int Line { get; set; }
             public int Column { get; set; }
-        }
-
-        public static int[] MapLines(string preprocessed)
-        {
-            var lines = preprocessed.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
-            int[] result = new int[lines.Length];
-            int originalSourceLine = 1;
-            for (int i = 0; i < lines.Length; i++)
-            {
-                var line = lines[i];
-                
-                if (line.StartsWith("#") || line.StartsWith("//#"))
-                {
-                    originalSourceLine = int.Parse(LineNumRegex.Match(line).Value);
-                    continue;
-                }
-                result[i] = originalSourceLine++;
-            }
-            return result;
-        }
-
-        private static ICollection<Message> ParseStderr(string stderr)
-        {
-            var messages = new LinkedList<Message>();
-            using (var reader = new StringReader(stderr))
-            {
-                string line;
-                while ((line = reader.ReadLine()) != null)
-                {
-                    var match = ClangErrorRegex.Match(line);
-                    if (match.Success)
-                        messages.AddLast(new Message
-                        {
-                            Kind = MessageKindFromString(match.Groups["kind"].Value),
-                            Text = match.Groups["text"].Value,
-                            SourceFile = match.Groups["file"].Value,
-                            Line = int.Parse(match.Groups["line"].Value),
-                            Column = int.Parse(match.Groups["col"].Value)
-                        });
-                    else if (messages.Last != null)
-                        messages.Last.Value.Text += Environment.NewLine + line;
-                }
-            }
-            return messages;
         }
 
         public static IEnumerable<Message> ExtractMessages(string stderr, string preprocessed)
@@ -91,6 +33,118 @@ namespace VSRAD.BuildTools
             }
 
             return messages;
+        }
+
+        private enum ErrorFormat { Clang, Script, Undefined };
+
+        private static ICollection<Message> ParseStderr(string stderr)
+        {
+            var messages = new LinkedList<Message>();
+            var format = ErrorFormat.Undefined;
+            using (var reader = new StringReader(stderr))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    Message message;
+                    switch (format)
+                    {
+                        case ErrorFormat.Clang: message = ParseClangMessage(line); break;
+                        case ErrorFormat.Script: message = ParseScriptMessage(line); break;
+                        default:
+                            if ((message = ParseClangMessage(line)) != null)
+                                format = ErrorFormat.Clang;
+                            else if ((message = ParseScriptMessage(line)) != null)
+                                format = ErrorFormat.Script;
+                            break;
+                    }
+                    if (message != null)
+                        messages.AddLast(message);
+                    else if (messages.Last != null)
+                        messages.Last.Value.Text += Environment.NewLine + line;
+                }
+            }
+            return messages;
+        }
+
+        public static int[] MapLines(string preprocessed)
+        {
+            var lines = preprocessed.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            int[] result = new int[lines.Length];
+            int originalSourceLine = 1;
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+
+                if (line.StartsWith("#") || line.StartsWith("//#"))
+                {
+                    originalSourceLine = int.Parse(LineNumRegex.Match(line).Value);
+                    continue;
+                }
+                result[i] = originalSourceLine++;
+            }
+            return result;
+        }
+
+        private static readonly Regex ClangErrorRegex = new Regex(
+            @"(?<file>[^:]+):(?<line>\d+):(?<col>\d+):\s*(?<kind>error|warning|note):\s(?<text>.+)", RegexOptions.Compiled);
+
+        private static Message ParseClangMessage(string header)
+        {
+            var match = ClangErrorRegex.Match(header);
+            if (!match.Success) return null;
+            return new Message
+            {
+                Kind = ParseMessageKind(match.Groups["kind"].Value),
+                Text = match.Groups["text"].Value,
+                SourceFile = match.Groups["file"].Value,
+                Line = int.Parse(match.Groups["line"].Value),
+                Column = int.Parse(match.Groups["col"].Value)
+            };
+        }
+
+        private static readonly Regex ScriptErrorRegex = new Regex(
+            @"\*(?<kind>[EW]),(?<code>\w+)(?>\s\((?<file>[\w<>]+):(?<line>\d+)\))?:\s(?<text>.+)", RegexOptions.Compiled);
+
+        private static readonly Regex ScriptErrorLocationInTextRegex = new Regex(
+            @"\((?<file>[\w<>]+):(?<line>\d+)\)", RegexOptions.Compiled);
+
+        private static Message ParseScriptMessage(string header)
+        {
+            var match = ScriptErrorRegex.Match(header);
+            if (!match.Success) return null;
+            var message = new Message
+            {
+                Kind = ParseMessageKind(match.Groups["kind"].Value),
+                Text = match.Groups["text"].Value
+            };
+            if (match.Groups["file"].Success)
+            {
+                message.SourceFile = match.Groups["file"].Value;
+                message.Line = int.Parse(match.Groups["line"].Value);
+            }
+            else
+            {
+                match = ScriptErrorLocationInTextRegex.Match(message.Text);
+                if (match.Success)
+                {
+                    message.SourceFile = match.Groups["file"].Value;
+                    message.Line = int.Parse(match.Groups["line"].Value);
+                    message.Text = match.Groups["text"].Value;
+                }
+            }
+            return message;
+        }
+
+        private static MessageKind ParseMessageKind(string kind)
+        {
+            switch (kind)
+            {
+                case "E": case "error": return MessageKind.Error;
+                case "W": case "warning": return MessageKind.Warning;
+                case "note": return MessageKind.Note;
+                default: throw new ArgumentException();
+            }
         }
     }
 }

--- a/VSRAD.BuildTools/RemoteBuildTask.cs
+++ b/VSRAD.BuildTools/RemoteBuildTask.cs
@@ -41,24 +41,24 @@ namespace VSRAD.BuildTools
                 return false;
             }
 
-            foreach (var message in RemoteBuildStderrParser.ExtractMessages(result.Stderr, result.PreprocessedSource))
+            foreach (var message in Errors.Parser.ExtractMessages(result.Stderr, result.PreprocessedSource))
                 switch (message.Kind)
                 {
-                    case RemoteBuildStderrParser.MessageKind.Error:
+                    case Errors.MessageKind.Error:
                         Log.LogError(
                             subcategory: null, errorCode: null, helpKeyword: null,
                             message: message.Text, file: message.SourceFile,
                             lineNumber: message.Line, columnNumber: message.Column,
                             endLineNumber: 0, endColumnNumber: 0);
                         break;
-                    case RemoteBuildStderrParser.MessageKind.Warning:
+                    case Errors.MessageKind.Warning:
                         Log.LogWarning(
                             subcategory: null, warningCode: null, helpKeyword: null,
                             message: message.Text, file: message.SourceFile,
                             lineNumber: message.Line, columnNumber: message.Column,
                             endLineNumber: 0, endColumnNumber: 0);
                         break;
-                    case RemoteBuildStderrParser.MessageKind.Note:
+                    case Errors.MessageKind.Note:
                         Log.LogWarning(
                             subcategory: null, warningCode: null, helpKeyword: null,
                             message: "note: " + message.Text, file: message.SourceFile,

--- a/VSRAD.BuildTools/VSRAD.BuildTools.csproj
+++ b/VSRAD.BuildTools/VSRAD.BuildTools.csproj
@@ -48,10 +48,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Errors\Message.cs" />
     <Compile Include="IPCBuildResult.cs" />
     <Compile Include="RemoteBuildTask.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RemoteBuildStderrParser.cs" />
+    <Compile Include="Errors\Parser.cs" />
     <Compile Include="IPCBridge.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/VSRAD.BuildTools/VSRAD.BuildTools.csproj
+++ b/VSRAD.BuildTools/VSRAD.BuildTools.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Errors\LineMapper.cs" />
     <Compile Include="Errors\Message.cs" />
     <Compile Include="IPCBuildResult.cs" />
     <Compile Include="RemoteBuildTask.cs" />

--- a/VSRAD.BuildToolsTests/Errors/LineMapperTests.cs
+++ b/VSRAD.BuildToolsTests/Errors/LineMapperTests.cs
@@ -8,20 +8,19 @@ namespace VSRAD.BuildToolsTests.Errors
     public class LineMapperTests
     {
         public const string ErrString = @"
-test.c:5:10: error: invalid digit 'a' in octal constant
+test.c:12:10: error: invalid digit 'a' in octal constant
  return 0asdfshgmgmg
          ^
 1 error generated.
 ";
 
-        public const string PpString = @"
-# 1 ""test.c""
-# 1 ""<built-in>""
-# 1 ""<command-line>""
-# 31 ""<command-line>""
-# 1 ""/usr/include/stdc-predef.h"" 1 3 4
-# 32 ""<command-line>"" 2
-# 1 ""test.c""
+        public const string PpString = @"//# 1 ""test.c""
+//# 1 ""<built-in>""
+//# 1 ""<command-line>""
+//# 31 ""<command-line>""
+//# 1 ""/usr/include/stdc-predef.h"" 1 3 4
+//# 32 ""<command-line>"" 2
+//# 1 ""test.c""
 
 
 int main(int argc, char** argv)
@@ -49,7 +48,6 @@ int main() {
         [Fact]
         public void PreprocessMapLinesTest()
         {
-
             var lineMapping = MapLines(Preprocessed);
             Assert.Equal(new int[] { 1, 2, 3, 4, 0, 16, 17, 0, 55, 56, 57 }, lineMapping);
         }

--- a/VSRAD.BuildToolsTests/Errors/LineMapperTests.cs
+++ b/VSRAD.BuildToolsTests/Errors/LineMapperTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using Xunit;
+using static VSRAD.BuildTools.Errors.LineMapper;
+using static VSRAD.BuildTools.Errors.Parser;
+
+namespace VSRAD.BuildToolsTests.Errors
+{
+    public class LineMapperTests
+    {
+        public const string ErrString = @"
+test.c:5:10: error: invalid digit 'a' in octal constant
+ return 0asdfshgmgmg
+         ^
+1 error generated.
+";
+
+        public const string PpString = @"
+# 1 ""test.c""
+# 1 ""<built-in>""
+# 1 ""<command-line>""
+# 31 ""<command-line>""
+# 1 ""/usr/include/stdc-predef.h"" 1 3 4
+# 32 ""<command-line>"" 2
+# 1 ""test.c""
+
+
+int main(int argc, char** argv)
+        {
+
+            return 0asdfshgmgmg
+
+}
+
+";
+
+
+        public const string Preprocessed = @"
+int main() {
+    int a = 1 + 1;
+    int b = 2 + 2;
+# 16 'source.c'
+    int c = 3 + 3;
+    int d = 4 + 4;
+# 55 'source.c'
+    int f = 0xDEAD;
+}
+";
+
+        [Fact]
+        public void PreprocessMapLinesTest()
+        {
+
+            var lineMapping = MapLines(Preprocessed);
+            Assert.Equal(new int[] { 1, 2, 3, 4, 0, 16, 17, 0, 55, 56, 57 }, lineMapping);
+        }
+
+        [Fact]
+        public void ParseErrorsWithPreprocessedTest()
+        {
+            var messages = ExtractMessages(ErrString, PpString);
+            Assert.Equal(5, messages.First().Line);
+        }
+    }
+}

--- a/VSRAD.BuildToolsTests/Errors/ParserTests.cs
+++ b/VSRAD.BuildToolsTests/Errors/ParserTests.cs
@@ -6,7 +6,10 @@ namespace VSRAD.BuildTools.Errors
 {
     public class ParserTests
     {
-        public const string ClangErrorString = @"
+        [Fact]
+        public void ClangErrorTest()
+        {
+            var messages = ExtractMessages(@"
 input.s:267:27: error: expected absolute expression
       s_sub_u32         s[loop_xss], s[loop_x], 1
                           ^
@@ -17,12 +20,7 @@ host.c:4:2: warning: implicitly declaring library function 'printf' with type 'i
         printf(""h"");
         ^
 host.c:4:2: note: include the header<stdio.h> or explicitly provide a declaration for 'printf'
-";
-
-        [Fact]
-        public void ClangErrorTest()
-        {
-            var messages = ExtractMessages(ClangErrorString, "").ToList();
+", "").ToList();
 
             Assert.Equal(MessageKind.Error, messages[0].Kind);
             Assert.Equal(27, messages[0].Column);
@@ -53,6 +51,40 @@ host.c:4:2: note: include the header<stdio.h> or explicitly provide a declaratio
             Assert.Equal(2, messages[3].Column);
             Assert.Equal("host.c", messages[3].SourceFile);
             Assert.Equal(@"include the header<stdio.h> or explicitly provide a declaration for 'printf'", messages[3].Text);
+        }
+
+        [Fact]
+        public void ScriptErrorTest()
+        {
+            var messages = ExtractMessages(@"
+*E,fatal: undefined reference to 'printf' (<stdin>:3)
+*W,undefined: 1 undefined references found
+*E,syntax error (<stdin>:12): at symbol 'printf'
+    parse error: syntax error, unexpected T_PAAMAYIM_NEKUDOTAYIM
+    did you really mean to use the scope resolution op here?
+*E,fatal (auth.c:35): Uncaught error: Undefined variable: user
+", "").ToList();
+
+            Assert.Equal(MessageKind.Error, messages[0].Kind);
+            Assert.Equal(3, messages[0].Line);
+            Assert.Equal("<stdin>", messages[0].SourceFile);
+            Assert.Equal("fatal: undefined reference to 'printf'", messages[0].Text);
+
+            Assert.Equal(MessageKind.Warning, messages[1].Kind);
+            Assert.Null(messages[1].SourceFile);
+            Assert.Equal("undefined: 1 undefined references found", messages[1].Text);
+
+            Assert.Equal(MessageKind.Error, messages[2].Kind);
+            Assert.Equal(12, messages[2].Line);
+            Assert.Equal("<stdin>", messages[2].SourceFile);
+            Assert.Equal(@"syntax error: at symbol 'printf'
+    parse error: syntax error, unexpected T_PAAMAYIM_NEKUDOTAYIM
+    did you really mean to use the scope resolution op here?", messages[2].Text);
+
+            Assert.Equal(MessageKind.Error, messages[3].Kind);
+            Assert.Equal(35, messages[3].Line);
+            Assert.Equal("auth.c", messages[3].SourceFile);
+            Assert.Equal("fatal: Uncaught error: Undefined variable: user", messages[3].Text);
         }
     }
 }

--- a/VSRAD.BuildToolsTests/Errors/ParserTests.cs
+++ b/VSRAD.BuildToolsTests/Errors/ParserTests.cs
@@ -1,10 +1,10 @@
 ﻿using System.Linq;
 using Xunit;
-using static VSRAD.BuildTools.RemoteBuildStderrParser;
+using static VSRAD.BuildTools.Errors.Parser;
 
-namespace VSRAD.BuildTools
+namespace VSRAD.BuildTools.Errors
 {
-    public class RemoteBuildStderrParserTests
+    public class ParserTests
     {
         public const string ClangErrorString = @"
 input.s:267:27: error: expected absolute expression

--- a/VSRAD.BuildToolsTests/Errors/ParserTests.cs
+++ b/VSRAD.BuildToolsTests/Errors/ParserTests.cs
@@ -19,44 +19,6 @@ host.c:4:2: warning: implicitly declaring library function 'printf' with type 'i
 host.c:4:2: note: include the header<stdio.h> or explicitly provide a declaration for 'printf'
 ";
 
-        public const string ErrString = @"
-test.c:5:10: error: invalid digit 'a' in octal constant
- return 0asdfshgmgmg
-         ^
-1 error generated.
-";
-
-        public const string PpString = @"
-# 1 ""test.c""
-# 1 ""<built-in>""
-# 1 ""<command-line>""
-# 31 ""<command-line>""
-# 1 ""/usr/include/stdc-predef.h"" 1 3 4
-# 32 ""<command-line>"" 2
-# 1 ""test.c""
-
-
-int main(int argc, char** argv)
-        {
-
-            return 0asdfshgmgmg
-
-}
-
-";
-
-        public const string Preprocessed = @"
-int main() {
-    int a = 1 + 1;
-    int b = 2 + 2;
-# 16 'source.c'
-    int c = 3 + 3;
-    int d = 4 + 4;
-# 55 'source.c'
-    int f = 0xDEAD;
-}
-";
-
         [Fact]
         public void ClangErrorTest()
         {
@@ -91,20 +53,6 @@ int main() {
             Assert.Equal(2, messages[3].Column);
             Assert.Equal("host.c", messages[3].SourceFile);
             Assert.Equal(@"include the header<stdio.h> or explicitly provide a declaration for 'printf'", messages[3].Text);
-        }
-
-        [Fact]
-        public void PreprocessMapLinesTest()
-        {
-            var lineMapping = MapLines(Preprocessed);
-            Assert.Equal(new int[] { 1, 2, 3, 4, 0, 16, 17, 0, 55, 56, 57 }, lineMapping);
-        }
-
-        [Fact]
-        public void ParseErrorsWithPreprocessedTest()
-        {
-            var messages = ExtractMessages(ErrString, PpString);
-            Assert.Equal(5, messages.First().Line);
         }
     }
 }

--- a/VSRAD.BuildToolsTests/RemoteBuildStderrParserTests.cs
+++ b/VSRAD.BuildToolsTests/RemoteBuildStderrParserTests.cs
@@ -19,6 +19,32 @@ host.c:4:2: warning: implicitly declaring library function 'printf' with type 'i
 host.c:4:2: note: include the header<stdio.h> or explicitly provide a declaration for 'printf'
 ";
 
+        public const string ErrString = @"
+test.c:5:10: error: invalid digit 'a' in octal constant
+ return 0asdfshgmgmg
+         ^
+1 error generated.
+";
+
+        public const string PpString = @"
+# 1 ""test.c""
+# 1 ""<built-in>""
+# 1 ""<command-line>""
+# 31 ""<command-line>""
+# 1 ""/usr/include/stdc-predef.h"" 1 3 4
+# 32 ""<command-line>"" 2
+# 1 ""test.c""
+
+
+int main(int argc, char** argv)
+        {
+
+            return 0asdfshgmgmg
+
+}
+
+";
+
         public const string Preprocessed = @"
 int main() {
     int a = 1 + 1;
@@ -72,6 +98,13 @@ int main() {
         {
             var lineMapping = MapLines(Preprocessed);
             Assert.Equal(new int[] { 1, 2, 3, 4, 0, 16, 17, 0, 55, 56, 57 }, lineMapping);
+        }
+
+        [Fact]
+        public void ParseErrorsWithPreprocessedTest()
+        {
+            var messages = ExtractMessages(ErrString, PpString);
+            Assert.Equal(5, messages.First().Line);
         }
     }
 }

--- a/VSRAD.BuildToolsTests/VSRAD.BuildToolsTests.csproj
+++ b/VSRAD.BuildToolsTests/VSRAD.BuildToolsTests.csproj
@@ -52,7 +52,7 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="RemoteBuildStderrParserTests.cs" />
+    <Compile Include="Errors\ParserTests.cs" />
     <Compile Include="RemoteBuildTaskTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/VSRAD.BuildToolsTests/VSRAD.BuildToolsTests.csproj
+++ b/VSRAD.BuildToolsTests/VSRAD.BuildToolsTests.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Errors\LineMapperTests.cs" />
     <Compile Include="Errors\ParserTests.cs" />
     <Compile Include="RemoteBuildTaskTests.cs" />
   </ItemGroup>


### PR DESCRIPTION
Automatically detect Clang/script error message formats and parse them accordingly.