### PR TITLE
Syntax bug fixes

### DIFF
--- a/VSRAD.Syntax/Collapse/OutliningTagger.cs
+++ b/VSRAD.Syntax/Collapse/OutliningTagger.cs
@@ -19,6 +19,7 @@ namespace VSRAD.Syntax.Collapse
         public OutliningTagger(DocumentAnalysis documentAnalysis)
         {
             currentSpans = new List<Span>();
+            ParserUpdated(documentAnalysis.CurrentSnapshot, documentAnalysis.LastParserResult);
             documentAnalysis.ParserUpdated += ParserUpdated;
         }
 

--- a/VSRAD.Syntax/FunctionList/FunctionList.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionList.cs
@@ -79,6 +79,8 @@ namespace VSRAD.Syntax.FunctionList
 
                     if (asmType == AsmType.RadAsm || asmType == AsmType.RadAsm2)
                         ThreadHelper.JoinableTaskFactory.RunAsync(() => UpdateFunctionListAsync(textBuffer));
+                    else
+                        ThreadHelper.JoinableTaskFactory.RunAsync(() => UpdateFunctionListAsync(version: null, blocks: new List<IBlock>()));
                 }
             }
         }

--- a/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
@@ -40,7 +40,7 @@ namespace VSRAD.Syntax.FunctionList
             Autoscroll = optionsProvider.Autoscroll;
             FunctionListSortState = optionsProvider.SortOptions;
             optionsProvider.OptionsUpdated += OptionsUpdated;
-            tokens.LayoutUpdated += (s, e) => ResizeOtherColumns();
+            tokens.LayoutUpdated += (s, e) => SetLineNumberColumnWidth();
         }
 
         private void OptionsUpdated(OptionsProvider sender)
@@ -117,7 +117,7 @@ namespace VSRAD.Syntax.FunctionList
                 tokens.Items.Add(token);
 
             /* Needs to update line number column width after adding new items */
-            ResizeLineNumberColumn();
+            AutosizeColumns();
         }
 
         private void ByNumber_Click(object sender, RoutedEventArgs e)
@@ -152,25 +152,29 @@ namespace VSRAD.Syntax.FunctionList
             }
         }
 
-        private void ResizeLineNumberColumn()
+        private void AutosizeColumns()
         {
             /* This is a well know behaviour of GridView https://stackoverflow.com/questions/560581/how-to-autosize-and-right-align-gridviewcolumn-data-in-wpf/1931423#1931423 */
             functionsGridView.Columns[0].Width = 0;
             if (!isHideLineNumber)
                 functionsGridView.Columns[0].Width = double.NaN;
+            functionsGridView.Columns[1].Width = 0;
+            functionsGridView.Columns[1].Width = double.NaN;
         }
 
-        private void ResizeOtherColumns()
+        private void SetLineNumberColumnWidth()
         {
-            // Line Number ActualWidth will apply only after UpdateLayout. After that, other columns width can be changed
-            functionsGridView.Columns[1].Width = tokens.ActualWidth - functionsGridView.Columns[0].ActualWidth;
+            // Line Number ActualWidth will apply only after UpdateLayout only then it can be compared with min width
+            if (functionsGridView.Columns[0].ActualWidth > 0)
+                functionsGridView.Columns[0].Width = Math.Max(functionsGridView.Columns[0].ActualWidth, 45.4 /*min width equals to 5 digits*/);
+
             LineNumberButtonColumn.Width = new GridLength(functionsGridView.Columns[0].ActualWidth);
         }
 
         private void ShowHideLineNumber(object sender, EventArgs e)
         {
             isHideLineNumber = !isHideLineNumber;
-            ResizeLineNumberColumn();
+            AutosizeColumns();
         }
 
         private void Search_TextChanged(object sender, TextChangedEventArgs e)

--- a/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
@@ -191,9 +191,11 @@ namespace VSRAD.Syntax.FunctionList
             try
             {
                 var token = (FunctionListItem)tokens.SelectedItem;
-                FunctionList.Instance
-                    .GetActiveTextView()
-                    .ChangeCaretPosition(token.LineNumber - 1);
+                if (token != null)
+                {
+                    var view = FunctionList.Instance.GetActiveTextView();
+                    view?.ChangeCaretPosition(token.LineNumber - 1);
+                }
             }
             catch (Exception e)
             {

--- a/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
@@ -64,9 +64,9 @@ namespace VSRAD.Syntax.FunctionList
 
             CurrentVersion = textSnapshot;
             Tokens = newTokens.ToList();
-            Helper.SortAndFilter(Tokens, FunctionListSortState, SearchText);
+            var filteredTokens = Helper.SortAndFilter(Tokens, FunctionListSortState, SearchText);
             
-            await AddTokensToViewAsync(Tokens);
+            await AddTokensToViewAsync(filteredTokens);
             if (LastHighlightedToken != null)
                 await HighlightCurrentFunctionAsync(LastHighlightedToken.Type, LastHighlightedToken.LineNumber);
         }

--- a/VSRAD.Syntax/Helpers/ParserResultExtension.cs
+++ b/VSRAD.Syntax/Helpers/ParserResultExtension.cs
@@ -76,5 +76,8 @@ namespace VSRAD.Syntax.Helpers
 
             return scopedTokens;
         }
+
+        public static IEnumerable<AnalysisToken> GetDefinitionToken(this IEnumerable<AnalysisToken> tokens) =>
+            tokens.Where(t => t.Type == RadAsmTokenType.LocalVariable || t.Type == RadAsmTokenType.GlobalVariable || t.Type == RadAsmTokenType.Label);
     }
 }

--- a/VSRAD.Syntax/IntelliSense/Completion/CompletionSource.cs
+++ b/VSRAD.Syntax/IntelliSense/Completion/CompletionSource.cs
@@ -11,6 +11,7 @@ using VSRAD.Syntax.Parser;
 using RadCompletionItem = VSRAD.Syntax.IntelliSense.Completion.Providers.CompletionItem;
 using RadCompletionContext = VSRAD.Syntax.IntelliSense.Completion.Providers.CompletionContext;
 using VSRAD.Syntax.Parser.Tokens;
+using System;
 
 namespace VSRAD.Syntax.IntelliSense.Completion
 {
@@ -75,25 +76,33 @@ namespace VSRAD.Syntax.IntelliSense.Completion
             if (triggerLocation == triggerLocation.Snapshot.Length)
                 return false;
 
-            var currentTokenType = _documentAnalysis.LexerTokenToRadAsmToken(_documentAnalysis.GetToken(triggerLocation).Type);
-            if (currentTokenType == RadAsmTokenType.Comment)
+            try
             {
-                return false;
-            }
-
-            if (triggerLocation > 0)
-            {
-                var previousTokenType = _documentAnalysis.LexerTokenToRadAsmToken(_documentAnalysis.GetToken(triggerLocation - 1).Type);
-                if (previousTokenType == RadAsmTokenType.Keyword
-                    || previousTokenType == RadAsmTokenType.Preprocessor
-                    || previousTokenType == RadAsmTokenType.Number)
+                var currentTokenType = _documentAnalysis.LexerTokenToRadAsmToken(_documentAnalysis.GetToken(triggerLocation).Type);
+                if (currentTokenType == RadAsmTokenType.Comment)
                 {
                     return false;
                 }
+
+                if (triggerLocation > 0)
+                {
+                    var previousTokenType = _documentAnalysis.LexerTokenToRadAsmToken(_documentAnalysis.GetToken(triggerLocation - 1).Type);
+                    if (previousTokenType == RadAsmTokenType.Keyword
+                        || previousTokenType == RadAsmTokenType.Preprocessor
+                        || previousTokenType == RadAsmTokenType.Number)
+                    {
+                        return false;
+                    }
+                }
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // outdated parser results so you cannot get valid tokens for the trigger location
+                return false;
             }
 
             if (trigger.Reason == CompletionTriggerReason.Invoke
-                || trigger.Reason == CompletionTriggerReason.InvokeAndCommitIfUnique)
+                    || trigger.Reason == CompletionTriggerReason.InvokeAndCommitIfUnique)
             {
                 return true;
             }

--- a/VSRAD.Syntax/IntelliSense/Navigation/NavigationTokenService.cs
+++ b/VSRAD.Syntax/IntelliSense/Navigation/NavigationTokenService.cs
@@ -177,7 +177,7 @@ namespace VSRAD.Syntax.IntelliSense
             {
                 while (currentBlock != null)
                 {
-                    foreach (var token in currentBlock.Tokens.Where(t => t.Type != RadAsmTokenType.Instruction))
+                    foreach (var token in currentBlock.Tokens.GetDefinitionToken())
                     {
                         if (token.TrackingToken.GetText(version) == text)
                         {
@@ -201,7 +201,7 @@ namespace VSRAD.Syntax.IntelliSense
                 {
                     var codeBlock = codeBlockStack.Pop();
 
-                    foreach (var token in codeBlock.Tokens.Where(t => t.Type != RadAsmTokenType.Instruction))
+                    foreach (var token in codeBlock.Tokens.GetDefinitionToken())
                     {
                         if (token.TrackingToken.GetText(version) == text)
                         {

--- a/VSRAD.Syntax/Parser/RadAsm/AsmParser.cs
+++ b/VSRAD.Syntax/Parser/RadAsm/AsmParser.cs
@@ -54,6 +54,7 @@ namespace VSRAD.Syntax.Parser.RadAsm
                             var analysisToken = new AnalysisToken(RadAsmTokenType.FunctionName, tokens[i + 1]);
                             currentBlock = new FunctionBlock(currentBlock, BlockType.Function, token, analysisToken);
                             parserState = ParserState.SearchArguments;
+                            parameters.Clear();
 
                             definitionTokens.Add(new KeyValuePair<AnalysisToken, ITextSnapshot>(analysisToken, version));
                             i += 1;
@@ -61,7 +62,6 @@ namespace VSRAD.Syntax.Parser.RadAsm
                     }
                     else if (token.Type == RadAsmLexer.ENDM && currentBlock.Type == BlockType.Function)
                     {
-                        parameters.Clear();
                         currentBlock.SetEnd(version, token.GetEnd(version), token);
                         currentBlock = SetBlockReady(currentBlock, blocks);
 
@@ -197,7 +197,7 @@ namespace VSRAD.Syntax.Parser.RadAsm
                     {
                         var analysisToken = new AnalysisToken(RadAsmTokenType.FunctionParameter, token);
                         currentBlock.Tokens.Add(analysisToken);
-                        parameters.Add("\\" + token.GetText(version), analysisToken);
+                        parameters["\\" + token.GetText(version)] = analysisToken;
                     }
                 }
             }

--- a/VSRAD.Syntax/Parser/RadAsm2/Asm2Parser.cs
+++ b/VSRAD.Syntax/Parser/RadAsm2/Asm2Parser.cs
@@ -68,6 +68,7 @@ namespace VSRAD.Syntax.Parser.RadAsm2
                     {
                         if (tokens.Length - i > 2 && tokens[i + 1].Type == RadAsm2Lexer.IDENTIFIER)
                         {
+                            parameters.Clear();
                             if (tokens[i + 2].Type == RadAsm2Lexer.EOL)
                             {
                                 var analysisToken = new AnalysisToken(RadAsmTokenType.FunctionName, tokens[i + 1]);
@@ -116,7 +117,6 @@ namespace VSRAD.Syntax.Parser.RadAsm2
                         if (currentBlock.Type == BlockType.Function)
                         {
                             searchInFunction = false;
-                            parameters.Clear();
 
                             currentBlock.SetEnd(version, token.GetEnd(version), token);
                             currentBlock = SetBlockReady(currentBlock, blocks);
@@ -204,7 +204,7 @@ namespace VSRAD.Syntax.Parser.RadAsm2
                     {
                         var analysisToken = new AnalysisToken(RadAsmTokenType.FunctionParameter, token);
                         currentBlock.Tokens.Add(analysisToken);
-                        parameters.Add(token.GetText(version), analysisToken);
+                        parameters[token.GetText(version)] = analysisToken;
                     }
                 }
             }

--- a/VSRAD.Syntax/VSRAD.Syntax.csproj
+++ b/VSRAD.Syntax/VSRAD.Syntax.csproj
@@ -14,29 +14,6 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Internal asm2 lang debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Internal asm2 lang debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;INTERNAL_ASM2</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>
-    </CodeAnalysisRuleSet>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Internal asm2 lang release|AnyCPU' ">
-    <OutputPath>bin\Internal asm2 lang release\</OutputPath>
-    <DefineConstants>TRACE;INTERNAL_ASM2</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>
-    </CodeAnalysisRuleSet>
-    <WarningLevel>0</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
Parser:
 * Fixed a critical error if the shader source code was written incorrectly (function parameters have the same names), code highlighting and FL did not work (https://github.com/vsrad/radeon-asm-tools/commit/aab349391c3dc04c3aeecbc071600470c305894e)
 * Fixed error when opening an already open source file. This can be reproduced when opening a file using RadeonAsmDebugger (https://github.com/vsrad/radeon-asm-tools/pull/112/commits/f02e2316341a5337ef24926a8da37e2bc7c83741)

Function list:
 * Fixed filtering of the FL when changing the code window (if the filter was set). The filter was not applied before (https://github.com/vsrad/radeon-asm-tools/commit/971e212f61e860b7c3575dd3fa1ccb1b0b90a6be)
 * Fixed `Line Number` column width with large numbers (https://github.com/vsrad/radeon-asm-tools/pull/112/commits/9a718d8eaebad44cf34f6f929206b95aa4f13aeb)

Other:
 *  Fixed collapse when opening a file for the first time, previously it was applied only after changing the file (https://github.com/vsrad/radeon-asm-tools/commit/63e6f5fd97bed5f612ccae069dd2d6a76a3a0685)
 * Fixed display of tokens in quick info tooltip, now they are grouped by filepaths (if there is more than one). It is especially noticeable if several declarations of one instruction in the instruction documentation (https://github.com/vsrad/radeon-asm-tools/commit/ee80ced0a37c0e6dba8b595a6f6ade6326b7d64c)
