### PR TITLE
Run DA and PP as a part of project build

### DIFF
--- a/VSRAD.Package/Commands/DisassemblyCommand.cs
+++ b/VSRAD.Package/Commands/DisassemblyCommand.cs
@@ -3,9 +3,7 @@ using EnvDTE80;
 using Microsoft;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.TextManager.Interop;
 using System.ComponentModel.Composition;
-using System.IO;
 using VSRAD.Package.ProjectSystem;
 using Task = System.Threading.Tasks.Task;
 
@@ -39,7 +37,7 @@ namespace VSRAD.Package.Commands
             var dte = _serviceProvider.GetService(typeof(DTE)) as DTE2;
             Assumes.Present(dte);
             dte.ExecuteCommand("Build.BuildSolution");
-            dte.Events.BuildEvents.OnBuildProjConfigDone += (string project, string projectConfig, string platform, string solutionConfig, bool success) =>
+            dte.Events.BuildEvents.OnBuildDone += (vsBuildScope scope, vsBuildAction action) =>
                 OpenFileInEditor(options.LocalOutputCopyPath, options.LineMarker);
         }
     }

--- a/VSRAD.Package/Commands/PreprocessCommand.cs
+++ b/VSRAD.Package/Commands/PreprocessCommand.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.VisualStudio.ProjectSystem;
+﻿using EnvDTE;
+using EnvDTE80;
+using Microsoft;
+using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using System.ComponentModel.Composition;
-using System.IO;
-using VSRAD.DebugServer.IPC.Commands;
 using VSRAD.Package.ProjectSystem;
-using VSRAD.Package.Server;
 using Task = System.Threading.Tasks.Task;
 
 namespace VSRAD.Package.Commands
@@ -14,22 +14,16 @@ namespace VSRAD.Package.Commands
     internal sealed class PreprocessCommand : BaseRemoteCommand
     {
         private readonly IProject _project;
-        private readonly IFileSynchronizationManager _deployManager;
-        private readonly IOutputWindowManager _outputWindow;
-        private readonly ICommunicationChannel _channel;
+        private readonly BuildTools.BuildToolsServer _buildServer;
 
         [ImportingConstructor]
         public PreprocessCommand(
             IProject project,
-            IFileSynchronizationManager deployManager,
-            IOutputWindowManager outputWindow,
-            ICommunicationChannel channel,
+            BuildTools.BuildToolsServer buildServer,
             SVsServiceProvider serviceProvider) : base(Constants.PreprocessCommandId, serviceProvider)
         {
             _project = project;
-            _deployManager = deployManager;
-            _outputWindow = outputWindow;
-            _channel = channel;
+            _buildServer = buildServer;
         }
 
         public override async Task RunAsync()
@@ -37,26 +31,14 @@ namespace VSRAD.Package.Commands
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             var evaluator = await _project.GetMacroEvaluatorAsync(default);
             var options = await _project.Options.Profile.Preprocessor.EvaluateAsync(evaluator);
-            var command = new Execute { Executable = options.Executable, Arguments = options.Arguments, WorkingDirectory = options.WorkingDirectory, RunAsAdministrator = false };
 
-            await SetStatusBarTextAsync("RAD Debug: Preprocessing...");
-            try
-            {
-                await _deployManager.SynchronizeRemoteAsync();
-                var executor = new RemoteCommandExecutor("Preprocessing", _channel, _outputWindow);
-                var result = await executor.ExecuteWithResultAsync(command, options.RemoteOutputFile);
+            _buildServer.OverrideStepsForNextBuild(BuildTools.BuildSteps.Preprocessor);
 
-                if (!result.TryGetResult(out var execResult, out var error))
-                    throw new System.Exception(error.Message);
-                var (_, data) = execResult;
-
-                File.WriteAllBytes(options.LocalOutputCopyPath, data);
+            var dte = _serviceProvider.GetService(typeof(DTE)) as DTE2;
+            Assumes.Present(dte);
+            dte.ExecuteCommand("Build.BuildSolution");
+            dte.Events.BuildEvents.OnBuildDone += (vsBuildScope scope, vsBuildAction action) =>
                 OpenFileInEditor(options.LocalOutputCopyPath, options.LineMarker);
-            }
-            finally
-            {
-                await ClearStatusBarAsync();
-            }
         }
     }
 }


### PR DESCRIPTION
* Add a way to programmatically override build steps for the next project build (e.g. so it only runs *preprocess* or *disassemble*)
* Implement DA and PP commands as wrappers over project build (resolves #27)