### PR TITLE
Add an option to disable existing breakpoints when a new one is added

### DIFF
--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -32,6 +32,9 @@ namespace VSRAD.Package.Options
         private ContinueMode _continueMode = ContinueMode.RoundRobin;
         public ContinueMode ContinueMode { get => _continueMode; set => SetField(ref _continueMode, value); }
 
+        private bool _singleActiveBreakpoint = false;
+        public bool SingleActiveBreakpoint { get => _singleActiveBreakpoint; set => SetField(ref _singleActiveBreakpoint, value); }
+
         public DebuggerOptions() { }
         public DebuggerOptions(List<Watch> watches) => Watches = watches;
     }

--- a/VSRAD.Package/ProjectSystem/BreakpointIntegration.cs
+++ b/VSRAD.Package/ProjectSystem/BreakpointIntegration.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading;
+using VSRAD.Package.Options;
+using Task = System.Threading.Tasks.Task;
+
+namespace VSRAD.Package.ProjectSystem
+{
+    [Export]
+    [AppliesTo(Constants.ProjectCapability)]
+    public sealed class BreakpointIntegration
+    {
+        private static readonly TimeSpan _pollDelay = new TimeSpan(250 * TimeSpan.TicksPerMillisecond);
+        private readonly SVsServiceProvider _serviceProvider;
+        private readonly IProject _project;
+
+        private readonly CancellationTokenSource _pollCts = new CancellationTokenSource();
+        private readonly Dictionary<string, EnvDTE.Breakpoint> _activeBreakpoints = new Dictionary<string, EnvDTE.Breakpoint>();
+
+        private EnvDTE.Debugger _debuggerDte;
+
+        [ImportingConstructor]
+        public BreakpointIntegration(SVsServiceProvider serviceProvider, IProject project)
+        {
+            _serviceProvider = serviceProvider;
+            _project = project;
+            _project.Loaded += Initialize;
+            _project.Unloaded += _pollCts.Cancel;
+        }
+
+        public void Initialize(ProjectOptions options)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            var dte = _serviceProvider.GetService(typeof(SDTE)) as EnvDTE.DTE;
+            Assumes.Present(dte);
+            _debuggerDte = dte.Debugger;
+            VSPackage.TaskFactory.RunAsyncWithErrorHandling(PollBreakpointsAsync);
+        }
+
+        private async Task PollBreakpointsAsync()
+        {
+            await VSPackage.TaskFactory.SwitchToMainThreadAsync();
+            while (!_pollCts.IsCancellationRequested)
+            {
+                if (_debuggerDte.Breakpoints != null)
+                {
+                    foreach (EnvDTE.Breakpoint newBp in _debuggerDte.Breakpoints)
+                    {
+                        if (!newBp.Enabled)
+                            continue;
+                        // If the breakpoint is enabled and does not match the previously active one, disable the latter
+                        if (_activeBreakpoints.TryGetValue(newBp.File, out var oldBp))
+                        {
+                            if (newBp != oldBp)
+                            {
+                                oldBp.Enabled = false;
+                                _activeBreakpoints[newBp.File] = newBp;
+                            }
+                        }
+                        else
+                        {
+                            _activeBreakpoints[newBp.File] = newBp;
+                        }
+                    }
+                }
+
+                await Task.Delay(_pollDelay);
+            }
+        }
+    }
+}

--- a/VSRAD.Package/ProjectSystem/Project.cs
+++ b/VSRAD.Package/ProjectSystem/Project.cs
@@ -15,10 +15,12 @@ using VSRAD.Package.Utils;
 namespace VSRAD.Package.ProjectSystem
 {
     public delegate void ProjectLoaded(ProjectOptions options);
+    public delegate void ProjectUnloaded();
 
     public interface IProject
     {
         event ProjectLoaded Loaded;
+        event ProjectUnloaded Unloaded;
 
         ProjectOptions Options { get; }
         string RootPath { get; }
@@ -33,6 +35,7 @@ namespace VSRAD.Package.ProjectSystem
     public sealed class Project : IProject
     {
         public event ProjectLoaded Loaded;
+        public event ProjectUnloaded Unloaded;
 
         public ProjectOptions Options { get; private set; }
 
@@ -57,6 +60,12 @@ namespace VSRAD.Package.ProjectSystem
             Options.VisualizerOptions.PropertyChanged += (s, e) => SaveOptions();
             Options.VisualizerColumnStyling.StylingChanged += SaveOptions;
             Loaded?.Invoke(Options);
+        }
+
+        public void Unload()
+        {
+            SaveOptions();
+            Unloaded?.Invoke();
         }
 
         public void SaveOptions() => Options.Write(_optionsFilePath);

--- a/VSRAD.Package/ProjectSystem/ProjectLifecycle.cs
+++ b/VSRAD.Package/ProjectSystem/ProjectLifecycle.cs
@@ -46,7 +46,6 @@ namespace VSRAD.Package.ProjectSystem
             ((Project)_project).Load();
             QuickInfoState.SetProjectOnLoad(_project);
             Debugger.SetProjectOnLoad(_project);
-            BuildServer.SetProjectOnLoad(_project);
 
             var configuredProject = await _unconfiguredProject.GetSuggestedConfiguredProjectAsync();
             ToolWindowIntegration = new ToolWindowIntegration(configuredProject, _project, Debugger);
@@ -56,9 +55,8 @@ namespace VSRAD.Package.ProjectSystem
 
         private async Task ProjectUnloadingAsync(object sender, EventArgs args)
         {
-            _project.SaveOptions();
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            BuildServer.OnProjectUnloading();
+            ((Project)_project).Unload();
             VSPackage.ProjectUnloaded();
         }
 

--- a/VSRAD.Package/ProjectSystem/ProjectLifecycle.cs
+++ b/VSRAD.Package/ProjectSystem/ProjectLifecycle.cs
@@ -34,6 +34,8 @@ namespace VSRAD.Package.ProjectSystem
         [Import]
         private DebuggerIntegration Debugger { get; set; }
         [Import]
+        private BreakpointIntegration Breakpoints { get; set; }
+        [Import]
         private BuildToolsServer BuildServer { get; set; }
 
         [Export(typeof(IToolWindowIntegration))]

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -54,10 +54,14 @@
                     <viz:NumberInput VerticalContentAlignment="Center" Width="50" Height="24" Minimum="0" Maximum="512"
                                         Value="{Binding DataContext.Options.VisualizerOptions.LaneGrouping, UpdateSourceTrigger=PropertyChanged, ElementName=Root}"/>
                 </StackPanel>
-                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                    <Label Content="Continue Mode:"/>
-                    <ComboBox SelectedItem="{Binding Options.DebuggerOptions.ContinueMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                <StackPanel Orientation="Vertical" Margin="0,8,0,0">
+                    <CheckBox Content="Disable other breakpoints when adding a new one"
+                            IsChecked="{Binding Options.DebuggerOptions.SingleActiveBreakpoint, UpdateSourceTrigger=PropertyChanged}"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                        <Label Content="Continue Mode:"/>
+                        <ComboBox SelectedItem="{Binding Options.DebuggerOptions.ContinueMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                               ItemsSource="{Binding Source={StaticResource ContinueMode}}"/>
+                    </StackPanel>
                 </StackPanel>
             </StackPanel>
             <Label Margin="8,4,0,0" Content="Visualizer Coloring Ranges"/>

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -160,6 +160,7 @@
     <Compile Include="DebugVisualizer\Watch.cs" />
     <Compile Include="BuildTools\BuildToolsServer.cs" />
     <Compile Include="Options\DefaultOptionValues.cs" />
+    <Compile Include="ProjectSystem\BreakpointIntegration.cs" />
     <Compile Include="Utils\ContinueMode.cs" />
     <Compile Include="ProjectSystem\Macros\MacroEditor.cs" />
     <Compile Include="Properties\Resources.Designer.cs">


### PR DESCRIPTION
Unfortunately, Visual Studio does not provide an API to observe breakpoints in design mode:
* ["After consulting with the debugger team, there is no public API for this."](https://social.msdn.microsoft.com/Forums/en-US/fe2e7263-c0a2-40d1-9349-5c64a3e5b188/how-do-i-detect-a-breakpoint-being-deleted-in-visual-studio?forum=vsx)
* ["After some discussion with the Ms VS team, there is no service to get event from the breakpoint window."](https://social.msdn.microsoft.com/Forums/en-US/ada85864-a5ef-4191-8e82-dd1f3fa54446/how-to-get-notified-when-user-remove-a-breakpoint-from-the-breakpoint-window?forum=vsx)

The approach taken in this PR is not pretty, but it works: we poll the DTE breakpoint list every 250 milliseconds (this delay can be tweaked later) to detect state changes. No polling is performed when the option is disabled in settings.