### PR TITLE
Rewrite break state

### DIFF
--- a/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
@@ -26,7 +26,7 @@ namespace VSRAD.Package.DebugVisualizer
                 ColumnState[i] |= ColumnStates.Inactive;
         }
 
-        public void Recompute(VisualizerOptions options, ColumnStylingOptions styling, uint groupSize, uint[] system)
+        public void Recompute(VisualizerOptions options, ColumnStylingOptions styling, uint groupSize, Server.WatchView system)
         {
             GroupSize = groupSize;
 
@@ -39,7 +39,7 @@ namespace VSRAD.Package.DebugVisualizer
             ComputeHiddenColumnSeparators();
         }
 
-        private void ComputeInactiveLanes(VisualizerOptions options, uint[] system)
+        private void ComputeInactiveLanes(VisualizerOptions options, Server.WatchView system)
         {
             if (system == null)
                 return;

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -319,7 +319,7 @@ namespace VSRAD.Package.DebugVisualizer
                 base.OnColumnDividerWidthChanged(e);
         }
 
-        public void ApplyDataStyling(ProjectOptions options, uint groupSize, uint[] system)
+        public void ApplyDataStyling(ProjectOptions options, uint groupSize, Server.WatchView system)
         {
             // Prevent the scrollbar from jerking due to visibility changes
             var scrollingOffset = HorizontalScrollingOffset;

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -1,142 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Threading.Tasks;
-using VSRAD.Package.Utils;
-
-namespace VSRAD.Package.Server
+﻿namespace VSRAD.Package.Server
 {
     public sealed class BreakState
     {
-        public ReadOnlyCollection<string> Watches { get; }
+        public BreakStateData Data { get; }
 
-        private uint _groupSize = 512;
+        public long TotalElapsedMilliseconds { get; }
+        public long ExecElapsedMilliseconds { get; }
+        public string StatusString { get; }
 
-        public readonly long TotalElapsedMilliseconds;
-        public readonly long ExecElapsedMilliseconds;
-        public readonly string StatusString;
-
-        public uint GroupSize
+        public BreakState(BreakStateData breakStateData, long totalElapsedMilliseconds, long execElapsedMilliseconds, string statusString)
         {
-            get => _groupSize;
-            set
-            {
-                if (value != _groupSize)
-                {
-                    _groupSize = value;
-                    _valuesByGroup.Clear();
-                }
-            }
-        }
-
-        // struct record {
-        // uint32_t hidden;
-        // uint32_t watches[n_watches];
-        // };
-        // record log_file[group_count][group_size]
-        //
-        // hidden is an array spread across 64 records
-
-        private uint _groupIndex;
-
-        private readonly Dictionary<uint, uint[]> _valuesByGroup = new Dictionary<uint, uint[]>();
-
-        private readonly Options.OutputFile _outputFile;
-        private readonly DateTime _outputTimestamp;
-        private readonly uint _outputDwordCount;
-        private readonly uint _recordSize;
-        private readonly ICommunicationChannel _channel;
-        private readonly int _outputOffset;
-
-        public BreakState(Options.OutputFile outputFile, DateTime outputTimestamp, uint outputByteCount, int outputOffset, ReadOnlyCollection<string> watches, ICommunicationChannel channel, long totalElapsedMilliseconds, long execElapsedMilliseconds, string statusString)
-        {
-            _outputFile = outputFile;
-            _outputTimestamp = outputTimestamp;
-            _outputDwordCount = outputByteCount / 4;
-            _recordSize = 1 /* hidden */ + (uint)watches.Count;
-            Watches = watches;
-            _channel = channel;
-            _outputOffset = outputOffset;
+            Data = breakStateData;
             StatusString = statusString;
             TotalElapsedMilliseconds = totalElapsedMilliseconds;
             ExecElapsedMilliseconds = execElapsedMilliseconds;
-        }
-
-        public uint[] System { get; } = new uint[512];
-
-        public uint GetGroupCount(uint groupSize) => _outputDwordCount / groupSize / _recordSize;
-
-        public bool TryGetWatch(string watch, out uint[] values)
-        {
-            var watchIndex = Watches.IndexOf(watch);
-
-            if (watchIndex == -1)
-            {
-                values = null;
-                return false;
-            }
-
-            values = new uint[GroupSize];
-
-            for (uint valueIdx = 0, dwordIdx = (uint)watchIndex + 1 /* system */;
-                 dwordIdx < _valuesByGroup[_groupIndex].Length && valueIdx < GroupSize;
-                 valueIdx++, dwordIdx += _recordSize)
-            {
-                values[valueIdx] = _valuesByGroup[_groupIndex][dwordIdx];
-            }
-
-            return true;
-        }
-
-        public async Task<Result<bool>> ChangeGroupAsync(uint groupIndex, uint groupSize)
-        {
-            GroupSize = groupSize;
-            if (!_valuesByGroup.TryGetValue(groupIndex, out var values))
-            {
-                var fetchResult = await FetchGroupAsync(groupIndex).ConfigureAwait(false);
-                if (!fetchResult.TryGetResult(out values, out var error))
-                    return error;
-                _valuesByGroup[groupIndex] = values;
-            }
-            _groupIndex = groupIndex;
-            SetSystemFromGroup(values);
-            return true;
-        }
-
-        private void SetSystemFromGroup(uint[] groupValues)
-        {
-            for (uint sysIdx = 0, dwordIdx = 0; dwordIdx < groupValues.Length; sysIdx++, dwordIdx += _recordSize)
-            {
-                System[sysIdx] = groupValues[dwordIdx];
-            }
-        }
-
-        private async Task<Result<uint[]>> FetchGroupAsync(uint groupIndex)
-        {
-            int byteOffset = (int)(4 * groupIndex * GroupSize * _recordSize);
-            int byteCount = (int)(4 * GroupSize * _recordSize);
-            var response = await _channel.SendWithReplyAsync<DebugServer.IPC.Responses.ResultRangeFetched>(
-                new DebugServer.IPC.Commands.FetchResultRange
-                {
-                    FilePath = _outputFile.Path,
-                    BinaryOutput = _outputFile.BinaryOutput,
-                    ByteOffset = byteOffset,
-                    ByteCount = byteCount,
-                    OutputOffset = _outputOffset
-                }).ConfigureAwait(false);
-
-            if (response.Status != DebugServer.IPC.Responses.FetchStatus.Successful)
-                return new Error("Output file could not be opened.");
-
-            if (response.Timestamp != _outputTimestamp)
-                return new Error("Output file has changed since the last debugger execution.");
-
-            if (response.Data.Length < byteCount)
-                return new Error($"Group #{groupIndex} is incomplete: expected to read {byteCount} bytes but the output file contains {response.Data.Length}.");
-
-            uint[] data = new uint[response.Data.Length / 4];
-            Buffer.BlockCopy(response.Data, 0, data, 0, response.Data.Length);
-            return data;
         }
     }
 }

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -3,17 +3,18 @@
     public sealed class BreakState
     {
         public BreakStateData Data { get; }
-
         public long TotalElapsedMilliseconds { get; }
         public long ExecElapsedMilliseconds { get; }
         public string StatusString { get; }
+        public int ExitCode { get; }
 
-        public BreakState(BreakStateData breakStateData, long totalElapsedMilliseconds, long execElapsedMilliseconds, string statusString)
+        public BreakState(BreakStateData breakStateData, long totalElapsedMilliseconds, long execElapsedMilliseconds, string statusString, int exitCode)
         {
             Data = breakStateData;
-            StatusString = statusString;
             TotalElapsedMilliseconds = totalElapsedMilliseconds;
             ExecElapsedMilliseconds = execElapsedMilliseconds;
+            StatusString = statusString;
+            ExitCode = exitCode;
         }
     }
 }

--- a/VSRAD.Package/Server/BreakStateData.cs
+++ b/VSRAD.Package/Server/BreakStateData.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using VSRAD.Package.Options;
+
+namespace VSRAD.Package.Server
+{
+    // struct lane_data {
+    // uint32_t system;
+    // uint32_t watches[n_watches];
+    // };
+    // lane_data log_file[group_count][group_size]
+    //
+    // system[64] is spread across a wavefront (64 lanes)
+
+    public sealed class WatchView
+    {
+        private readonly int _groupOffset;
+        private readonly int _laneDataOffset;
+        private readonly int _laneDataSize;
+
+        private readonly uint[] _data;
+
+        public WatchView(uint[] data, int groupOffset, int laneDataOffset, int laneDataSize)
+        {
+            _data = data;
+            _groupOffset = groupOffset;
+            _laneDataOffset = laneDataOffset;
+            _laneDataSize = laneDataSize;
+        }
+
+        public uint this[int index]
+        {
+            get
+            {
+                var dwordIdx = _groupOffset + _laneDataOffset + index * _laneDataSize;
+                return _data[dwordIdx];
+            }
+        }
+    }
+
+    public sealed class BreakStateData
+    {
+        public ReadOnlyCollection<string> Watches { get; }
+
+        public int GroupIndex { get; private set; }
+        public int GroupSize { get; private set; }
+
+        private readonly OutputFile _outputFile;
+        private readonly DateTime _outputFileTimestamp;
+        private readonly int _outputOffset;
+        private readonly int _laneDataSize;
+
+        private readonly uint[] _data;
+        private readonly BitArray _fetchedDataWaves; // 1 bit per 64 lanes
+
+        public BreakStateData(ReadOnlyCollection<string> watches, OutputFile file, DateTime fileTimestamp, int outputByteCount, int outputOffset)
+        {
+            Watches = watches;
+            _outputFile = file;
+            _outputFileTimestamp = fileTimestamp;
+            _outputOffset = outputOffset;
+            _laneDataSize = 1 /* system */ + watches.Count;
+
+            var outputDwordCount = outputByteCount / 4;
+            _data = new uint[outputDwordCount];
+            _fetchedDataWaves = new BitArray(outputDwordCount / 64);
+        }
+
+        public uint GetGroupCount(uint groupSize) => (uint)(_data.Length / groupSize / _laneDataSize);
+
+        public WatchView GetSystem()
+        {
+            var groupOffset = GroupIndex * GroupSize * _laneDataSize;
+            return new WatchView(_data, groupOffset, laneDataOffset: 0, _laneDataSize);
+        }
+
+        public WatchView GetWatch(string watch)
+        {
+            var watchIndex = Watches.IndexOf(watch);
+            if (watchIndex == -1)
+                return null;
+
+            var groupOffset = GroupIndex * GroupSize * _laneDataSize;
+            return new WatchView(_data, groupOffset, laneDataOffset: watchIndex + 1 /* system */, _laneDataSize);
+        }
+
+        public async Task<string> ChangeGroupWithWarningsAsync(ICommunicationChannel channel, int groupIndex, int groupSize)
+        {
+            int byteOffset = 4 * groupIndex * groupSize * _laneDataSize;
+            int byteCount = 4 * groupSize * _laneDataSize;
+
+            if (IsGroupFetched(byteOffset, byteCount))
+                return null;
+
+            var response = await channel.SendWithReplyAsync<DebugServer.IPC.Responses.ResultRangeFetched>(
+                new DebugServer.IPC.Commands.FetchResultRange
+                {
+                    FilePath = _outputFile.Path,
+                    BinaryOutput = _outputFile.BinaryOutput,
+                    ByteOffset = byteOffset,
+                    ByteCount = byteCount,
+                    OutputOffset = _outputOffset
+                }).ConfigureAwait(false);
+
+            SetGroupData(byteOffset, byteCount, response.Data);
+            GroupIndex = groupIndex;
+            GroupSize = groupSize;
+
+            if (response.Status != DebugServer.IPC.Responses.FetchStatus.Successful)
+                return "Output file could not be opened.";
+
+            if (response.Timestamp != _outputFileTimestamp)
+                return "Output file has changed since the last debugger execution.";
+
+            if (response.Data.Length < byteCount)
+                return $"Group #{groupIndex} is incomplete: expected to read {byteCount} bytes but the output file contains {response.Data.Length}.";
+
+            return null;
+        }
+
+        private bool IsGroupFetched(int byteOffset, int byteCount)
+        {
+            for (int i = byteOffset / 64; i < (byteOffset + byteCount) / 64; ++i)
+                if (!_fetchedDataWaves[i])
+                    return false;
+            return true;
+        }
+
+        private void SetGroupData(int byteOffset, int byteCount, byte[] groupData)
+        {
+            Buffer.BlockCopy(groupData, 0, _data, byteOffset, groupData.Length);
+            for (int i = byteOffset / 64; i < (byteOffset + byteCount) / 64; ++i)
+                _fetchedDataWaves[i] = true;
+        }
+    }
+}

--- a/VSRAD.Package/Server/DebugSession.cs
+++ b/VSRAD.Package/Server/DebugSession.cs
@@ -130,8 +130,9 @@ namespace VSRAD.Package.Server
                 return new Error($"Output file ({output.File}) was not modified.", title: "Data may be stale");
 
             _timer.Stop();
-            return new BreakState(output, metadataResponse.Timestamp, (uint)metadataResponse.ByteCount,
-                _project.Options.Profile.Debugger.OutputOffset, watches, _channel, _timer.ElapsedMilliseconds, execElapsedMilliseconds, statusString);
+
+            var breakStateData = new BreakStateData(watches, output, metadataResponse.Timestamp, metadataResponse.ByteCount, _project.Options.Profile.Debugger.OutputOffset);
+            return new BreakState(breakStateData, _timer.ElapsedMilliseconds, execElapsedMilliseconds, statusString);
         }
 
         private Task<MetadataFetched> GetMetadataAsync(Options.OutputFile file) =>

--- a/VSRAD.Package/Server/DebugSession.cs
+++ b/VSRAD.Package/Server/DebugSession.cs
@@ -16,8 +16,6 @@ namespace VSRAD.Package.Server
         private readonly IFileSynchronizationManager _fileSynchronizationManager;
         private readonly RemoteCommandExecutor _remoteExecutor;
 
-        private readonly Stopwatch _timer;
-
         public DebugSession(
             IProject project,
             ICommunicationChannel channel,
@@ -29,12 +27,12 @@ namespace VSRAD.Package.Server
             _channel = channel;
             _fileSynchronizationManager = fileSynchronizationManager;
             _remoteExecutor = new RemoteCommandExecutor("Debugger", channel, outputWindowManager, errorListManager);
-            _timer = new Stopwatch();
         }
 
         public async Task<Result<BreakState>> ExecuteAsync(uint[] breakLines, ReadOnlyCollection<string> watches)
         {
-            _timer.Restart();
+            var execTimer = Stopwatch.StartNew();
+
             var evaluator = await _project.GetMacroEvaluatorAsync(breakLines).ConfigureAwait(false);
             var options = await _project.Options.Profile.Debugger.EvaluateAsync(evaluator).ConfigureAwait(false);
             var outputFile = options.RemoteOutputFile;
@@ -58,9 +56,9 @@ namespace VSRAD.Package.Server
                     RunAsAdministrator = options.RunAsAdmin,
                     ExecutionTimeoutSecs = options.TimeoutSecs,
                     WorkingDirectory = options.RemoteOutputFile.Directory
-                }).ConfigureAwait(false);
+                }, checkExitCode: false).ConfigureAwait(false);
 
-            if (!executionResult.TryGetResult(out var resultData, out var error))
+            if (!executionResult.TryGetResult(out var execution, out var error))
                 return error;
 
             if (options.ParseValidWatches)
@@ -79,7 +77,12 @@ namespace VSRAD.Package.Server
                     return error;
             }
 
-            return await CreateBreakStateAsync(options.RemoteOutputFile, initOutputTimestamp, watches, resultData.ExecutionTime, statusString);
+            var dataResult = await CreateBreakStateDataAsync(options.RemoteOutputFile, initOutputTimestamp, watches).ConfigureAwait(false);
+            if (!dataResult.TryGetResult(out var data, out error))
+                return error;
+
+            execTimer.Stop();
+            return new BreakState(data, execTimer.ElapsedMilliseconds, execution.ExecutionTime, statusString, execution.ExitCode);
         }
 
         private async Task<Result<ReadOnlyCollection<string>>> GetValidWatchesAsync(DateTime initValidWatchesTimestamp, Options.OutputFile validWatchesFile)
@@ -121,7 +124,7 @@ namespace VSRAD.Package.Server
             return statusString;
         }
 
-        private async Task<Result<BreakState>> CreateBreakStateAsync(Options.OutputFile output, DateTime initOutputTimestamp, ReadOnlyCollection<string> watches, long execElapsedMilliseconds, string statusString)
+        private async Task<Result<BreakStateData>> CreateBreakStateDataAsync(Options.OutputFile output, DateTime initOutputTimestamp, ReadOnlyCollection<string> watches)
         {
             var metadataResponse = await GetMetadataAsync(output).ConfigureAwait(false);
             if (metadataResponse.Status != FetchStatus.Successful)
@@ -129,10 +132,7 @@ namespace VSRAD.Package.Server
             if (metadataResponse.Timestamp == initOutputTimestamp)
                 return new Error($"Output file ({output.File}) was not modified.", title: "Data may be stale");
 
-            _timer.Stop();
-
-            var breakStateData = new BreakStateData(watches, output, metadataResponse.Timestamp, metadataResponse.ByteCount, _project.Options.Profile.Debugger.OutputOffset);
-            return new BreakState(breakStateData, _timer.ElapsedMilliseconds, execElapsedMilliseconds, statusString);
+            return new BreakStateData(watches, output, metadataResponse.Timestamp, metadataResponse.ByteCount, _project.Options.Profile.Debugger.OutputOffset);
         }
 
         private Task<MetadataFetched> GetMetadataAsync(Options.OutputFile file) =>

--- a/VSRAD.Package/Server/RemoteCommandExecutor.cs
+++ b/VSRAD.Package/Server/RemoteCommandExecutor.cs
@@ -14,7 +14,7 @@ namespace VSRAD.Package.Server
             "Execution timeout is exceeded. " + tag + " command on the target machine is terminated.";
         private static string ErrorCouldNotLaunch(string tag) =>
             tag + " process could not be started on the target machine. Make sure the path to the executable is specified correctly.";
-        private static string ErrorNonZeroExitCode(string tag, int exitCode) =>
+        public static string ErrorNonZeroExitCode(string tag, int exitCode) =>
             tag + $" command on the target machine returned a non-zero exit code ({exitCode}). Check your application or debug script output in Output -> RAD Debug.";
 
         private readonly ICommunicationChannel _channel;

--- a/VSRAD.Package/Server/RemoteCommandExecutor.cs
+++ b/VSRAD.Package/Server/RemoteCommandExecutor.cs
@@ -57,15 +57,20 @@ namespace VSRAD.Package.Server
             var stdout = result.Stdout.TrimEnd('\r', '\n');
             var stderr = result.Stderr.TrimEnd('\r', '\n');
 
+            var status = result.Status == ExecutionStatus.Completed ? $"exit code {result.ExitCode}"
+                       : result.Status == ExecutionStatus.TimedOut ? "timed out"
+                       : "could not launch";
+
             if (stdout.Length == 0 && stderr.Length == 0)
             {
-                await _outputWriter.PrintMessageAsync($"[{_outputTag}] No stdout/stderr captured").ConfigureAwait(false);
+                await _outputWriter.PrintMessageAsync($"[{_outputTag}] No stdout/stderr captured ({status})").ConfigureAwait(false);
             }
             else
             {
-                await _outputWriter.PrintMessageAsync($"[{_outputTag}] Captured stdout", stdout).ConfigureAwait(false);
-                await _outputWriter.PrintMessageAsync($"[{_outputTag}] Captured stderr", stderr).ConfigureAwait(false);
-                if (_errorListManager != null) await _errorListManager.AddToErrorListAsync(stderr).ConfigureAwait(false);
+                await _outputWriter.PrintMessageAsync($"[{_outputTag}] Captured stdout ({status})", stdout).ConfigureAwait(false);
+                await _outputWriter.PrintMessageAsync($"[{_outputTag}] Captured stderr ({status})", stderr).ConfigureAwait(false);
+                if (_errorListManager != null)
+                    await _errorListManager.AddToErrorListAsync(stderr).ConfigureAwait(false);
             }
 
             switch (result.Status)

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -177,6 +177,7 @@
     <Compile Include="DebugVisualizer\ContextMenus\SubgroupContextMenu.cs" />
     <Compile Include="DebugVisualizer\ContextMenus\TypeContextMenu.cs" />
     <Compile Include="Errors.cs" />
+    <Compile Include="Server\BreakStateData.cs" />
     <Compile Include="ToolWindows\EvaluateSelectedControl.xaml.cs">
       <DependentUpon>EvaluateSelectedControl.xaml</DependentUpon>
     </Compile>

--- a/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using VSRAD.Package.Options;
+using VSRAD.Package.Server;
 using Xunit;
 
 namespace VSRAD.Package.DebugVisualizer.Tests
@@ -24,7 +25,7 @@ namespace VSRAD.Package.DebugVisualizer.Tests
             system[9] = (uint)tmp[0];
 
             var styling = new ComputedColumnStyling();
-            styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = false }, new ColumnStylingOptions(), groupSize: 64, system: system);
+            styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = false }, new ColumnStylingOptions(), groupSize: 64, system: new WatchView(system));
 
             for (int i = 0; i < 5; i++)
                 Assert.True((styling.ColumnState[i] & ColumnStates.Inactive) != 0);
@@ -38,7 +39,7 @@ namespace VSRAD.Package.DebugVisualizer.Tests
             for (int i = 46; i < 64; i++)
                 Assert.True((styling.ColumnState[i] & ColumnStates.Inactive) != 0);
 
-            styling.Recompute(new VisualizerOptions { MaskLanes = false, CheckMagicNumber = false }, new ColumnStylingOptions(), groupSize: 64, system: system);
+            styling.Recompute(new VisualizerOptions { MaskLanes = false, CheckMagicNumber = false }, new ColumnStylingOptions(), groupSize: 64, system: new WatchView(system));
 
             for (int i = 0; i < 64; i++)
                 Assert.False((styling.ColumnState[45] & ColumnStates.Inactive) != 0);
@@ -54,7 +55,7 @@ namespace VSRAD.Package.DebugVisualizer.Tests
 
             var visualizerOptions = new VisualizerOptions { MaskLanes = false, CheckMagicNumber = true, MagicNumber = 0x7 };
             var styling = new ComputedColumnStyling();
-            styling.Recompute(visualizerOptions, new ColumnStylingOptions(), groupSize: 256, system: system);
+            styling.Recompute(visualizerOptions, new ColumnStylingOptions(), groupSize: 256, system: new WatchView(system));
 
             for (int i = 0; i < 63; i++)
                 Assert.False((styling.ColumnState[i] & ColumnStates.Inactive) != 0);

--- a/VSRAD.PackageTests/Server/BreakStateTests.cs
+++ b/VSRAD.PackageTests/Server/BreakStateTests.cs
@@ -42,7 +42,7 @@ namespace VSRAD.PackageTests.Server
             var group2Bin = new byte[sizeof(int) * 512];
             Buffer.BlockCopy(data, group1Bin.Length, group2Bin, 0, group2Bin.Length);
 
-            var breakState = new BreakState(breakStateData, 666, 333, "");
+            var breakState = new BreakState(breakStateData, 666, 333, "", 0);
 
             // Group 1
             channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful, Data = group1Bin }, (_) => { });
@@ -110,7 +110,7 @@ namespace VSRAD.PackageTests.Server
                 outputByteCount: 4096,
                 outputOffset: 0);
 
-            var breakState = new BreakState(breakStateData, 666, 333, "");
+            var breakState = new BreakState(breakStateData, 666, 333, "", 0);
 
             channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Array.Empty<byte>() },
             (command) =>

--- a/VSRAD.PackageTests/Server/BreakStateTests.cs
+++ b/VSRAD.PackageTests/Server/BreakStateTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using VSRAD.DebugServer.IPC.Commands;
 using VSRAD.DebugServer.IPC.Responses;
@@ -10,20 +11,116 @@ namespace VSRAD.PackageTests.Server
     public class BreakStateTests
     {
         [Fact]
+        public async Task WatchViewTestAsync()
+        {
+            var channel = new MockCommunicationChannel();
+            var breakStateData = new BreakStateData(
+                watches: new ReadOnlyCollection<string>(new[] { "local_id", "group_id", "group_size" }),
+                file: new Package.Options.OutputFile("/home/journey", "hermes", true),
+                fileTimestamp: default,
+                outputByteCount: 4096,
+                outputOffset: 0);
+
+            var data = new int[1024]; // 2 groups by 2 waves (1 wave = 64 lanes), each containing 1 system dword and 3 watch dwords 
+            for (int group = 0; group < 2; ++group)
+            {
+                for (int wave = 0; wave < 2; ++wave)
+                {
+                    for (int lane = 0; lane < 64; ++lane)
+                    {
+                        int flatLaneIdx = group * 128 + wave * 64 + lane;
+                        int laneDataOffset = 4 * flatLaneIdx;
+                        data[laneDataOffset + 0] = flatLaneIdx; // system = global id
+                        data[laneDataOffset + 1] = lane;        // first watch = local id
+                        data[laneDataOffset + 2] = group;       // second watch = group id
+                        data[laneDataOffset + 3] = 128;         // third watch = group size (constant 128)
+                    }
+                }
+            }
+            var group1Bin = new byte[sizeof(int) * 512];
+            Buffer.BlockCopy(data, 0, group1Bin, 0, group1Bin.Length);
+            var group2Bin = new byte[sizeof(int) * 512];
+            Buffer.BlockCopy(data, group1Bin.Length, group2Bin, 0, group2Bin.Length);
+
+            var breakState = new BreakState(breakStateData, 666, 333, "");
+
+            // Group 1
+            channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful, Data = group1Bin }, (_) => { });
+            var warning = await breakState.Data.ChangeGroupWithWarningsAsync(channel.Object, 0, 128);
+            Assert.Null(warning);
+
+            var system = breakState.Data.GetSystem();
+            for (var i = 0; i < 128; ++i)
+                Assert.Equal(i, (int)system[i]);
+            var watchLocalId = breakState.Data.GetWatch("local_id");
+            for (var i = 0; i < 128; ++i)
+                Assert.Equal(i % 64, (int)watchLocalId[i]);
+            var watchGroupId = breakState.Data.GetWatch("group_id");
+            for (var i = 0; i < 128; ++i)
+                Assert.Equal(0, (int)watchGroupId[i]);
+            var watchGroupSize = breakState.Data.GetWatch("group_size");
+            for (var i = 0; i < 128; ++i)
+                Assert.Equal(128, (int)watchGroupSize[i]);
+
+            // Group 2
+            channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful, Data = group2Bin }, (_) => { });
+            warning = await breakState.Data.ChangeGroupWithWarningsAsync(channel.Object, 1, 128);
+            Assert.Null(warning);
+
+            system = breakState.Data.GetSystem();
+            for (var i = 0; i < 128; ++i)
+                Assert.Equal(128 + i, (int)system[i]);
+            watchLocalId = breakState.Data.GetWatch("local_id");
+            for (var i = 0; i < 128; ++i)
+                Assert.Equal(i % 64, (int)watchLocalId[i]);
+            watchGroupId = breakState.Data.GetWatch("group_id");
+            for (var i = 0; i < 128; ++i)
+                Assert.Equal(1, (int)watchGroupId[i]);
+            watchGroupSize = breakState.Data.GetWatch("group_size");
+            for (var i = 0; i < 128; ++i)
+                Assert.Equal(128, (int)watchGroupSize[i]);
+
+            // Switching to a smaller group that was already fetched doesn't send any requests
+            // Group 1 of size 64 = second half of group 1 of size 128
+            warning = await breakState.Data.ChangeGroupWithWarningsAsync(channel.Object, 1, 64);
+            Assert.Null(warning);
+
+            system = breakState.Data.GetSystem();
+            for (var i = 0; i < 64; ++i)
+                Assert.Equal(64 + i, (int)system[i]);
+            watchLocalId = breakState.Data.GetWatch("local_id");
+            for (var i = 0; i < 64; ++i)
+                Assert.Equal(i % 64, (int)watchLocalId[i]);
+            watchGroupId = breakState.Data.GetWatch("group_id");
+            for (var i = 0; i < 64; ++i)
+                Assert.Equal(0, (int)watchGroupId[i]);
+            watchGroupSize = breakState.Data.GetWatch("group_size");
+            for (var i = 0; i < 64; ++i)
+                Assert.Equal(128, (int)watchGroupSize[i]);
+        }
+
+        [Fact]
         public async Task EmptyResultRangeTestAsync()
         {
             var channel = new MockCommunicationChannel();
-            var breakState = new BreakState(new Package.Options.OutputFile("/home/kyubey/projects", "log.tar", true),
-                default, outputByteCount: 4096, outputOffset: 0, watches: new ReadOnlyCollection<string>(new[] { "h" }), channel.Object, 666, 333, "");
+            var breakStateData = new BreakStateData(
+                watches: new ReadOnlyCollection<string>(new[] { "h" }),
+                file: new Package.Options.OutputFile("/home/kyubey/projects", "log.tar", true),
+                fileTimestamp: default,
+                outputByteCount: 4096,
+                outputOffset: 0);
 
-            channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful },
+            var breakState = new BreakState(breakStateData, 666, 333, "");
+
+            channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Array.Empty<byte>() },
             (command) =>
             {
                 Assert.Equal(new[] { "/home/kyubey/projects", "log.tar" }, command.FilePath);
             });
-            var result = await breakState.ChangeGroupAsync(0, 512);
-            Assert.False(result.TryGetResult(out _, out var error));
-            Assert.Equal("Group #0 is incomplete: expected to read 4096 bytes but the output file contains 0.", error.Message);
+            var warning = await breakState.Data.ChangeGroupWithWarningsAsync(channel.Object, 0, 512);
+            Assert.Equal("Group #0 is incomplete: expected to read 4096 bytes but the output file contains 0.", warning);
+            // Data is set to 0 if unavailable
+            Assert.Equal(0u, breakState.Data.GetSystem()[0]);
         }
     }
 }

--- a/VSRAD.PackageTests/Server/DebugSessionTests.cs
+++ b/VSRAD.PackageTests/Server/DebugSessionTests.cs
@@ -40,7 +40,7 @@ namespace VSRAD.Package.ProjectSystem.Tests
 
             var result = await session.ExecuteAsync(new[] { 13u }, new ReadOnlyCollection<string>(new[] { "jill", "julianne" }.ToList()));
             Assert.True(result.TryGetResult(out var breakState, out _));
-            Assert.Collection(breakState.Watches,
+            Assert.Collection(breakState.Data.Watches,
                 (first) => Assert.Equal("jill", first),
                 (second) => Assert.Equal("julianne", second));
 

--- a/VSRAD.PackageTests/Server/DebugSessionTests.cs
+++ b/VSRAD.PackageTests/Server/DebugSessionTests.cs
@@ -66,10 +66,12 @@ namespace VSRAD.Package.ProjectSystem.Tests
             channel.ThenRespond<FetchMetadata, MetadataFetched>(new MetadataFetched { Status = FetchStatus.FileNotFound },
                 (command) => Assert.Equal(new[] { "/glitch/city", "va11" }, command.FilePath));
             channel.ThenRespond<Execute, ExecutionCompleted>(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 33 }, (_) => { });
+            channel.ThenRespond<FetchMetadata, MetadataFetched>(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.Now },
+                (command) => Assert.Equal(new[] { "/glitch/city", "va11" }, command.FilePath));
 
-            var result = await session.ExecuteAsync(new[] { 13u }, new ReadOnlyCollection<string>(new[] { "jill", "julianne" }.ToList()));
-            Assert.False(result.TryGetResult(out _, out var error));
-            Assert.Equal("Debugger command on the target machine returned a non-zero exit code (33). Check your application or debug script output in Output -> RAD Debug.", error.Message);
+            var result = await session.ExecuteAsync(new[] { 13u }, new ReadOnlyCollection<string>(new[]  { "jill", "julianne" }.ToList()));
+            Assert.True(result.TryGetResult(out var breakState, out var error));
+            Assert.Equal(33, breakState.ExitCode);
 
             Assert.True(channel.AllInteractionsHandled);
         }


### PR DESCRIPTION
* Display watch data regardless of the debug script exit code
* Gray out watch data if execution fails (could not launch, timed out, stale data, etc.)
* Include execution status (exit code, timed out, could not launch) in RAD Output messages

To accommodate the new slice visualizer feature:
* Store break data in a contiguous array, use a bit vector to track which parts are fetched (one bit per 64 items, the smallest group size)
* Access watches via a view into the original data array instead of allocating an array per watch