### PR TITLE
Column selector rewrite

### DIFF
--- a/VSRAD.Package/DebugVisualizer/ColumnSelector.cs
+++ b/VSRAD.Package/DebugVisualizer/ColumnSelector.cs
@@ -111,5 +111,16 @@ namespace VSRAD.Package.DebugVisualizer
             foreach (var emptyRegion in emptyRegions)
                 regions.Remove(emptyRegion);
         }
+
+        public static string GetSelectorMultiplication(string currentSelector, string newSelector)
+        {
+            var currentIndexes = ToIndexes(currentSelector);
+            var newIndexes = ToIndexes(newSelector);
+
+            if (currentIndexes.All(i => newIndexes.Contains(i)))
+                return FromIndexes(newIndexes);
+            else
+                return FromIndexes(newIndexes.Intersect(currentIndexes));
+        }
     }
 }

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -148,12 +148,16 @@ namespace VSRAD.Package.DebugVisualizer
         {
             var hiddenColumsIndexes = DataColumns
                 .Where(x => !x.Visible)
-                .Select(x => x.Index - DataColumnOffset)
-                .ToList();
+                .Select(x => x.Index - DataColumnOffset);
 
+            var currentIndexes = ColumnSelector.ToIndexes(_stylingOptions.VisibleColumns);
             var newIndexes = ColumnSelector.ToIndexes(newSelector);
 
-            _stylingOptions.VisibleColumns = ColumnSelector.FromIndexes(newIndexes.Except(hiddenColumsIndexes));
+            if (currentIndexes.All(i => newIndexes.Contains(i)))
+                _stylingOptions.VisibleColumns = ColumnSelector.FromIndexes(newIndexes);
+            else
+                _stylingOptions.VisibleColumns = ColumnSelector.FromIndexes(newIndexes.Except(hiddenColumsIndexes));
+
             ClearSelection();
         }
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -146,18 +146,8 @@ namespace VSRAD.Package.DebugVisualizer
 
         public void ColumnSelectorChanged(string newSelector)
         {
-            var hiddenColumsIndexes = DataColumns
-                .Where(x => !x.Visible)
-                .Select(x => x.Index - DataColumnOffset);
-
-            var currentIndexes = ColumnSelector.ToIndexes(_stylingOptions.VisibleColumns);
-            var newIndexes = ColumnSelector.ToIndexes(newSelector);
-
-            if (currentIndexes.All(i => newIndexes.Contains(i)))
-                _stylingOptions.VisibleColumns = ColumnSelector.FromIndexes(newIndexes);
-            else
-                _stylingOptions.VisibleColumns = ColumnSelector.FromIndexes(newIndexes.Except(hiddenColumsIndexes));
-
+            _stylingOptions.VisibleColumns =
+                ColumnSelector.GetSelectorMultiplication(_stylingOptions.VisibleColumns, newSelector);
             ClearSelection();
         }
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -146,7 +146,14 @@ namespace VSRAD.Package.DebugVisualizer
 
         public void ColumnSelectorChanged(string newSelector)
         {
-            _stylingOptions.VisibleColumns = newSelector;
+            var hiddenColumsIndexes = DataColumns
+                .Where(x => !x.Visible)
+                .Select(x => x.Index - DataColumnOffset)
+                .ToList();
+
+            var newIndexes = ColumnSelector.ToIndexes(newSelector);
+
+            _stylingOptions.VisibleColumns = ColumnSelector.FromIndexes(newIndexes.Except(hiddenColumsIndexes));
             ClearSelection();
         }
 

--- a/VSRAD.PackageTests/DebugVisualizer/ColumnSelectorTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/ColumnSelectorTests.cs
@@ -44,5 +44,49 @@ namespace VSRAD.PackageTests.DebugVisualizer
             Assert.Equal("30-32:34-36:38-41:43-45:51:53-55", highlightRegions[2].Selector);
             Assert.Equal(3, highlightRegions.Count);
         }
+
+        [Fact]
+        public void SelectorsMultiplicationTest()
+        {
+            var currentSelector = "0-511";
+
+            // keep first
+            currentSelector = ColumnSelector.GetSelectorMultiplication(currentSelector, "0-255");
+            Assert.Equal("0-255", currentSelector);
+
+            currentSelector = ColumnSelector.GetSelectorMultiplication(currentSelector, "0-127:256-384");
+            Assert.Equal("0-127", currentSelector);
+
+            currentSelector = ColumnSelector.GetSelectorMultiplication(currentSelector, "0-63:128-191:256-319:384-447");
+            Assert.Equal("0-63", currentSelector);
+
+            currentSelector = ColumnSelector.GetSelectorMultiplication(currentSelector, "0-127");
+            Assert.Equal("0-127", currentSelector);
+
+            currentSelector = ColumnSelector.GetSelectorMultiplication(currentSelector, "0-255");
+            Assert.Equal("0-255", currentSelector);
+
+            currentSelector = ColumnSelector.GetSelectorMultiplication(currentSelector, "0-511");
+            Assert.Equal("0-511", currentSelector);
+
+            //keep last
+            currentSelector = ColumnSelector.GetSelectorMultiplication(currentSelector, "256-511");
+            Assert.Equal("256-511", currentSelector);
+
+            currentSelector = ColumnSelector.GetSelectorMultiplication(currentSelector, "128-255:384-511");
+            Assert.Equal("384-511", currentSelector);
+
+            currentSelector = ColumnSelector.GetSelectorMultiplication(currentSelector, "64-127:192-255:320-383:448-511");
+            Assert.Equal("448-511", currentSelector);
+
+            currentSelector = ColumnSelector.GetSelectorMultiplication(currentSelector, "384-511");
+            Assert.Equal("384-511", currentSelector);
+
+            currentSelector = ColumnSelector.GetSelectorMultiplication(currentSelector, "256-511");
+            Assert.Equal("256-511", currentSelector);
+
+            currentSelector = ColumnSelector.GetSelectorMultiplication(currentSelector, "0-511");
+            Assert.Equal("0-511", currentSelector);
+        }
     }
 }


### PR DESCRIPTION
New ranges selected from context menu multiplies by current selector, unless current column set is a subset of a new one - in that case new selector uses "as is".