### PR TITLE
Multiple breakpoints

### DIFF
--- a/VSRAD.Deborgar/EngineCallback.cs
+++ b/VSRAD.Deborgar/EngineCallback.cs
@@ -8,7 +8,7 @@ namespace VSRAD.Deborgar
     {
         void OnAttach();
         void OnBreakpointBound(Breakpoint breakpoint);
-        void OnBreakpointHit(IDebugBoundBreakpoint2 breakpoint);
+        void OnBreakpointsHit(IDebugBoundBreakpoint2[] breakpoints);
         void OnProgramTerminated();
         void OnStepComplete();
         void OnBreakComplete();
@@ -41,9 +41,9 @@ namespace VSRAD.Deborgar
             Send(new AD7BreakpointBoundEvent(breakpoint), AD7BreakpointBoundEvent.GUID);
         }
 
-        public void OnBreakpointHit(IDebugBoundBreakpoint2 breakpoint)
+        public void OnBreakpointsHit(IDebugBoundBreakpoint2[] breakpoints)
         {
-            var boundBreakpoints = new AD7BoundBreakpointsEnum(new[] { breakpoint });
+            var boundBreakpoints = new AD7BoundBreakpointsEnum(breakpoints);
             Send(new AD7BreakpointEvent(boundBreakpoints), AD7BreakpointEvent.GUID);
         }
 

--- a/VSRAD.Deborgar/ExecutionController.cs
+++ b/VSRAD.Deborgar/ExecutionController.cs
@@ -7,11 +7,11 @@ namespace VSRAD.Deborgar.Server
         private readonly IEngineIntegration _engineIntegration;
         private readonly IEngineCallbacks _callbacks;
 
-        private readonly Dictionary<string, (bool isStepping, uint breakLine)> _stepState =
-            new Dictionary<string, (bool isStepping, uint breakLine)>();
+        private readonly Dictionary<string, (bool isStepping, uint[] breakLines)> _stepState =
+            new Dictionary<string, (bool isStepping, uint[] breakLines)>();
 
         public string CurrentFile { get; private set; }
-        public uint CurrentBreakTarget => _stepState[CurrentFile].breakLine;
+        public uint[] CurrentBreakTarget => _stepState[CurrentFile].breakLines;
 
         public ExecutionController(IEngineIntegration engineIntegration, IEngineCallbacks callbacks)
         {
@@ -24,26 +24,41 @@ namespace VSRAD.Deborgar.Server
         public void ComputeNextBreakTarget(string file, IBreakpointManager breakpointManager)
         {
             CurrentFile = file;
-            if (!_engineIntegration.PopRunToLineIfSet(file, out var breakLine))
-            {
-                var prevBreakLine = _stepState.TryGetValue(file, out var prevState) 
-                    ? prevState.breakLine 
-                    : _engineIntegration.RerunOnContinue()
-                        ? breakpointManager.GetNextBreakpointLine(file, 0)
-                        : 0;
+            _stepState[file] = (isStepping: false, ComputeBreakLines(file, breakpointManager));
+        }
 
-                breakLine = _engineIntegration.RerunOnContinue()
-                    ? prevBreakLine
-                    : breakpointManager.GetNextBreakpointLine(file, prevBreakLine);
+        private uint[] ComputeBreakLines(string file, IBreakpointManager breakpointManager)
+        {
+            if (_engineIntegration.PopRunToLineIfSet(file, out var breakLine))
+                return new[] { breakLine };
+            switch (_engineIntegration.GetBreakMode())
+            {
+                case BreakMode.Multiple:
+                    return breakpointManager.GetBreakpointLines(file);
+                case BreakMode.SingleRerun:
+                    if (_stepState.TryGetValue(file, out var prevState))
+                        return new[] { prevState.breakLines[0] };
+                    return new[] { breakpointManager.GetNextBreakpointLine(file, 0) };
+                default:
+                    var prevBreakLine = _stepState.TryGetValue(file, out prevState) ? prevState.breakLines[0] : 0;
+                    return new[] { breakpointManager.GetNextBreakpointLine(file, prevBreakLine) };
             }
-            _stepState[file] = (isStepping: false, breakLine);
         }
 
         public void ComputeNextStepTarget(string file)
         {
             CurrentFile = file;
-            var prevBreakLine = _stepState.TryGetValue(file, out var prevState) ? prevState.breakLine : 0;
-            _stepState[file] = (isStepping: true, breakLine: prevBreakLine + 1);
+            if (_stepState.TryGetValue(file, out var prevState))
+            {
+                if (_engineIntegration.GetBreakMode() == BreakMode.Multiple)
+                    _stepState[file] = (isStepping: true, prevState.breakLines);
+                else
+                    _stepState[file] = (isStepping: true, breakLines: new[] { prevState.breakLines[0] + 1 });
+            }
+            else
+            {
+                _stepState[file] = (isStepping: true, breakLines: new[] { 0u });
+            }
         }
 
         private void ExecutionCompleted(bool success)

--- a/VSRAD.Deborgar/ExecutionController.cs
+++ b/VSRAD.Deborgar/ExecutionController.cs
@@ -35,12 +35,8 @@ namespace VSRAD.Deborgar.Server
             {
                 case BreakMode.Multiple:
                     return breakpointManager.GetBreakpointLines(file);
-                case BreakMode.SingleRerun:
-                    if (_stepState.TryGetValue(file, out var prevState))
-                        return new[] { prevState.breakLines[0] };
-                    return new[] { breakpointManager.GetNextBreakpointLine(file, 0) };
                 default:
-                    var prevBreakLine = _stepState.TryGetValue(file, out prevState) ? prevState.breakLines[0] : 0;
+                    var prevBreakLine = _stepState.TryGetValue(file, out var prevState) ? prevState.breakLines[0] : 0;
                     return new[] { breakpointManager.GetNextBreakpointLine(file, prevBreakLine) };
             }
         }

--- a/VSRAD.Deborgar/IEngineIntegration.cs
+++ b/VSRAD.Deborgar/IEngineIntegration.cs
@@ -1,17 +1,20 @@
-﻿using System;
-
-namespace VSRAD.Deborgar
+﻿namespace VSRAD.Deborgar
 {
     public delegate void ExecutionCompleted(bool success);
 
+    public enum BreakMode
+    {
+        SingleRoundRobin, SingleRerun, Multiple
+    }
+
     public interface IEngineIntegration
     {
-        void ExecuteToLine(uint breakLine);
+        void Execute(uint[] breakLines);
         string GetActiveProjectFile();
         string GetProjectRelativePath(string absoluteFilePath);
         uint GetFileLineCount(string projectFilePath);
+        BreakMode GetBreakMode();
         bool PopRunToLineIfSet(string file, out uint runToLine);
-        bool RerunOnContinue();
 
         event ExecutionCompleted ExecutionCompleted;
     }

--- a/VSRAD.Deborgar/SourceFileLineContext.cs
+++ b/VSRAD.Deborgar/SourceFileLineContext.cs
@@ -12,8 +12,8 @@ namespace VSRAD.Deborgar
 
         private readonly TEXT_POSITION _position;
 
-        public SourceFileLineContext(string projectPath, uint line)
-            : this(projectPath, new TEXT_POSITION { dwLine = line, dwColumn = 0 }) { }
+        public SourceFileLineContext(string projectPath, uint[] lines)
+            : this(projectPath, new TEXT_POSITION { dwLine = lines[0], dwColumn = 0 }) { }
 
         public SourceFileLineContext(string projectPath, TEXT_POSITION position)
         {

--- a/VSRAD.DeborgarTests/ProgramTests.cs
+++ b/VSRAD.DeborgarTests/ProgramTests.cs
@@ -32,16 +32,16 @@ namespace VSRAD.DeborgarTests
             breakpointManager.Setup((b) => b.GetNextBreakpointLine("h.s", 0)).Returns(7);
             breakpointManager.Setup((b) => b.GetNextBreakpointLine("h.s", 7)).Returns(13);
             breakpointManager.Setup((b) => b.GetNextBreakpointLine("h.s", 13)).Returns(21);
-            integration.Setup((i) => i.ExecuteToLine(It.IsAny<uint>())).Callback(() =>
+            integration.Setup((i) => i.Execute(It.IsAny<uint[]>())).Callback(() =>
                 integration.Raise((i) => i.ExecutionCompleted += null, true));
 
             program.ExecuteOnThread(null);
-            integration.Verify((i) => i.ExecuteToLine(7), Times.Once);
+            integration.Verify((i) => i.Execute(new uint[] { 7 }), Times.Once);
             callbacks.Verify((c) => c.OnBreakComplete(), Times.Once);
             Helpers.VerifyBreakFrameLocation(program, "h.s", 7);
 
             program.ExecuteOnThread(null);
-            integration.Verify((i) => i.ExecuteToLine(13), Times.Once);
+            integration.Verify((i) => i.Execute(new uint[] { 13 }), Times.Once);
             callbacks.Verify((c) => c.OnBreakComplete(), Times.Exactly(2));
             Helpers.VerifyBreakFrameLocation(program, "h.s", 13);
 
@@ -49,7 +49,7 @@ namespace VSRAD.DeborgarTests
             uint runToLine = 666;
             integration.Setup((i) => i.PopRunToLineIfSet("h.s", out runToLine)).Returns(true);
             program.ExecuteOnThread(null);
-            integration.Verify((i) => i.ExecuteToLine(666), Times.Once);
+            integration.Verify((i) => i.Execute(new uint[] { 666 }), Times.Once);
             callbacks.Verify((c) => c.OnBreakComplete(), Times.Exactly(3));
             Helpers.VerifyBreakFrameLocation(program, "h.s", 666);
         }
@@ -63,20 +63,20 @@ namespace VSRAD.DeborgarTests
             breakpointManager.Setup((b) => b.GetNextBreakpointLine("hhhh.s", 0)).Returns(13);
 
             // Execution to line 7 fails, the editor highlights line 7
-            integration.Setup((i) => i.ExecuteToLine(It.IsAny<uint>())).Callback(() =>
+            integration.Setup((i) => i.Execute(It.IsAny<uint[]>())).Callback(() =>
                 integration.Raise((i) => i.ExecutionCompleted += null, false));
             program.ExecuteOnThread(null);
 
-            integration.Verify((i) => i.ExecuteToLine(7), Times.Once);
+            integration.Verify((i) => i.Execute(new uint[] { 7 }), Times.Once);
             callbacks.Verify((c) => c.OnBreakComplete(), Times.Once);
             Helpers.VerifyBreakFrameLocation(program, "h.s", 7);
 
             // The next run continues to the next breakpoint despite the error
-            integration.Setup((i) => i.ExecuteToLine(It.IsAny<uint>())).Callback(() =>
+            integration.Setup((i) => i.Execute(It.IsAny<uint[]>())).Callback(() =>
                 integration.Raise((i) => i.ExecutionCompleted += null, true));
             program.ExecuteOnThread(null);
 
-            integration.Verify((i) => i.ExecuteToLine(9), Times.Once);
+            integration.Verify((i) => i.Execute(new uint[] { 9 }), Times.Once);
             callbacks.Verify((c) => c.OnBreakComplete(), Times.Exactly(2));
             Helpers.VerifyBreakFrameLocation(program, "h.s", 9);
         }

--- a/VSRAD.Package/Commands/EvaluateSelectedCommand.cs
+++ b/VSRAD.Package/Commands/EvaluateSelectedCommand.cs
@@ -54,7 +54,7 @@ namespace VSRAD.Package.Commands
             var breakLine = _codeEditor.GetCurrentLine() + 1;
             var watchName = activeWord.Trim();
 
-            var evaluator = await _project.GetMacroEvaluatorAsync(breakLine, watchesOverride: new[] { watchName });
+            var evaluator = await _project.GetMacroEvaluatorAsync(new[] { breakLine }, watchesOverride: new[] { watchName });
             var options = await _project.Options.Profile.Debugger.EvaluateAsync(evaluator);
             await SetStatusBarTextAsync($"RAD Debug: Evaluating {watchName}...");
             try

--- a/VSRAD.Package/DebugVisualizer/ColumnStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/ColumnStyling.cs
@@ -28,7 +28,7 @@ namespace VSRAD.Package.DebugVisualizer
             }
         }
 
-        public void Apply(IReadOnlyList<DataGridViewColumn> columns, uint groupSize, uint laneGrouping, int laneDividerWidth, int hiddenColumnSeparatorWidth)
+        public void Apply(IReadOnlyList<DataGridViewColumn> columns, uint groupSize, uint laneGrouping, int laneDividerWidth = 3, int hiddenColumnSeparatorWidth = 8)
         {
             if (columns.Count != VisualizerTable.DataColumnCount)
                 throw new ArgumentException("ColumnStyling applies to exactly 512 columns");

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -29,11 +29,8 @@ namespace VSRAD.Package.Options
         private string _breakArgs = "";
         public string BreakArgs { get => _breakArgs; set => SetField(ref _breakArgs, value); }
 
-        private ContinueMode _continueMode = ContinueMode.RoundRobin;
-        public ContinueMode ContinueMode { get => _continueMode; set => SetField(ref _continueMode, value); }
-
-        private bool _singleActiveBreakpoint = false;
-        public bool SingleActiveBreakpoint { get => _singleActiveBreakpoint; set => SetField(ref _singleActiveBreakpoint, value); }
+        private Deborgar.BreakMode _breakMode;
+        public Deborgar.BreakMode BreakMode { get => _breakMode; set => SetField(ref _breakMode, value); }
 
         public DebuggerOptions() { }
         public DebuggerOptions(List<Watch> watches) => Watches = watches;

--- a/VSRAD.Package/ProjectSystem/BreakpointIntegration.cs
+++ b/VSRAD.Package/ProjectSystem/BreakpointIntegration.cs
@@ -33,11 +33,11 @@ namespace VSRAD.Package.ProjectSystem
 
         public void Initialize(ProjectOptions options)
         {
-            SetSingleActiveBreakpointMode(options.DebuggerOptions.SingleActiveBreakpoint);
+            SetSingleActiveBreakpointMode(options.DebuggerOptions.BreakMode == Deborgar.BreakMode.SingleRerun);
             options.DebuggerOptions.PropertyChanged += (s, e) =>
             {
-                if (e.PropertyName == nameof(DebuggerOptions.SingleActiveBreakpoint))
-                    SetSingleActiveBreakpointMode(options.DebuggerOptions.SingleActiveBreakpoint);
+                if (e.PropertyName == nameof(DebuggerOptions.BreakMode))
+                    SetSingleActiveBreakpointMode(options.DebuggerOptions.BreakMode == Deborgar.BreakMode.SingleRerun);
             };
         }
 

--- a/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
+++ b/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
@@ -97,12 +97,12 @@ namespace VSRAD.Package.ProjectSystem
                 dte.Debugger.Go();
         }
 
-        void IEngineIntegration.ExecuteToLine(uint breakLine)
+        void IEngineIntegration.Execute(uint[] breakLines)
         {
             var watches = _project.Options.DebuggerOptions.GetWatchSnapshot();
             VSPackage.TaskFactory.RunAsyncWithErrorHandling(async () =>
             {
-                var result = await _debugSession.ExecuteToLineAsync(breakLine, watches);
+                var result = await _debugSession.ExecuteAsync(breakLines, watches);
                 await VSPackage.TaskFactory.SwitchToMainThreadAsync();
                 if (result.TryGetResult(out var breakState, out var error))
                 {
@@ -127,6 +127,9 @@ namespace VSRAD.Package.ProjectSystem
         string IEngineIntegration.GetProjectRelativePath(string path) =>
             _project.GetRelativePath(path);
 
+        BreakMode IEngineIntegration.GetBreakMode() =>
+            _project.Options.DebuggerOptions.BreakMode;
+
         bool IEngineIntegration.PopRunToLineIfSet(string file, out uint runToLine)
         {
             if (_debugRunToLine.HasValue && _debugRunToLine.Value.file == file)
@@ -140,11 +143,6 @@ namespace VSRAD.Package.ProjectSystem
                 runToLine = 0;
                 return false;
             }
-        }
-
-        public bool RerunOnContinue()
-        {
-            return _project.Options.DebuggerOptions.ContinueMode == Utils.ContinueMode.RestartLine;
         }
     }
 }

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using VSRAD.Package.Utils;
-using Task = System.Threading.Tasks.Task;
 
 namespace VSRAD.Package.ProjectSystem.Macros
 {
@@ -14,13 +13,13 @@ namespace VSRAD.Package.ProjectSystem.Macros
 #pragma warning restore CA1815
     {
         public (string filename, uint line) ActiveSourceFile { get; }
-        public uint BreakLine { get; }
+        public uint[] BreakLines { get; }
         public string[] WatchesOverride { get; }
 
-        public MacroEvaluatorTransientValues((string, uint) activeSourceFile, uint breakLine = 0, string[] watchesOverride = null)
+        public MacroEvaluatorTransientValues((string, uint) activeSourceFile, uint[] breakLines = null, string[] watchesOverride = null)
         {
             ActiveSourceFile = activeSourceFile;
-            BreakLine = breakLine;
+            BreakLines = breakLines;
             WatchesOverride = watchesOverride;
         }
     }
@@ -108,7 +107,7 @@ namespace VSRAD.Package.ProjectSystem.Macros
                     ? string.Join(":", values.WatchesOverride)
                     : string.Join(":", debuggerOptions.GetWatchSnapshot()) },
                 { RadMacros.AWatches, string.Join(":", debuggerOptions.GetAWatchSnapshot()) },
-                { RadMacros.BreakLine, values.BreakLine.ToString() },
+                { RadMacros.BreakLine, string.Join(",", values.BreakLines ?? new[] { 0u }) },
                 { RadMacros.DebugAppArgs, debuggerOptions.AppArgs },
                 { RadMacros.DebugBreakArgs, debuggerOptions.BreakArgs },
                 { RadMacros.Counter, debuggerOptions.Counter.ToString() }

--- a/VSRAD.Package/ProjectSystem/Project.cs
+++ b/VSRAD.Package/ProjectSystem/Project.cs
@@ -26,7 +26,7 @@ namespace VSRAD.Package.ProjectSystem
         string RootPath { get; }
         string GetRelativePath(string absoluteFilePath);
         string GetAbsolutePath(string projectRelativePath);
-        Task<IMacroEvaluator> GetMacroEvaluatorAsync(uint breakLine = 0, string[] watchesOverride = null);
+        Task<IMacroEvaluator> GetMacroEvaluatorAsync(uint[] breakLines = null, string[] watchesOverride = null);
         void SaveOptions();
     }
 
@@ -85,7 +85,7 @@ namespace VSRAD.Package.ProjectSystem
         #region MacroEvaluator
         private (IActiveCodeEditor, ICommunicationChannel, IProjectProperties)? _macroEvaluatorDependencies;
 
-        public async Task<IMacroEvaluator> GetMacroEvaluatorAsync(uint breakLine = 0, string[] watchesOverride = null)
+        public async Task<IMacroEvaluator> GetMacroEvaluatorAsync(uint[] breakLines = null, string[] watchesOverride = null)
         {
             await VSPackage.TaskFactory.SwitchToMainThreadAsync();
 
@@ -104,8 +104,7 @@ namespace VSRAD.Package.ProjectSystem
 
             var file = GetRelativePath(codeEditor.GetAbsoluteSourcePath());
             var line = codeEditor.GetCurrentLine();
-            var transients = new MacroEvaluatorTransientValues(
-                activeSourceFile: (file, line), breakLine: breakLine, watchesOverride: watchesOverride);
+            var transients = new MacroEvaluatorTransientValues(activeSourceFile: (file, line), breakLines, watchesOverride);
 
             var remoteEnvironment = new AsyncLazy<IReadOnlyDictionary<string, string>>(
                 channel.GetRemoteEnvironmentAsync, VSPackage.TaskFactory);

--- a/VSRAD.Package/Server/DebugSession.cs
+++ b/VSRAD.Package/Server/DebugSession.cs
@@ -31,10 +31,10 @@ namespace VSRAD.Package.Server
             _timer = new Stopwatch();
         }
 
-        public async Task<Result<BreakState>> ExecuteToLineAsync(uint breakLine, ReadOnlyCollection<string> watches)
+        public async Task<Result<BreakState>> ExecuteAsync(uint[] breakLines, ReadOnlyCollection<string> watches)
         {
             _timer.Restart();
-            var evaluator = await _project.GetMacroEvaluatorAsync(breakLine).ConfigureAwait(false);
+            var evaluator = await _project.GetMacroEvaluatorAsync(breakLines[0]).ConfigureAwait(false);
             var options = await _project.Options.Profile.Debugger.EvaluateAsync(evaluator).ConfigureAwait(false);
             var outputFile = options.RemoteOutputFile;
 

--- a/VSRAD.Package/Server/DebugSession.cs
+++ b/VSRAD.Package/Server/DebugSession.cs
@@ -34,7 +34,7 @@ namespace VSRAD.Package.Server
         public async Task<Result<BreakState>> ExecuteAsync(uint[] breakLines, ReadOnlyCollection<string> watches)
         {
             _timer.Restart();
-            var evaluator = await _project.GetMacroEvaluatorAsync(breakLines[0]).ConfigureAwait(false);
+            var evaluator = await _project.GetMacroEvaluatorAsync(breakLines).ConfigureAwait(false);
             var options = await _project.Options.Profile.Debugger.EvaluateAsync(evaluator).ConfigureAwait(false);
             var outputFile = options.RemoteOutputFile;
 

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -6,6 +6,8 @@
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:viz="clr-namespace:VSRAD.Package.DebugVisualizer"
              xmlns:utils="clr-namespace:VSRAD.Package.Utils"
+             xmlns:local="clr-namespace:VSRAD.Package.ToolWindows"
+             xmlns:deborgar="clr-namespace:VSRAD.Deborgar;assembly=VSRAD.Deborgar"
              mc:Ignorable="d"
              d:DesignHeight="800" d:DesignWidth="340">
     <UserControl.Resources>
@@ -25,9 +27,9 @@
                     <x:Type TypeName="viz:FontType"/>
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
-            <ObjectDataProvider x:Key="ContinueMode" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+            <ObjectDataProvider x:Key="BreakMode" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
                 <ObjectDataProvider.MethodParameters>
-                    <x:Type TypeName="utils:ContinueMode"/>
+                    <x:Type TypeName="deborgar:BreakMode"/>
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
             <utils:MagicNumberConverter x:Key="MagicNumberConverter"/>
@@ -64,16 +66,21 @@
                     <viz:NumberInput VerticalContentAlignment="Center" Width="50" Height="24" Minimum="0" Maximum="512"
                                         Value="{Binding DataContext.Options.VisualizerOptions.LaneGrouping, UpdateSourceTrigger=PropertyChanged, ElementName=Root}"/>
                 </StackPanel>
-                <StackPanel Orientation="Vertical" Margin="0,8,0,0">
-                    <CheckBox Content="Disable other breakpoints when adding a new one"
-                            IsChecked="{Binding Options.DebuggerOptions.SingleActiveBreakpoint, UpdateSourceTrigger=PropertyChanged}"/>
-                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                        <Label Content="Continue Mode:"/>
-                        <ComboBox SelectedItem="{Binding Options.DebuggerOptions.ContinueMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                              ItemsSource="{Binding Source={StaticResource ContinueMode}}"/>
-                    </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <Label Content="Break mode:"/>
+                    <ComboBox SelectedItem="{Binding Options.DebuggerOptions.BreakMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                              ItemsSource="{Binding Source={StaticResource BreakMode}}" VerticalContentAlignment="Center">
+                        <ComboBox.Resources>
+                            <local:BreakModeConverter x:Key="BreakModeConverter" />
+                        </ComboBox.Resources>
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Converter={StaticResource BreakModeConverter}}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
                 </StackPanel>
-                <Expander x:Name="VisualizerAppearanceExpander" Header="Visualizer Appearance">
+                <Expander Header="Visualizer Appearance" Margin="0,8,0,0">
                     <StackPanel>
                         <StackPanel Orientation="Horizontal">
                             <Label Content="Visualizer Name Column Alignment:"/>

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
@@ -1,6 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 using VSRAD.Package.Options;
 using VSRAD.Package.ProjectSystem.Macros;
@@ -62,9 +65,29 @@ namespace VSRAD.Package.ToolWindows
         }
 
         // TODO: can freeze here
-        private void EditProfiles(object sender, System.Windows.RoutedEventArgs e)
+        private void EditProfiles(object sender, RoutedEventArgs e)
         {
             new ProjectSystem.Profiles.ProfileOptionsWindow(_macroEditor, _projectOptions).ShowDialog();
         }
+    }
+
+    public sealed class BreakModeConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            switch (value)
+            {
+                case Deborgar.BreakMode.SingleRoundRobin:
+                    return "Single active breakpoint, round-robin";
+                case Deborgar.BreakMode.SingleRerun:
+                    return "Single active breakpoint, rerun same line";
+                case Deborgar.BreakMode.Multiple:
+                    return "Multiple active breakpoints";
+                default:
+                    return DependencyProperty.UnsetValue;
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture) => value;
     }
 }

--- a/VSRAD.Package/Utils/ContinueMode.cs
+++ b/VSRAD.Package/Utils/ContinueMode.cs
@@ -1,8 +1,0 @@
-﻿
-namespace VSRAD.Package.Utils
-{
-    public enum ContinueMode
-    {
-        RestartLine, RoundRobin
-    }
-}

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -164,7 +164,6 @@
     <Compile Include="Options\DefaultOptionValues.cs" />
     <Compile Include="Options\VisualizerAppearance.cs" />
     <Compile Include="ProjectSystem\BreakpointIntegration.cs" />
-    <Compile Include="Utils\ContinueMode.cs" />
     <Compile Include="ProjectSystem\Macros\MacroEditor.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/VSRAD.PackageTests/ProjectSystem/MacroEvaluatorTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/MacroEvaluatorTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using VSRAD.Package.DebugVisualizer;
 using VSRAD.Package.ProjectSystem.Macros;
-using VSRAD.PackageTests;
 using Xunit;
 
 namespace VSRAD.Package.ProjectSystem.Tests
@@ -51,13 +50,18 @@ namespace VSRAD.Package.ProjectSystem.Tests
             Assert.Equal("a:c:tide", result);
 
             var transients = new MacroEvaluatorTransientValues(
-                activeSourceFile: ("welcome home", 666), breakLine: 13, watchesOverride: new[] { "m", "c", "ride" });
+                activeSourceFile: ("welcome home", 666), breakLines: new[] { 13u }, watchesOverride: new[] { "m", "c", "ride" });
             evaluator = new MacroEvaluator(props.Object, transients, EmptyRemoteEnv, debuggerOptions, new Options.ProfileOptions());
 
             result = await evaluator.GetMacroValueAsync(RadMacros.Watches);
             Assert.Equal("m:c:ride", result);
             result = await evaluator.EvaluateAsync($"$({RadMacros.ActiveSourceFile}):$({RadMacros.ActiveSourceFileLine}), stop at $({RadMacros.BreakLine})");
             Assert.Equal("welcome home:666, stop at 13", result);
+
+            transients = new MacroEvaluatorTransientValues(activeSourceFile: ("", 0), breakLines: new[] { 20u, 1u, 9u });
+            evaluator = new MacroEvaluator(props.Object, transients, EmptyRemoteEnv, debuggerOptions, new Options.ProfileOptions());
+            result = await evaluator.EvaluateAsync($"-l $({RadMacros.BreakLine})");
+            Assert.Equal("-l 20,1,9", result);
         }
 
         [Fact]

--- a/VSRAD.PackageTests/Server/DebugSessionTests.cs
+++ b/VSRAD.PackageTests/Server/DebugSessionTests.cs
@@ -24,7 +24,7 @@ namespace VSRAD.Package.ProjectSystem.Tests
             {
                 { RadMacros.DebuggerWorkingDirectory, "/glitch/city" },
                 { RadMacros.DebuggerOutputPath, "va11" }
-            });
+            }).Object;
 
             var outputWindow = new Mock<IOutputWindowManager>();
             outputWindow.Setup((w) => w.GetExecutionResultPane()).Returns(new Mock<IOutputWindowWriter>().Object);
@@ -36,7 +36,7 @@ namespace VSRAD.Package.ProjectSystem.Tests
             channel.ThenRespond<FetchMetadata, MetadataFetched>(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.Now },
                 (command) => Assert.Equal(new[] { "/glitch/city", "va11" }, command.FilePath));
 
-            var result = await session.ExecuteToLineAsync(13, new ReadOnlyCollection<string>(new[] { "jill", "julianne" }.ToList()));
+            var result = await session.ExecuteAsync(new[] { 13u }, new ReadOnlyCollection<string>(new[] { "jill", "julianne" }.ToList()));
             Assert.True(result.TryGetResult(out var breakState, out _));
             Assert.Collection(breakState.Watches,
                 (first) => Assert.Equal("jill", first),
@@ -53,7 +53,7 @@ namespace VSRAD.Package.ProjectSystem.Tests
             {
                 { RadMacros.DebuggerWorkingDirectory, "/glitch/city" },
                 { RadMacros.DebuggerOutputPath, "va11" }
-            });
+            }).Object;
 
             var outputWindow = new Mock<IOutputWindowManager>();
             outputWindow.Setup((w) => w.GetExecutionResultPane()).Returns(new Mock<IOutputWindowWriter>().Object);
@@ -63,7 +63,7 @@ namespace VSRAD.Package.ProjectSystem.Tests
                 (command) => Assert.Equal(new[] { "/glitch/city", "va11" }, command.FilePath));
             channel.ThenRespond<Execute, ExecutionCompleted>(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 33 }, (_) => { });
 
-            var result = await session.ExecuteToLineAsync(13, new ReadOnlyCollection<string>(new[] { "jill", "julianne" }.ToList()));
+            var result = await session.ExecuteAsync(new[] { 13u }, new ReadOnlyCollection<string>(new[] { "jill", "julianne" }.ToList()));
             Assert.False(result.TryGetResult(out _, out var error));
             Assert.Equal(RemoteCommandExecutor.ErrorNonZeroExitCode(33), error.Message);
 

--- a/VSRAD.PackageTests/Server/FileSynchronizationManagerTests.cs
+++ b/VSRAD.PackageTests/Server/FileSynchronizationManagerTests.cs
@@ -117,7 +117,7 @@ namespace VSRAD.PackageTests.Server
 
             var project = new Mock<IProject>(MockBehavior.Strict);
             project.Setup((p) => p.RootPath).Returns(_projectRoot);
-            project.Setup((p) => p.GetMacroEvaluatorAsync(It.IsAny<uint>(), It.IsAny<string[]>())).Returns(Task.FromResult(evaluator.Object));
+            project.Setup((p) => p.GetMacroEvaluatorAsync(It.IsAny<uint[]>(), It.IsAny<string[]>())).Returns(Task.FromResult(evaluator.Object));
 
             var options = new ProjectOptions();
             options.AddProfile("Default", new ProfileOptions(general: generalOptions));

--- a/VSRAD.PackageTests/TestHelper.cs
+++ b/VSRAD.PackageTests/TestHelper.cs
@@ -44,7 +44,7 @@ namespace VSRAD.PackageTests
             foreach (var macro in macros)
                 evaluator.Setup((e) => e.GetMacroValueAsync(macro.Key)).Returns(Task.FromResult(macro.Value));
 
-            mock.Setup((p) => p.GetMacroEvaluatorAsync(It.IsAny<uint>(), It.IsAny<string[]>())).Returns(Task.FromResult(evaluator.Object));
+            mock.Setup((p) => p.GetMacroEvaluatorAsync(It.IsAny<uint[]>(), It.IsAny<string[]>())).Returns(Task.FromResult(evaluator.Object));
             return mock;
         }
     }

--- a/VSRAD.PackageTests/TestHelper.cs
+++ b/VSRAD.PackageTests/TestHelper.cs
@@ -32,7 +32,7 @@ namespace VSRAD.PackageTests
             sta.Join();
         }
 
-        public static IProject MakeProjectWithProfile(Dictionary<string, string> macros, string projectRoot = "", Package.Options.ProfileOptions profile = null)
+        public static Mock<IProject> MakeProjectWithProfile(Dictionary<string, string> macros, string projectRoot = "", Package.Options.ProfileOptions profile = null)
         {
             var mock = new Mock<IProject>(MockBehavior.Strict);
             var options = new Package.Options.ProjectOptions();
@@ -45,7 +45,7 @@ namespace VSRAD.PackageTests
                 evaluator.Setup((e) => e.GetMacroValueAsync(macro.Key)).Returns(Task.FromResult(macro.Value));
 
             mock.Setup((p) => p.GetMacroEvaluatorAsync(It.IsAny<uint>(), It.IsAny<string[]>())).Returns(Task.FromResult(evaluator.Object));
-            return mock.Object;
+            return mock;
         }
     }
 }


### PR DESCRIPTION
Implements #62

*Disable other breakpoints when adding a new one* and *Continue mode* options are now merged into a single *Break mode* dropdown. It also includes a new mode where `$(RadBreakLine)` expands to a comma-separated list of all breakpoints in the current file.

The issue mentions drawing a stop arrow on all breakpoints when the mode is set to multiple, but I couldn't find an easy way to do that and seeing how it's marked as low priority I think it can be postponed.