### PR TITLE
Perform $ENVR macro substitution on VS side

### DIFF
--- a/VSRAD.DebugServer/IPC/IPCSerialization.cs
+++ b/VSRAD.DebugServer/IPC/IPCSerialization.cs
@@ -1,7 +1,6 @@
-﻿using System.IO;
-using System;
-using System.Text.RegularExpressions;
+﻿using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace VSRAD.DebugServer.IPC
 {
@@ -38,7 +37,6 @@ namespace VSRAD.DebugServer.IPC
     public sealed class IPCReader : BinaryReader
     {
         public IPCReader(Stream stream) : base(stream) { }
-        private static readonly Regex envMacroRegex = new Regex(@"\$ENVR\(([^)]+)\)", RegexOptions.Compiled);
 
         public string[] ReadLengthPrefixedStringArray()
         {
@@ -66,17 +64,5 @@ namespace VSRAD.DebugServer.IPC
 
         public DateTime ReadDateTime() =>
             DateTime.FromBinary(ReadInt64());
-
-        public override string ReadString()
-        {
-            var rawString = base.ReadString();
-            foreach(Match m in envMacroRegex.Matches(rawString))
-            {
-                var envName = m.Groups[1].Value;
-                var envValue = Environment.GetEnvironmentVariable(envName);
-                rawString = rawString.Replace(m.Value, envValue);
-            }
-            return rawString;
-        }
     }
 }

--- a/VSRAD.DebugServerTests/Handlers/ExecuteHandlerTest.cs
+++ b/VSRAD.DebugServerTests/Handlers/ExecuteHandlerTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using VSRAD.DebugServer.IPC.Commands;
 using VSRAD.DebugServer.IPC.Responses;
 using Xunit;
@@ -35,32 +34,6 @@ namespace VSRAD.DebugServerTests.Handlers
 
             var tmpContents = File.ReadAllText(tmpFile);
             Assert.Equal("command ran successfully\r\n", tmpContents);
-        }
-
-        [Fact]
-        public async void RunCommandWithEnvVariable()
-        {
-            Environment.SetEnvironmentVariable("PILOT_NAME", "ShinjiIkari");
-
-            var response = await Helper.DispatchCommandAsync<Execute, ExecutionCompleted>(
-                new Execute
-                {
-                    Executable = "python.exe",
-                    Arguments = $"-c \"print('pilot name: $ENVR(PILOT_NAME)')\""
-                });
-            Assert.Equal(ExecutionStatus.Completed, response.Status);
-            Assert.Equal(0, response.ExitCode);
-            Assert.Equal("pilot name: ShinjiIkari\r\n", response.Stdout);
-
-            response = await Helper.DispatchCommandAsync<Execute, ExecutionCompleted>(
-                new Execute
-                {
-                    Executable = "python.exe",
-                    Arguments = $"-c \"print('pilot name: $ENVR(I_DONT_EXIST)')\""
-                });
-            Assert.Equal(ExecutionStatus.Completed, response.Status);
-            Assert.Equal(0, response.ExitCode);
-            Assert.Equal("pilot name: \r\n", response.Stdout);
         }
 
         [Fact]

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEditManager.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEditManager.cs
@@ -42,7 +42,7 @@ namespace VSRAD.Package.ProjectSystem.Macros
                 remoteEnvironment = new Dictionary<string, string>();
             }
 
-            var evaluator = new MacroEvaluator(_project, projectProperties, transients, remoteEnvironment, profileOptions);
+            var evaluator = new MacroEvaluator(projectProperties, transients, remoteEnvironment, _project.Options.DebuggerOptions, profileOptions);
 
             await VSPackage.TaskFactory.SwitchToMainThreadAsync();
 

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEditManager.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEditManager.cs
@@ -30,9 +30,10 @@ namespace VSRAD.Package.ProjectSystem.Macros
             var propertiesProvider = configuredProject.GetService<IProjectPropertiesProvider>("ProjectPropertiesProvider");
             var projectProperties = propertiesProvider.GetCommonProperties();
 
-            var evaluator = new MacroEvaluator(_project, projectProperties,
-                values: new MacroEvaluatorTransientValues(activeSourceFile: ("<current source file>", 0)),
-                profileOptionsOverride: profileOptions);
+            var remoteEnv = await _channel.GetRemoteEnvironmentAsync().ConfigureAwait(false);
+            var transients = new MacroEvaluatorTransientValues(activeSourceFile: ("<current source file>", 0));
+
+            var evaluator = new MacroEvaluator(_project, projectProperties, transients, remoteEnv, profileOptions);
 
             await VSPackage.TaskFactory.SwitchToMainThreadAsync();
 

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
@@ -79,7 +79,6 @@ namespace VSRAD.Package.ProjectSystem.Macros
     {
         private static readonly Regex _macroRegex = new Regex(@"\$(ENVR?)?\(([^()]+)\)", RegexOptions.Compiled);
 
-        private readonly IProject _project;
         private readonly IProjectProperties _projectProperties;
         private readonly IReadOnlyDictionary<string, string> _remoteEnvironment;
 
@@ -87,16 +86,15 @@ namespace VSRAD.Package.ProjectSystem.Macros
         private readonly Dictionary<string, string> _macroCache;
 
         public MacroEvaluator(
-            IProject project,
             IProjectProperties projectProperties,
             MacroEvaluatorTransientValues values,
             IReadOnlyDictionary<string, string> remoteEnvironment,
-            Options.ProfileOptions profileOptionsOverride = null)
+            Options.DebuggerOptions debuggerOptions,
+            Options.ProfileOptions profileOptions)
         {
-            _project = project;
             _projectProperties = projectProperties;
             _remoteEnvironment = remoteEnvironment;
-            _profileOptions = profileOptionsOverride ?? _project.Options.Profile;
+            _profileOptions = profileOptions;
 
             // Properties that are macros but do not contain macros themselves
             _macroCache = new Dictionary<string, string>
@@ -105,12 +103,12 @@ namespace VSRAD.Package.ProjectSystem.Macros
                 { RadMacros.ActiveSourceFileLine, values.ActiveSourceFile.line.ToString() },
                 { RadMacros.Watches, values.WatchesOverride != null
                     ? string.Join(":", values.WatchesOverride)
-                    : string.Join(":", _project.Options.DebuggerOptions.GetWatchSnapshot()) },
-                { RadMacros.AWatches, string.Join(":", _project.Options.DebuggerOptions.GetAWatchSnapshot()) },
+                    : string.Join(":", debuggerOptions.GetWatchSnapshot()) },
+                { RadMacros.AWatches, string.Join(":", debuggerOptions.GetAWatchSnapshot()) },
                 { RadMacros.BreakLine, values.BreakLine.ToString() },
-                { RadMacros.DebugAppArgs, _project.Options.DebuggerOptions.AppArgs },
-                { RadMacros.DebugBreakArgs, _project.Options.DebuggerOptions.BreakArgs },
-                { RadMacros.Counter, _project.Options.DebuggerOptions.Counter.ToString() }
+                { RadMacros.DebugAppArgs, debuggerOptions.AppArgs },
+                { RadMacros.DebugBreakArgs, debuggerOptions.BreakArgs },
+                { RadMacros.Counter, debuggerOptions.Counter.ToString() }
             };
         }
 

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
@@ -177,17 +177,15 @@ namespace VSRAD.Package.ProjectSystem.Macros
 
         private Task<string> ReplaceMacroMatchAsync(Match macroMatch, string recursionStartName)
         {
-            var macroName = macroMatch.Groups[2].Value;
+            var macro = macroMatch.Groups[2].Value;
             switch (macroMatch.Groups[1].Value)
             {
                 case "ENV":
-                    return Task.FromResult(Environment.GetEnvironmentVariable(macroName));
+                    return Task.FromResult(Environment.GetEnvironmentVariable(macro));
                 case "ENVR":
-                    if (_remoteEnvironment.TryGetValue(macroName, out var macroValue))
-                        return Task.FromResult(macroValue);
-                    return Task.FromResult(macroMatch.Value);
+                    return Task.FromResult(_remoteEnvironment.TryGetValue(macro, out var value) ? value : "");
                 default:
-                    return GetMacroValueAsync(macroName, recursionStartName);
+                    return GetMacroValueAsync(macro, recursionStartName);
             }
         }
     }

--- a/VSRAD.Package/ProjectSystem/Project.cs
+++ b/VSRAD.Package/ProjectSystem/Project.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Threading.Tasks;
 using VSRAD.Package.Options;
 using VSRAD.Package.ProjectSystem.Macros;
+using VSRAD.Package.Server;
 using VSRAD.Package.Utils;
 
 namespace VSRAD.Package.ProjectSystem

--- a/VSRAD.Package/ProjectSystem/Project.cs
+++ b/VSRAD.Package/ProjectSystem/Project.cs
@@ -96,7 +96,7 @@ namespace VSRAD.Package.ProjectSystem
 
             var remoteEnvironment = await channel.GetRemoteEnvironmentAsync();
 
-            return new MacroEvaluator(this, properties, transients, remoteEnvironment);
+            return new MacroEvaluator(properties, transients, remoteEnvironment, Options.DebuggerOptions, Options.Profile);
         }
         #endregion
     }

--- a/VSRAD.Package/ProjectSystem/Project.cs
+++ b/VSRAD.Package/ProjectSystem/Project.cs
@@ -71,7 +71,7 @@ namespace VSRAD.Package.ProjectSystem
             Path.Combine(RootPath, projectRelativePath);
 
         #region MacroEvaluator
-        private (IActiveCodeEditor, IProjectProperties)? _macroEvaluatorDependencies;
+        private (IActiveCodeEditor, ICommunicationChannel, IProjectProperties)? _macroEvaluatorDependencies;
 
         public async Task<IMacroEvaluator> GetMacroEvaluatorAsync(uint breakLine = 0, string[] watchesOverride = null)
         {
@@ -81,20 +81,23 @@ namespace VSRAD.Package.ProjectSystem
             {
                 var configuredProject = await _unconfiguredProject.GetSuggestedConfiguredProjectAsync();
                 var activeCodeEditor = configuredProject.GetExport<IActiveCodeEditor>();
+                var communicationChannel = configuredProject.GetExport<ICommunicationChannel>();
 
                 var propertiesProvider = configuredProject.GetService<IProjectPropertiesProvider>("ProjectPropertiesProvider");
                 var projectProperties = propertiesProvider.GetCommonProperties();
 
-                _macroEvaluatorDependencies = (activeCodeEditor, projectProperties);
+                _macroEvaluatorDependencies = (activeCodeEditor, communicationChannel, projectProperties);
             }
-            var (codeEditor, properties) = _macroEvaluatorDependencies.Value;
+            var (codeEditor, channel, properties) = _macroEvaluatorDependencies.Value;
+
             var file = GetRelativePath(codeEditor.GetAbsoluteSourcePath());
             var line = codeEditor.GetCurrentLine();
             var transients = new MacroEvaluatorTransientValues(activeSourceFile: (file, line), breakLine: breakLine, watchesOverride: watchesOverride);
 
-            return new MacroEvaluator(this, properties, transients);
+            var remoteEnvironment = await channel.GetRemoteEnvironmentAsync();
+
+            return new MacroEvaluator(this, properties, transients, remoteEnvironment);
         }
         #endregion
-
     }
 }

--- a/VSRAD.Package/Server/CommunicationChannel.cs
+++ b/VSRAD.Package/Server/CommunicationChannel.cs
@@ -42,6 +42,13 @@ namespace VSRAD.Package.Server
         void ForceDisconnect();
     }
 
+    public sealed class ConnectionRefusedException : System.IO.IOException
+    {
+        public ConnectionRefusedException(ServerConnectionOptions connection) :
+            base($"Unable to establish connection to a debug server at {connection}")
+        { }
+    }
+
     public enum ClientState
     {
         Disconnected,
@@ -163,7 +170,7 @@ namespace VSRAD.Package.Server
             catch (Exception)
             {
                 ConnectionState = ClientState.Disconnected;
-                throw new Exception($"Unable to establish connection to a debug server at {ConnectionOptions}");
+                throw new ConnectionRefusedException(ConnectionOptions);
             }
         }
     }

--- a/VSRAD.Package/Server/CommunicationChannel.cs
+++ b/VSRAD.Package/Server/CommunicationChannel.cs
@@ -15,16 +15,6 @@ using Task = System.Threading.Tasks.Task;
 
 namespace VSRAD.Package.Server
 {
-    public readonly struct ConnectedRemoteState
-    {
-        public IReadOnlyDictionary<string, string> RemoteEnvironment { get; }
-
-        public ConnectedRemoteState(IReadOnlyDictionary<string, string> remoteEnvironment)
-        {
-            RemoteEnvironment = remoteEnvironment;
-        }
-    }
-
     public interface ICommunicationChannel
     {
         event Action ConnectionStateChanged;

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
@@ -24,24 +24,24 @@ namespace VSRAD.Package.ToolWindows
 
             public ICommand DisconnectCommand { get; }
 
-            private readonly ICommunicationChannelManager _channelManager;
+            private readonly ICommunicationChannel _channel;
 
-            public Context(ProjectOptions options, ICommunicationChannelManager channel)
+            public Context(ProjectOptions options, ICommunicationChannel channel)
             {
                 Options = options;
                 Options.Profiles.PropertyChanged += (s, e) => { if (e.PropertyName == nameof(Options.Profiles.Keys)) RaisePropertyChanged(nameof(ProfileNames)); };
-                _channelManager = channel;
-                _channelManager.ConnectionStateChanged += ConnectionStateChanged;
-                DisconnectCommand = new WpfDelegateCommand((_) => _channelManager.ForceDisconnect(), isEnabled: false);
+                _channel = channel;
+                _channel.ConnectionStateChanged += ConnectionStateChanged;
+                DisconnectCommand = new WpfDelegateCommand((_) => _channel.ForceDisconnect(), isEnabled: false);
                 ConnectionStateChanged();
             }
 
             private void ConnectionStateChanged()
             {
-                DisconnectLabel = _channelManager.ChannelState.state == ClientState.Connected ? "Disconnect"
-                                : _channelManager.ChannelState.state == ClientState.Connecting ? "Connecting..." : "Disconnected";
-                ConnectionInfo = _channelManager.ChannelState.connectionInfo;
-                ((WpfDelegateCommand)DisconnectCommand).IsEnabled = _channelManager.ChannelState.state == ClientState.Connected;
+                DisconnectLabel = _channel.ConnectionState == ClientState.Connected ? "Disconnect"
+                                : _channel.ConnectionState == ClientState.Connecting ? "Connecting..." : "Disconnected";
+                ConnectionInfo = _channel.ConnectionOptions.ToString();
+                ((WpfDelegateCommand)DisconnectCommand).IsEnabled = _channel.ConnectionState == ClientState.Connected;
             }
         }
 
@@ -52,7 +52,7 @@ namespace VSRAD.Package.ToolWindows
         {
             _projectOptions = integration.ProjectOptions;
             _macroEditor = integration.GetExport<MacroEditManager>();
-            DataContext = new Context(integration.ProjectOptions, integration.GetExport<ICommunicationChannelManager>());
+            DataContext = new Context(integration.ProjectOptions, integration.GetExport<ICommunicationChannel>());
             InitializeComponent();
             ColoringRegionsGrid.PreviewMouseWheel += (s, e) =>
             {

--- a/VSRAD.PackageTests/ProjectSystem/MacroEvaluatorTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/MacroEvaluatorTests.cs
@@ -9,19 +9,18 @@ namespace VSRAD.Package.ProjectSystem.Tests
 {
     public class MacroEvaluatorTests
     {
+        private static readonly IReadOnlyDictionary<string, string> EmptyRemoteEnv = new Dictionary<string, string>();
+
         [Fact]
         public async Task ProjectPropertiesTestAsync()
         {
-            var project = new Mock<IProject>();
+            var profileOptions = new Options.ProfileOptions(debugger: new Options.DebuggerProfileOptions(
+                arguments: "/home/sayaka/projects/debug_bin.py --solution $(SolutionDir)"));
+
             var props = new Mock<IProjectProperties>();
+            props.Setup((p) => p.GetEvaluatedPropertyValueAsync("SolutionDir")).ReturnsAsync("/opt/rocm/examples/h");
 
-            var options = new Options.ProjectOptions();
-            options.AddProfile("Default", new Options.ProfileOptions(debugger: new Options.DebuggerProfileOptions(
-                arguments: "/home/sayaka/projects/debug_bin.py --solution $(SolutionDir)")));
-            project.Setup((p) => p.Options).Returns(options);
-            props.Setup((p) => p.GetEvaluatedPropertyValueAsync("SolutionDir")).Returns(Task.FromResult("/opt/rocm/examples/h"));
-
-            var evaluator = new MacroEvaluator(project.Object, props.Object, default);
+            var evaluator = new MacroEvaluator(props.Object, default, EmptyRemoteEnv, new Options.DebuggerOptions(), profileOptions);
             var result = await evaluator.GetMacroValueAsync(RadMacros.DebuggerArguments);
             Assert.Equal("/home/sayaka/projects/debug_bin.py --solution /opt/rocm/examples/h", result);
         }
@@ -29,73 +28,52 @@ namespace VSRAD.Package.ProjectSystem.Tests
         [Fact]
         public async Task GetMacroValueRecursiveTestAsync()
         {
-            var project = new Mock<IProject>();
             var props = new Mock<IProjectProperties>();
 
-            var options = new Options.ProjectOptions();
-            options.AddProfile("Default", new Options.ProfileOptions(debugger: new Options.DebuggerProfileOptions(
+            var profileOptions = new Options.ProfileOptions(debugger: new Options.DebuggerProfileOptions(
                 executable: $"/opt/rocm/debug_exe $({RadMacros.DebuggerArguments})",
-                arguments: $"--exec $({RadMacros.DebuggerExecutable})")));
-            project.Setup((p) => p.Options).Returns(options);
+                arguments: $"--exec $({RadMacros.DebuggerExecutable})"));
 
-            var evaluator = new MacroEvaluator(project.Object, props.Object, default);
+            var evaluator = new MacroEvaluator(props.Object, default, EmptyRemoteEnv, new Options.DebuggerOptions(), profileOptions);
             var exception = await Assert.ThrowsAsync<MacroEvaluationException>(
-                async () => _ = await evaluator.GetMacroValueAsync(RadMacros.DebuggerExecutable));
+                () => _ = evaluator.GetMacroValueAsync(RadMacros.DebuggerExecutable));
             Assert.Equal($"Unable to evaluate $({RadMacros.DebuggerExecutable}): the macro refers to itself.", exception.Message);
         }
 
         [Fact]
         public async Task TransientValuesTestAsync()
         {
-            var project = new Mock<IProject>();
             var props = new Mock<IProjectProperties>();
 
-            var options = new Options.ProjectOptions();
-            options.AddProfile("Default", new Options.ProfileOptions());
-            options.DebuggerOptions.Watches = new List<DebugVisualizer.Watch>
+            var debuggerOptions = new Options.DebuggerOptions
             {
-                new DebugVisualizer.Watch("a", DebugVisualizer.VariableType.Hex, false),
-                new DebugVisualizer.Watch("c", DebugVisualizer.VariableType.Hex, false),
-                new DebugVisualizer.Watch("tide", DebugVisualizer.VariableType.Hex, false)
+                Watches = new List<DebugVisualizer.Watch>
+                {
+                    new DebugVisualizer.Watch("a", DebugVisualizer.VariableType.Hex, false),
+                    new DebugVisualizer.Watch("c", DebugVisualizer.VariableType.Hex, false),
+                    new DebugVisualizer.Watch("tide", DebugVisualizer.VariableType.Hex, false)
+                }
             };
-            project.Setup((p) => p.Options).Returns(options);
 
-            var evaluator = new MacroEvaluator(project.Object, props.Object, default);
+            var evaluator = new MacroEvaluator(props.Object, default, EmptyRemoteEnv, debuggerOptions, new Options.ProfileOptions());
             var result = await evaluator.GetMacroValueAsync(RadMacros.Watches);
             Assert.Equal("a:c:tide", result);
 
-            evaluator = new MacroEvaluator(project.Object, props.Object, new MacroEvaluatorTransientValues(
-                activeSourceFile: ("welcome home", 666), breakLine: 13, watchesOverride: new[] { "m", "c", "ride" }));
-            Assert.Equal("m:c:ride", await evaluator.GetMacroValueAsync(RadMacros.Watches));
-            Assert.Equal("welcome home:666, stop at 13", await evaluator.EvaluateAsync($"$({RadMacros.ActiveSourceFile}):$({RadMacros.ActiveSourceFileLine}), stop at $({RadMacros.BreakLine})"));
-        }
+            var transients = new MacroEvaluatorTransientValues(
+                activeSourceFile: ("welcome home", 666), breakLine: 13, watchesOverride: new[] { "m", "c", "ride" });
+            evaluator = new MacroEvaluator(props.Object, transients, EmptyRemoteEnv, debuggerOptions, new Options.ProfileOptions());
 
-        [Fact]
-        public async Task ProfileOptionsOverrideTestAsync()
-        {
-            var project = new Mock<IProject>();
-            var props = new Mock<IProjectProperties>();
-
-            var options = new Options.ProjectOptions();
-            options.AddProfile("sayaka", new Options.ProfileOptions(general: new Options.GeneralProfileOptions("soul")));
-            options.AddProfile("mami", new Options.ProfileOptions(general: new Options.GeneralProfileOptions("head")));
-            options.ActiveProfile = "sayaka";
-            project.Setup((p) => p.Options).Returns(options);
-
-            var evaluator = new MacroEvaluator(project.Object, props.Object, default);
-            Assert.Equal("soul", await evaluator.GetMacroValueAsync(RadMacros.DeployDirectory));
-            evaluator = new MacroEvaluator(project.Object, props.Object, default, profileOptionsOverride: options.Profiles["mami"]);
-            Assert.Equal("head", await evaluator.GetMacroValueAsync(RadMacros.DeployDirectory));
+            result = await evaluator.GetMacroValueAsync(RadMacros.Watches);
+            Assert.Equal("m:c:ride", result);
+            result = await evaluator.EvaluateAsync($"$({RadMacros.ActiveSourceFile}):$({RadMacros.ActiveSourceFileLine}), stop at $({RadMacros.BreakLine})");
+            Assert.Equal("welcome home:666, stop at 13", result);
         }
 
         [Fact]
         public async Task EmptyMacroNameTestAsync()
         {
-            var project = new Mock<IProject>();
             var props = new Mock<IProjectProperties>(MockBehavior.Strict); // fails the test if called
-            project.Setup((p) => p.Options).Returns(new Options.ProjectOptions());
-
-            var evaluator = new MacroEvaluator(project.Object, props.Object, default, profileOptionsOverride: new Options.ProfileOptions());
+            var evaluator = new MacroEvaluator(props.Object, default, EmptyRemoteEnv, new Options.DebuggerOptions(), new Options.ProfileOptions());
             Assert.Equal("$()", await evaluator.EvaluateAsync("$()"));
             Assert.Equal("", await evaluator.EvaluateAsync(""));
         }
@@ -103,14 +81,12 @@ namespace VSRAD.Package.ProjectSystem.Tests
         [Fact]
         public async Task ParserEdgeCaseTestAsync()
         {
-            var project = new Mock<IProject>();
             var props = new Mock<IProjectProperties>();
-            props.Setup((p) => p.GetEvaluatedPropertyValueAsync("S")).Returns(Task.FromResult("start"));
-            props.Setup((p) => p.GetEvaluatedPropertyValueAsync("M")).Returns(Task.FromResult("middle"));
-            props.Setup((p) => p.GetEvaluatedPropertyValueAsync("E")).Returns(Task.FromResult("end"));
-            project.Setup((p) => p.Options).Returns(new Options.ProjectOptions());
+            props.Setup((p) => p.GetEvaluatedPropertyValueAsync("S")).ReturnsAsync("start");
+            props.Setup((p) => p.GetEvaluatedPropertyValueAsync("M")).ReturnsAsync("middle");
+            props.Setup((p) => p.GetEvaluatedPropertyValueAsync("E")).ReturnsAsync("end");
 
-            var evaluator = new MacroEvaluator(project.Object, props.Object, default, profileOptionsOverride: new Options.ProfileOptions());
+            var evaluator = new MacroEvaluator(props.Object, default, EmptyRemoteEnv, new Options.DebuggerOptions(), new Options.ProfileOptions());
             Assert.Equal("start middle end", await evaluator.EvaluateAsync("$(S) $(M) $(E)"));
             Assert.Equal("start $$() $( middle end", await evaluator.EvaluateAsync("$(S) $$() $( $(M) $(E)"));
             Assert.Equal("$( nested middle $( $", await evaluator.EvaluateAsync("$( nested $(M) $( $"));

--- a/VSRAD.PackageTests/ProjectSystem/MacroEvaluatorTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/MacroEvaluatorTests.cs
@@ -60,6 +60,9 @@ namespace VSRAD.Package.ProjectSystem.Tests
             var evaluator = new MacroEvaluator(props.Object, default, remoteEnv, new Options.DebuggerOptions(), new Options.ProfileOptions());
             var result = await evaluator.EvaluateAsync("Local: $ENV(PATH), Remote: $ENVR(PATH), Break at: $ENVR(MAMI_BREAKPOINT)");
             Assert.Equal($"Local: {localPath}, Remote: /usr/bin:/root/soulgems, Break at: head", result);
+
+            result = await evaluator.EvaluateAsync("Local: $ENV(HOPEFULLY_NON_EXISTENT_VAR), Remote: $ENVR(HOPEFULLY_NON_EXISTENT_VAR)");
+            Assert.Equal("Local: , Remote: ", result);
         }
 
         [Fact]


### PR DESCRIPTION
Upon connecting to the server, the extension requests a list of environment variables defined on the remote host. This information is stored until the connection is closed and used by `MacroEvaluator`.

Resolves #24 

