### PR TITLE
Function signature did not participate in function detection

### DIFF
--- a/VSRAD.Syntax/FunctionList/FunctionList.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionList.cs
@@ -165,7 +165,9 @@ namespace VSRAD.Syntax.FunctionList
         {
             foreach (var func in blocks)
             {
-                if (func.Scope.GetSpan(line.Snapshot).Contains(line.Start))
+                var pointStart = func.TokenStart.GetStart(line.Snapshot);
+                var pointEnd = func.TokenEnd.GetEnd(line.Snapshot);
+                if (pointStart < line.End && pointEnd > line.Start)
                     return func;
             }
 

--- a/VSRAD.Syntax/FunctionList/FunctionList.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionList.cs
@@ -160,16 +160,8 @@ namespace VSRAD.Syntax.FunctionList
                 ThreadHelper.JoinableTaskFactory.RunAsync(() => Instance.UpdateFunctionListAsync(version, blocks));
         }
 
-        private static FunctionBlock GetFunctionBy(IEnumerable<FunctionBlock> blocks, SnapshotPoint position)
-        {
-            foreach (var func in blocks)
-            {
-                if (PointInFunction(func, position))
-                    return func;
-            }
-
-            return null;
-        }
+        private static FunctionBlock GetFunctionBy(IEnumerable<FunctionBlock> blocks, SnapshotPoint position) =>
+            blocks.FirstOrDefault(func => PointInFunction(func, position));
 
         private static bool PointInFunction(FunctionBlock func, SnapshotPoint position)
         {

--- a/VSRAD.Syntax/FunctionList/FunctionListEventFactory.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionListEventFactory.cs
@@ -32,7 +32,7 @@ namespace VSRAD.Syntax.FunctionList
                 var documentAnalysis = _documentAnalysisProvoder.CreateDocumentAnalysis(view.TextBuffer);
 
                 documentAnalysis.ParserUpdated += FunctionList.TryUpdateFunctionList;
-                view.Caret.PositionChanged += (obj, args) => FunctionList.TryHighlightCurrentFunction(args.TextView);
+                view.Caret.PositionChanged += (obj, args) => FunctionList.TryHighlightCurrentFunction(args.NewPosition.BufferPosition);
 
                 FunctionList.TryUpdateFunctionList(documentAnalysis.CurrentSnapshot, documentAnalysis.LastParserResult);
             }


### PR DESCRIPTION
## Explanation of the bug
The problem was that the function was not highlighted in the Function List if the caret was on the signature line. 
The function was highlighted only if the cursor was in the scope of the function as in the following pictures:
<img width="427" alt="pr1" src="https://user-images.githubusercontent.com/40007198/86898652-ab412700-c111-11ea-8b8f-878e6b4d31dd.PNG">  <img width="292" alt="pr2" src="https://user-images.githubusercontent.com/40007198/86898675-b1cf9e80-c111-11ea-84c7-8b240acd0091.PNG">

## Solution
This PR solves this problem, now the function is correctly highlighted in the FL. Also now the cursor position is used to highlight the function, not the line.
