### PR TITLE
Further profile improvements

### DIFF
--- a/VSRAD.DebugServer/IPC/Commands.cs
+++ b/VSRAD.DebugServer/IPC/Commands.cs
@@ -68,6 +68,9 @@ namespace VSRAD.DebugServer.IPC.Commands
 
         public bool RunAsAdministrator { get; set; }
 
+        // Note that WaitForCompletion cannot be set to false for remote execution --
+        // it is simply not sent so we don't have to change the serialization format,
+        // which will break backward compatibility
         public bool WaitForCompletion { get; set; } = true;
 
         public int ExecutionTimeoutSecs { get; set; }
@@ -89,7 +92,6 @@ namespace VSRAD.DebugServer.IPC.Commands
             Executable = reader.ReadString(),
             Arguments = reader.ReadString(),
             RunAsAdministrator = reader.ReadBoolean(),
-            WaitForCompletion = reader.ReadBoolean(),
             ExecutionTimeoutSecs = reader.ReadInt32()
         };
 
@@ -99,7 +101,6 @@ namespace VSRAD.DebugServer.IPC.Commands
             writer.Write(Executable);
             writer.Write(Arguments);
             writer.Write(RunAsAdministrator);
-            writer.Write(WaitForCompletion);
             writer.Write(ExecutionTimeoutSecs);
         }
     }

--- a/VSRAD.Package/BuildTools/BuildToolsServer.cs
+++ b/VSRAD.Package/BuildTools/BuildToolsServer.cs
@@ -102,7 +102,7 @@ namespace VSRAD.Package.BuildTools
                     break;
                 }
         }
-
+#if false
         private BuildSteps GetBuildSteps(Options.BuildProfileOptions buildOptions)
         {
             if (_buildStepsOverride is BuildSteps overriddenSteps)
@@ -200,5 +200,6 @@ namespace VSRAD.Package.BuildTools
             var messages = await _errorProcessor.ExtractMessagesAsync(result.Stderr, preprocessed);
             return (result.ExitCode, messages);
         }
+#endif
     }
 }

--- a/VSRAD.Package/Commands/EvaluateSelectedCommand.cs
+++ b/VSRAD.Package/Commands/EvaluateSelectedCommand.cs
@@ -61,7 +61,7 @@ namespace VSRAD.Package.Commands
             await SetStatusBarTextAsync($"RAD Debug: Evaluating {watchName}...");
             try
             {
-                var data = await RunAsync(options);
+                uint[] data = null;// await RunAsync(options);
                 if (data == null)
                 {
                     Errors.ShowCritical($"Please add {watchName} to watches and start a regular debug session.", $"Unable to evaluate {watchName}");

--- a/VSRAD.Package/Options/Actions.cs
+++ b/VSRAD.Package/Options/Actions.cs
@@ -20,9 +20,6 @@ namespace VSRAD.Package.Options
 
     public interface IActionStep : INotifyPropertyChanged
     {
-        [JsonIgnore]
-        string Description { get; }
-
         Task<IActionStep> EvaluateAsync(IMacroEvaluator evaluator, ProfileOptions profile, string sourceAction);
     }
 
@@ -60,39 +57,24 @@ namespace VSRAD.Package.Options
     public sealed class CopyFileStep : DefaultNotifyPropertyChanged, IActionStep
     {
         private FileCopyDirection _direction;
-        public FileCopyDirection Direction
-        {
-            get => _direction;
-            set { SetField(ref _direction, value); RaisePropertyChanged(nameof(Description)); }
-        }
+        public FileCopyDirection Direction { get => _direction; set => SetField(ref _direction, value); }
 
         private string _sourcePath = "";
-        public string SourcePath
-        {
-            get => _sourcePath;
-            set { SetField(ref _sourcePath, value); RaisePropertyChanged(nameof(Description)); }
-        }
+        public string SourcePath { get => _sourcePath; set => SetField(ref _sourcePath, value); }
 
         private string _targetPath = "";
-        public string TargetPath
-        {
-            get => _targetPath;
-            set { SetField(ref _targetPath, value); RaisePropertyChanged(nameof(Description)); }
-        }
+        public string TargetPath { get => _targetPath; set => SetField(ref _targetPath, value); }
 
         private bool _checkTimestamp;
         public bool CheckTimestamp { get => _checkTimestamp; set => SetField(ref _checkTimestamp, value); }
 
-        public string Description
+        public override string ToString()
         {
-            get
-            {
-                if (string.IsNullOrEmpty(SourcePath) || string.IsNullOrEmpty(TargetPath))
-                    return "Copy File (not configured)";
+            if (string.IsNullOrEmpty(SourcePath) || string.IsNullOrEmpty(TargetPath))
+                return "Copy File";
 
-                var dir = Direction == FileCopyDirection.LocalToRemote ? "to Remote" : "from Remote";
-                return $"Copy {dir} {SourcePath} -> {TargetPath}";
-            }
+            var dir = Direction == FileCopyDirection.LocalToRemote ? "to Remote" : "from Remote";
+            return $"Copy {dir} {SourcePath} -> {TargetPath}";
         }
 
         public override bool Equals(object obj) =>
@@ -133,25 +115,13 @@ namespace VSRAD.Package.Options
     public sealed class ExecuteStep : DefaultNotifyPropertyChanged, IActionStep
     {
         private StepEnvironment _environment;
-        public StepEnvironment Environment
-        {
-            get => _environment;
-            set { SetField(ref _environment, value); RaisePropertyChanged(nameof(Description)); }
-        }
+        public StepEnvironment Environment { get => _environment; set => SetField(ref _environment, value); }
 
         private string _executable = "";
-        public string Executable
-        {
-            get => _executable;
-            set { SetField(ref _executable, value); RaisePropertyChanged(nameof(Description)); }
-        }
+        public string Executable { get => _executable; set => SetField(ref _executable, value); }
 
         private string _arguments = "";
-        public string Arguments
-        {
-            get => _arguments;
-            set { SetField(ref _arguments, value); RaisePropertyChanged(nameof(Description)); }
-        }
+        public string Arguments { get => _arguments; set => SetField(ref _arguments, value); }
 
         private string _workingDirectory = "";
         public string WorkingDirectory { get => _workingDirectory; set => SetField(ref _workingDirectory, value); }
@@ -165,16 +135,13 @@ namespace VSRAD.Package.Options
         private int _timeoutSecs = 0;
         public int TimeoutSecs { get => _timeoutSecs; set => SetField(ref _timeoutSecs, value); }
 
-        public string Description
+        public override string ToString()
         {
-            get
-            {
-                if (string.IsNullOrEmpty(Executable))
-                    return "Execute (not configured)";
+            if (string.IsNullOrEmpty(Executable))
+                return "Execute";
 
-                var env = Environment == StepEnvironment.Remote ? "Remote" : "Local";
-                return $"Execute {env} {Executable} {Arguments}";
-            }
+            var env = Environment == StepEnvironment.Remote ? "Remote" : "Local";
+            return $"Execute {env} {Executable} {Arguments}";
         }
 
         public override bool Equals(object obj) =>
@@ -215,28 +182,13 @@ namespace VSRAD.Package.Options
     public sealed class OpenInEditorStep : DefaultNotifyPropertyChanged, IActionStep
     {
         private string _path = "";
-        public string Path
-        {
-            get => _path;
-            set
-            {
-                SetField(ref _path, value);
-                RaisePropertyChanged(nameof(Description));
-            }
-        }
+        public string Path { get => _path; set => SetField(ref _path, value); }
 
         private string _lineMarker = "";
         public string LineMarker { get => _lineMarker; set => SetField(ref _lineMarker, value); }
 
-        public string Description
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(Path))
-                    return "Open in Editor (not configured)";
-                return $"Open {Path}";
-            }
-        }
+        public override string ToString() =>
+            string.IsNullOrEmpty(Path) ? "Open in Editor" : $"Open {Path}";
 
         public override bool Equals(object obj) =>
             obj is OpenInEditorStep step && Path == step.Path && LineMarker == step.LineMarker;
@@ -264,15 +216,7 @@ namespace VSRAD.Package.Options
     public sealed class RunActionStep : DefaultNotifyPropertyChanged, IActionStep
     {
         private string _name = "";
-        public string Name
-        {
-            get => _name;
-            set
-            {
-                SetField(ref _name, value);
-                RaisePropertyChanged(nameof(Description));
-            }
-        }
+        public string Name { get => _name; set => SetField(ref _name, value); }
 
         [JsonIgnore]
         public List<IActionStep> EvaluatedSteps { get; }
@@ -284,15 +228,8 @@ namespace VSRAD.Package.Options
             EvaluatedSteps = evaluatedSteps;
         }
 
-        public string Description
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(Name))
-                    return "Run Action (not configured)";
-                return $"Run {Name}";
-            }
-        }
+        public override string ToString() =>
+            string.IsNullOrEmpty(Name) ? "Run Action" : $"Run {Name}";
 
         public override bool Equals(object obj) => obj is RunActionStep step && Name == step.Name;
 

--- a/VSRAD.Package/Options/Actions.cs
+++ b/VSRAD.Package/Options/Actions.cs
@@ -244,11 +244,10 @@ namespace VSRAD.Package.Options
         {
             if (string.IsNullOrEmpty(Name))
             {
-                if (actionsTraversed.Count == 1)
-                    return EvaluationError(actionsTraversed[0], "Run Action", "No action specified");
-                else
-                    return EvaluationError(actionsTraversed[0], "Run Action", "No action specified, required by " +
-                        string.Join(" -> ", actionsTraversed.Select(a => "\"" + a + "\"")));
+                var message = "No action specified";
+                if (actionsTraversed.Count > 1)
+                    message += ", required by " + string.Join(" -> ", actionsTraversed.Select(a => "\"" + a + "\""));
+                return EvaluationError(actionsTraversed[0], "Run Action", message);
             }
             if (actionsTraversed.Contains(Name))
             {
@@ -259,11 +258,10 @@ namespace VSRAD.Package.Options
             var action = profile.Actions.FirstOrDefault(a => a.Name == Name);
             if (action == null)
             {
-                if (actionsTraversed.Count == 1)
-                    return EvaluationError(actionsTraversed[0], "Run Action", "Action \"" + Name + "\" is not found");
-                else
-                    return EvaluationError(actionsTraversed[0], "Run Action", "Action \"" + Name + "\" is not found, required by " +
-                        string.Join(" -> ", actionsTraversed.Select(a => "\"" + a + "\"")));
+                var message = "Action \"" + Name + "\" is not found";
+                if (actionsTraversed.Count > 1)
+                    message += ", required by " + string.Join(" -> ", actionsTraversed.Select(a => "\"" + a + "\""));
+                return EvaluationError(actionsTraversed[0], "Run Action", message);
             }
 
             actionsTraversed.Add(Name);
@@ -282,7 +280,13 @@ namespace VSRAD.Package.Options
                 {
                     var evalResult = await step.EvaluateAsync(evaluator, profile, actionsTraversed[0]);
                     if (!evalResult.TryGetResult(out evaluated, out _))
-                        return EvaluationError(actionsTraversed[0], "Run Action", "Action \"" + Name + "\" is misconfigured");
+                    {
+                        var message = "Action \"" + Name + "\" is misconfigured";
+                        actionsTraversed.Remove(Name);
+                        if (actionsTraversed.Count > 1)
+                            message += ", required by " + string.Join(" -> ", actionsTraversed.Select(a => "\"" + a + "\""));
+                        return EvaluationError(actionsTraversed[0], "Run Action", message);
+                    }
                 }
                 evaluatedSteps.Add(evaluated);
             }

--- a/VSRAD.Package/Options/BuiltinActionFile.cs
+++ b/VSRAD.Package/Options/BuiltinActionFile.cs
@@ -15,12 +15,13 @@ namespace VSRAD.Package.Options
         private bool _checkTimestamp = true;
         public bool CheckTimestamp { get => _checkTimestamp; set => SetField(ref _checkTimestamp, value); }
 
-        public async Task<BuiltinActionFile> EvaluateAsync(IMacroEvaluator evaluator) =>
-            new BuiltinActionFile
-            {
-                Location = Location,
-                Path = await evaluator.EvaluateAsync(Path),
-                CheckTimestamp = CheckTimestamp
-            };
+        public async Task<Result<BuiltinActionFile>> EvaluateAsync(IMacroEvaluator evaluator)
+        {
+            var pathResult = await evaluator.EvaluateAsync(Path);
+            if (!pathResult.TryGetResult(out var evaluatedPath, out var error))
+                return error;
+
+            return new BuiltinActionFile { Location = Location, Path = evaluatedPath, CheckTimestamp = CheckTimestamp };
+        }
     }
 }

--- a/VSRAD.Package/Options/ProfileOptions.cs
+++ b/VSRAD.Package/Options/ProfileOptions.cs
@@ -1,7 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Threading.Tasks;
 using VSRAD.Package.ProjectSystem.Macros;
 using VSRAD.Package.Utils;
@@ -141,20 +140,39 @@ namespace VSRAD.Package.Options
         [JsonIgnore]
         public ServerConnectionOptions Connection => new ServerConnectionOptions(RemoteMachine, Port);
 
-        public async Task<GeneralProfileOptions> EvaluateAsync(IMacroEvaluator evaluator) => new GeneralProfileOptions
+        public async Task<Result<GeneralProfileOptions>> EvaluateAsync(IMacroEvaluator evaluator)
         {
-            ProfileName = ProfileName,
-            RemoteMachine = RemoteMachine,
-            Port = Port,
-            CopySources = CopySources,
-            DeployDirectory = await evaluator.EvaluateAsync(DeployDirectory),
-            LocalWorkDir = await evaluator.EvaluateAsync(LocalWorkDir),
-            RemoteWorkDir = await evaluator.EvaluateAsync(RemoteWorkDir),
-            AdditionalSources = AdditionalSources
-        };
+            var deployDirResult = await evaluator.EvaluateAsync(DeployDirectory);
+            if (!deployDirResult.TryGetResult(out var evaluatedDeployDir, out var error))
+                return error;
+            var envResult = await EvaluateActionEnvironmentAsync(evaluator);
+            if (!envResult.TryGetResult(out var evaluatedEnv, out error))
+                return error;
 
-        public async Task<ActionEnvironment> EvaluateActionEnvironmentAsync(IMacroEvaluator evaluator) =>
-            new ActionEnvironment(await evaluator.EvaluateAsync(LocalWorkDir), await evaluator.EvaluateAsync(RemoteWorkDir));
+            return new GeneralProfileOptions
+            {
+                ProfileName = ProfileName,
+                RemoteMachine = RemoteMachine,
+                Port = Port,
+                CopySources = CopySources,
+                DeployDirectory = evaluatedDeployDir,
+                LocalWorkDir = evaluatedEnv.LocalWorkDir,
+                RemoteWorkDir = evaluatedEnv.RemoteWorkDir,
+                AdditionalSources = AdditionalSources
+            };
+        }
+
+        public async Task<Result<ActionEnvironment>> EvaluateActionEnvironmentAsync(IMacroEvaluator evaluator)
+        {
+            var localDirResult = await evaluator.EvaluateAsync(LocalWorkDir);
+            if (!localDirResult.TryGetResult(out var evaluatedLocalDir, out var error))
+                return error;
+            var remoteDirResult = await evaluator.EvaluateAsync(RemoteWorkDir);
+            if (!remoteDirResult.TryGetResult(out var evaluatedRemoteDir, out error))
+                return error;
+
+            return new ActionEnvironment(evaluatedLocalDir, evaluatedRemoteDir);
+        }
     }
 
     public sealed class DebuggerProfileOptions
@@ -171,20 +189,28 @@ namespace VSRAD.Package.Options
 
         public async Task<Result<DebuggerProfileOptions>> EvaluateAsync(IMacroEvaluator evaluator, ProfileOptions profile)
         {
-            var evaluated = new DebuggerProfileOptions(
-                outputOffset: OutputOffset,
-                binaryOutput: BinaryOutput,
-                outputFile: await OutputFile.EvaluateAsync(evaluator),
-                watchesFile: await WatchesFile.EvaluateAsync(evaluator),
-                statusFile: await StatusFile.EvaluateAsync(evaluator));
+            var outputResult = await OutputFile.EvaluateAsync(evaluator);
+            if (!outputResult.TryGetResult(out var outputFile, out var error))
+                return error;
+            var watchesResult = await WatchesFile.EvaluateAsync(evaluator);
+            if (!watchesResult.TryGetResult(out var watchesFile, out error))
+                return error;
+            var statusResult = await StatusFile.EvaluateAsync(evaluator);
+            if (!statusResult.TryGetResult(out var statusFile, out error))
+                return error;
+
+            var evaluated = new DebuggerProfileOptions(outputOffset: OutputOffset, binaryOutput: BinaryOutput,
+                outputFile: outputFile, watchesFile: watchesFile, statusFile: statusFile);
+
             foreach (var step in Steps)
             {
                 var evalResult = await step.EvaluateAsync(evaluator, profile, ActionProfileOptions.BuiltinActionDebug);
-                if (evalResult.TryGetResult(out var evaluatedStep, out var error))
+                if (evalResult.TryGetResult(out var evaluatedStep, out error))
                     evaluated.Steps.Add(evaluatedStep);
                 else
                     return error;
             }
+
             return evaluated;
         }
 
@@ -198,6 +224,7 @@ namespace VSRAD.Package.Options
         }
     }
 
+#if false
     public sealed class DisassemblerProfileOptions
     {
         [Macro(RadMacros.DisassemblerExecutable)]
@@ -397,6 +424,7 @@ namespace VSRAD.Package.Options
             WorkingDirectory = workingDirectory;
         }
     }
+#endif
 
     public readonly struct ServerConnectionOptions : IEquatable<ServerConnectionOptions>
     {

--- a/VSRAD.Package/Options/ProfileOptions.cs
+++ b/VSRAD.Package/Options/ProfileOptions.cs
@@ -101,7 +101,7 @@ namespace VSRAD.Package.Options
         {
             var evaluated = new ActionProfileOptions { Name = Name };
             foreach (var step in Steps)
-                evaluated.Steps.Add(await step.EvaluateAsync(evaluator, profile));
+                evaluated.Steps.Add(await step.EvaluateAsync(evaluator, profile, Name));
             return evaluated;
         }
     }
@@ -173,7 +173,7 @@ namespace VSRAD.Package.Options
                 watchesFile: await WatchesFile.EvaluateAsync(evaluator),
                 statusFile: await StatusFile.EvaluateAsync(evaluator));
             foreach (var step in Steps)
-                evaluated.Steps.Add(await step.EvaluateAsync(evaluator, profile));
+                evaluated.Steps.Add(await step.EvaluateAsync(evaluator, profile, ActionProfileOptions.BuiltinActionDebug));
             return evaluated;
         }
 

--- a/VSRAD.Package/ProjectSystem/ActionLogger.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLogger.cs
@@ -58,7 +58,7 @@ namespace VSRAD.Package.ProjectSystem
                 if (prevStepsSucceeded)
                 {
                     var result = run.StepResults[i];
-                    log.AppendFormat("{0}=> [{1}] {2} {3} in {4}ms\r\n", logIndent, i, step.Description, result.Successful ? "SUCCEEDED" : "FAILED", run.StepRunMillis[i]);
+                    log.AppendFormat("{0}=> [{1}] {2} {3} in {4}ms\r\n", logIndent, i, step, result.Successful ? "SUCCEEDED" : "FAILED", run.StepRunMillis[i]);
                     if (!string.IsNullOrEmpty(result.Log))
                         log.Append(result.Log);
                     if (!string.IsNullOrEmpty(result.Warning))
@@ -70,7 +70,7 @@ namespace VSRAD.Package.ProjectSystem
                 }
                 else
                 {
-                    log.AppendFormat("{0}=> [{1}] {2} SKIPPED\r\n", logIndent, i, step.Description);
+                    log.AppendFormat("{0}=> [{1}] {2} SKIPPED\r\n", logIndent, i, step);
                 }
             }
 

--- a/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
+++ b/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
@@ -5,7 +5,6 @@ using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.TextManager.Interop;
 using System;
 using System.ComponentModel.Composition;

--- a/VSRAD.Package/ProjectSystem/Macros/DirtyProfileMacroEditor.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/DirtyProfileMacroEditor.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using VSRAD.Package.Options;
 using VSRAD.Package.Server;
+using VSRAD.Package.Utils;
 using Task = System.Threading.Tasks.Task;
 
 namespace VSRAD.Package.ProjectSystem.Macros
@@ -14,16 +15,16 @@ namespace VSRAD.Package.ProjectSystem.Macros
     {
         private readonly IProject _project;
         private readonly ICommunicationChannel _channel;
-        private readonly Options.ProfileOptions _dirtyProfile;
+        private readonly ProfileOptions _dirtyProfile;
 
-        public DirtyProfileMacroEditor(IProject project, ICommunicationChannel channel, Options.ProfileOptions dirtyProfile)
+        public DirtyProfileMacroEditor(IProject project, ICommunicationChannel channel, ProfileOptions dirtyProfile)
         {
             _project = project;
             _channel = channel;
             _dirtyProfile = dirtyProfile;
         }
 
-        public Task<IActionStep> EvaluateStepAsync(IActionStep step, string sourceAction)
+        public Task<Result<IActionStep>> EvaluateStepAsync(IActionStep step, string sourceAction)
         {
             var transients = new MacroEvaluatorTransientValues(sourceLine: 0, sourcePath: "<...>", sourceDir: "<...>", sourceFile: "<...>");
             var evaluator = new MacroEvaluator(ProjectProperties, transients, RemoteEnvironment, _project.Options.DebuggerOptions, _dirtyProfile);

--- a/VSRAD.Package/ProjectSystem/Macros/DirtyProfileMacroEditor.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/DirtyProfileMacroEditor.cs
@@ -32,7 +32,11 @@ namespace VSRAD.Package.ProjectSystem.Macros
         public async Task<string> EditAsync(string macroName, string currentValue)
         {
             var projectProperties = _project.GetProjectProperties();
-            var transients = new MacroEvaluatorTransientValues(activeSourceFile: ("<current source file>", 0));
+            var transients = new MacroEvaluatorTransientValues(sourceLine: 0,
+                sourcePath: "<current source full path>",
+                sourceDir: "<current source dir name>",
+                sourceFile: "<current source file name>");
+
             var remoteEnvironment = new AsyncLazy<IReadOnlyDictionary<string, string>>(async () =>
             {
                 try

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEditContext.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEditContext.cs
@@ -70,15 +70,11 @@ namespace VSRAD.Package.ProjectSystem.Macros
 
             foreach (var macro in projectMacroNames.Union(vsMacroNames))
             {
-                try
-                {
-                    var macroValue = await _evaluator.GetMacroValueAsync(macro).ConfigureAwait(false);
+                var macroResult = await _evaluator.GetMacroValueAsync(macro).ConfigureAwait(false);
+                if (macroResult.TryGetResult(out var macroValue, out var error))
                     macroList.Add(new KeyValuePair<string, string>("$(" + macro + ")", macroValue));
-                }
-                catch (MacroEvaluationException e)
-                {
-                    macroList.Add(new KeyValuePair<string, string>("$(" + macro + ")", "<" + e.Message + ">"));
-                }
+                else
+                    macroList.Add(new KeyValuePair<string, string>("$(" + macro + ")", "<" + error.Message + ">"));
             }
 
             foreach (DictionaryEntry e in Environment.GetEnvironmentVariables())
@@ -105,14 +101,11 @@ namespace VSRAD.Package.ProjectSystem.Macros
 
         private async Task<string> EvaluatePreviewAsync()
         {
-            try
-            {
-                return await _evaluator.EvaluateAsync(_macroValue);
-            }
-            catch (MacroEvaluationException e)
-            {
-                return e.Message;
-            }
+            var evalResult = await _evaluator.EvaluateAsync(_macroValue);
+            if (evalResult.TryGetResult(out var macroValue, out var error))
+                return macroValue;
+            else
+                return error.Message;
         }
 
         private bool FilterMacro(object macro)

--- a/VSRAD.Package/ProjectSystem/Macros/MacroListEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroListEditor.xaml.cs
@@ -41,7 +41,9 @@ namespace VSRAD.Package.ProjectSystem.Macros
     {
         public static MacroListDisplayCollection GetPredefinedMacroCollection() => new MacroListDisplayCollection
         {
-            new MacroItem(RadMacros.ActiveSourceFile, "<current source file>", userDefined: false),
+            new MacroItem(RadMacros.ActiveSourceFullPath, "<current source full path>", userDefined: false),
+            new MacroItem(RadMacros.ActiveSourceDir, "<current source dir name>", userDefined: false),
+            new MacroItem(RadMacros.ActiveSourceFile, "<current source file name>", userDefined: false),
             new MacroItem(RadMacros.ActiveSourceFileLine, "<line number under the cursor>", userDefined: false),
             new MacroItem(RadMacros.Watches, "<visualizer watches, colon-separated>", userDefined: false),
             new MacroItem(RadMacros.BreakLine, "<next breakpoint line(s), colon-separated>", userDefined: false),

--- a/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
@@ -157,7 +157,19 @@
                                 <RowDefinition Height="26"/>
                                 <RowDefinition Height="26"/>
                                 <RowDefinition Height="26"/>
-                                <RowDefinition Height="26"/>
+                                <RowDefinition>
+                                    <!-- Wait for Completion is not configurable for remote execution (see VSRAD.DebugServer.IPC.Commands) -->
+                                    <RowDefinition.Style>
+                                        <Style TargetType="{x:Type RowDefinition}">
+                                            <Setter Property="Height" Value="26" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Environment}" Value="Remote">
+                                                    <Setter Property="Height" Value="0" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </RowDefinition.Style>
+                                </RowDefinition>
                                 <RowDefinition Height="26"/>
                             </Grid.RowDefinitions>
                             <Label Content="Environment:" VerticalContentAlignment="Center" Padding="4,0" Height="22" Grid.Row="0" Grid.Column="0"/>

--- a/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
@@ -1,4 +1,5 @@
 ﻿<UserControl x:Class="VSRAD.Package.ProjectSystem.Profiles.ActionEditor"
+             x:Name="EditorRoot"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -25,6 +26,7 @@
                 <x:Type TypeName="opts:FileCopyDirection"/>
             </ObjectDataProvider.MethodParameters>
         </ObjectDataProvider>
+        <local:ActionEditorStepDescriptionConverter x:Key="StepDescriptionConverter"/>
     </UserControl.Resources>
     <StackPanel Orientation="Vertical" x:Name="Root">
         <DockPanel Height="26" Margin="0,4,4,4">
@@ -68,7 +70,9 @@
                                                 <ColumnDefinition/>
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
-                                            <TextBlock Margin="4,0" TextTrimming="CharacterEllipsis" Text="{Binding Description}" VerticalAlignment="Center" Grid.Column="0" />
+                                            <TextBlock Margin="4,0" TextTrimming="CharacterEllipsis" VerticalAlignment="Center" Grid.Column="0"
+                                                       DataContext="{Binding RelativeSource={RelativeSource Self}, Converter={StaticResource StepDescriptionConverter}}"
+                                                       Text="{Binding Description}" ToolTip="{Binding Description}" Tag="{Binding ElementName=EditorRoot}" />
                                             <StackPanel Orientation="Horizontal" Grid.Column="1" Margin="4,0">
                                                 <Button Content="▲" Command="{Binding DataContext.MoveUpCommand, ElementName=Root}" CommandParameter="{TemplateBinding Content}"
                                                         ToolTip="Move up" Width="22" Height="22" Margin="0,0,4,0" />

--- a/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml.cs
@@ -47,15 +47,11 @@ namespace VSRAD.Package.ProjectSystem.Profiles
         private async Task EvaluateDescriptionAsync(ActionEditor editor, IActionStep step)
         {
             await VSPackage.TaskFactory.SwitchToMainThreadAsync();
-            try
-            {
-                var evaluated = await editor.MacroEditor.EvaluateStepAsync(step, editor.ActionName);
+            var evalResult = await editor.MacroEditor.EvaluateStepAsync(step, editor.ActionName);
+            if (evalResult.TryGetResult(out var evaluated, out var error))
                 Description = evaluated.ToString();
-            }
-            catch (ActionEvaluationException e)
-            {
-                Description = $"{step} ({e.Description})";
-            }
+            else
+                Description = $"{step} ({error.Message})";
         }
     }
 

--- a/VSRAD.Package/ProjectSystem/Project.cs
+++ b/VSRAD.Package/ProjectSystem/Project.cs
@@ -100,27 +100,14 @@ namespace VSRAD.Package.ProjectSystem
 
             var projectProperties = GetProjectProperties();
 
-            var file = await GetRelativeSourcePathAsync();
-            var line = _codeEditor.GetCurrentLine();
-            var transients = new MacroEvaluatorTransientValues(activeSourceFile: (file, line), breakLines, watchesOverride);
+            var sourceLine = _codeEditor.GetCurrentLine();
+            var sourcePath = _codeEditor.GetAbsoluteSourcePath();
+            var transients = new MacroEvaluatorTransientValues(sourceLine, sourcePath, breakLines: breakLines, watchesOverride: watchesOverride);
 
             var remoteEnvironment = new AsyncLazy<IReadOnlyDictionary<string, string>>(
                 _communicationChannel.GetRemoteEnvironmentAsync, VSPackage.TaskFactory);
 
             return new MacroEvaluator(projectProperties, transients, remoteEnvironment, Options.DebuggerOptions, Options.Profile);
-        }
-
-        private async Task<string> GetRelativeSourcePathAsync()
-        {
-            var sourcePath = _codeEditor.GetAbsoluteSourcePath();
-            if (sourcePath.StartsWith(RootPath, StringComparison.OrdinalIgnoreCase))
-                return sourcePath.Substring(RootPath.Length + 1);
-
-            foreach (var (absolutePath, relativePath) in await _projectSourceManager.ListProjectFilesAsync())
-                if (absolutePath == sourcePath)
-                    return relativePath;
-
-            throw new ArgumentException($"\"{sourcePath}\" does not belong to the current project located at \"{RootPath}\"");
         }
         #endregion
     }

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -118,11 +118,15 @@ namespace VSRAD.Package.Server
 
         private async Task<StepResult> DoExecuteAsync(ExecuteStep step)
         {
+            var workDir = step.WorkingDirectory;
+            if (string.IsNullOrEmpty(workDir))
+                workDir = step.Environment == StepEnvironment.Local ? _environment.LocalWorkDir : _environment.RemoteWorkDir;
+
             var command = new Execute
             {
                 Executable = step.Executable,
                 Arguments = step.Arguments,
-                WorkingDirectory = step.WorkingDirectory,
+                WorkingDirectory = workDir,
                 RunAsAdministrator = step.RunAsAdmin,
                 WaitForCompletion = step.WaitForCompletion,
                 ExecutionTimeoutSecs = step.TimeoutSecs

--- a/VSRAD.Package/Server/DebugSession.cs
+++ b/VSRAD.Package/Server/DebugSession.cs
@@ -32,9 +32,12 @@ namespace VSRAD.Package.Server
         {
             var execTimer = Stopwatch.StartNew();
             var evaluator = await _project.GetMacroEvaluatorAsync(breakLines).ConfigureAwait(false);
-            var env = await _project.Options.Profile.General.EvaluateActionEnvironmentAsync(evaluator).ConfigureAwait(false);
+
+            var envResult = await _project.Options.Profile.General.EvaluateActionEnvironmentAsync(evaluator).ConfigureAwait(false);
+            if (!envResult.TryGetResult(out var env, out var evalError))
+                return new DebugRunResult(null, evalError, null);
             var optionsResult = await _project.Options.Profile.Debugger.EvaluateAsync(evaluator, _project.Options.Profile).ConfigureAwait(false);
-            if (!optionsResult.TryGetResult(out var options, out var evalError))
+            if (!optionsResult.TryGetResult(out var options, out evalError))
                 return new DebugRunResult(null, evalError, null);
             if (ValidateConfiguration(options) is Error configError)
                 return new DebugRunResult(null, configError, null);

--- a/VSRAD.Package/Server/DebugSession.cs
+++ b/VSRAD.Package/Server/DebugSession.cs
@@ -33,8 +33,9 @@ namespace VSRAD.Package.Server
             var execTimer = Stopwatch.StartNew();
             var evaluator = await _project.GetMacroEvaluatorAsync(breakLines).ConfigureAwait(false);
             var env = await _project.Options.Profile.General.EvaluateActionEnvironmentAsync(evaluator).ConfigureAwait(false);
-            var options = await _project.Options.Profile.Debugger.EvaluateAsync(evaluator, _project.Options.Profile).ConfigureAwait(false);
-
+            var optionsResult = await _project.Options.Profile.Debugger.EvaluateAsync(evaluator, _project.Options.Profile).ConfigureAwait(false);
+            if (!optionsResult.TryGetResult(out var options, out var evalError))
+                return new DebugRunResult(null, evalError, null);
             if (ValidateConfiguration(options) is Error configError)
                 return new DebugRunResult(null, configError, null);
 

--- a/VSRAD.Package/Server/FileSynchronizationManager.cs
+++ b/VSRAD.Package/Server/FileSynchronizationManager.cs
@@ -43,7 +43,10 @@ namespace VSRAD.Package.Server
         public async Task SynchronizeRemoteAsync()
         {
             var evaluator = await _project.GetMacroEvaluatorAsync(default);
-            var options = await _project.Options.Profile.General.EvaluateAsync(evaluator);
+            var optionsResult = await _project.Options.Profile.General.EvaluateAsync(evaluator);
+            if (!optionsResult.TryGetResult(out var options, out var error))
+                throw new Exception(error.Message);
+
             var mode = _project.Options.DebuggerOptions.Autosave ? DocumentSaveType.OpenDocuments : DocumentSaveType.None;
 
             await _projectSourceManager.SaveDocumentsAsync(mode);

--- a/VSRAD.PackageTests/ProjectSystem/ActionLoggerTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/ActionLoggerTests.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.VisualStudio.Shell;
 using Moq;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using VSRAD.Package.Options;
 using VSRAD.Package.ProjectSystem;
 using VSRAD.Package.ProjectSystem.Macros;
@@ -30,7 +27,7 @@ namespace VSRAD.PackageTests.ProjectSystem
             var evaluator = new Mock<IMacroEvaluator>();
             evaluator.Setup(e => e.EvaluateAsync(It.IsAny<string>())).Returns<string>(s => Task.FromResult(s));
 
-            var level1action = await profile.Actions[2].EvaluateAsync(evaluator.Object, profile);
+            Assert.True((await profile.Actions[2].EvaluateAsync(evaluator.Object, profile)).TryGetResult(out var level1action, out _));
             var level2action = (RunActionStep)level1action.Steps[0];
             var level3action = (RunActionStep)level2action.EvaluatedSteps[1];
 

--- a/VSRAD.PackageTests/ProjectSystem/ActionLoggerTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/ActionLoggerTests.cs
@@ -4,6 +4,7 @@ using VSRAD.Package.Options;
 using VSRAD.Package.ProjectSystem;
 using VSRAD.Package.ProjectSystem.Macros;
 using VSRAD.Package.Server;
+using VSRAD.Package.Utils;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
@@ -25,7 +26,7 @@ namespace VSRAD.PackageTests.ProjectSystem
             profile.Actions[2].Steps.Add(new CopyFileStep { Direction = FileCopyDirection.LocalToRemote, CheckTimestamp = true, TargetPath = "incubator", SourcePath = "soul" });
 
             var evaluator = new Mock<IMacroEvaluator>();
-            evaluator.Setup(e => e.EvaluateAsync(It.IsAny<string>())).Returns<string>(s => Task.FromResult(s));
+            evaluator.Setup(e => e.EvaluateAsync(It.IsAny<string>())).Returns<string>(s => Task.FromResult<Result<string>>(s));
 
             Assert.True((await profile.Actions[2].EvaluateAsync(evaluator.Object, profile)).TryGetResult(out var level1action, out _));
             var level2action = (RunActionStep)level1action.Steps[0];

--- a/VSRAD.PackageTests/ProjectSystem/Macros/MacroEditContextTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Macros/MacroEditContextTests.cs
@@ -23,7 +23,7 @@ namespace VSRAD.PackageTests.ProjectSystem.Macros
 
             var props = new Mock<IProjectProperties>();
             var evaluator = new MacroEvaluator(props.Object,
-                new MacroEvaluatorTransientValues(("nofile", 0)),
+                new MacroEvaluatorTransientValues(0, @"I:\C\ftg"),
                 MacroEvaluatorTests.EmptyRemoteEnv,
                 new DebuggerOptions(), profile);
             var context = new MacroEditContext("A", "$(B)", evaluator);
@@ -47,7 +47,7 @@ namespace VSRAD.PackageTests.ProjectSystem.Macros
 
             var props = new Mock<IProjectProperties>();
             var evaluator = new MacroEvaluator(props.Object,
-                new MacroEvaluatorTransientValues(("nofile", 0)),
+                new MacroEvaluatorTransientValues(0, @"I:\C\ftg"),
                 MacroEvaluatorTests.EmptyRemoteEnv,
                 new DebuggerOptions(), profile);
             var context = new MacroEditContext("A", "$(B)", evaluator);

--- a/VSRAD.PackageTests/ProjectSystem/Macros/MacroEvaluatorTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Macros/MacroEvaluatorTests.cs
@@ -52,16 +52,16 @@ namespace VSRAD.PackageTests.ProjectSystem.Macros
             var result = await evaluator.GetMacroValueAsync(RadMacros.Watches);
             Assert.Equal("a:c:tide", result);
 
-            var transients = new MacroEvaluatorTransientValues(
-                activeSourceFile: ("welcome home", 666), breakLines: new[] { 13u }, watchesOverride: new[] { "m", "c", "ride" });
+            var transients = new MacroEvaluatorTransientValues(sourceLine: 666, sourcePath: @"B:\welcome\home",
+                breakLines: new[] { 13u }, watchesOverride: new[] { "m", "c", "ride" });
             evaluator = new MacroEvaluator(props.Object, transients, EmptyRemoteEnv, debuggerOptions, new ProfileOptions());
 
             result = await evaluator.GetMacroValueAsync(RadMacros.Watches);
             Assert.Equal("m:c:ride", result);
-            result = await evaluator.EvaluateAsync($"$({RadMacros.ActiveSourceFile}):$({RadMacros.ActiveSourceFileLine}), stop at $({RadMacros.BreakLine})");
-            Assert.Equal("welcome home:666, stop at 13", result);
+            result = await evaluator.EvaluateAsync($"$({RadMacros.ActiveSourceDir})\\$({RadMacros.ActiveSourceFile}):$({RadMacros.ActiveSourceFileLine}), stop at $({RadMacros.BreakLine})");
+            Assert.Equal(@"B:\welcome\home:666, stop at 13", result);
 
-            transients = new MacroEvaluatorTransientValues(activeSourceFile: ("", 0), breakLines: new[] { 20u, 1u, 9u });
+            transients = new MacroEvaluatorTransientValues(0, "nofile", breakLines: new[] { 20u, 1u, 9u });
             evaluator = new MacroEvaluator(props.Object, transients, EmptyRemoteEnv, debuggerOptions, new ProfileOptions());
             result = await evaluator.EvaluateAsync($"-l $({RadMacros.BreakLine})");
             Assert.Equal("-l 20:1:9", result);

--- a/VSRAD.PackageTests/Server/ActionMacroEvaluationTests.cs
+++ b/VSRAD.PackageTests/Server/ActionMacroEvaluationTests.cs
@@ -1,5 +1,4 @@
 ﻿using Moq;
-using System;
 using System.Threading.Tasks;
 using VSRAD.Package.Options;
 using VSRAD.Package.ProjectSystem.Macros;
@@ -9,26 +8,103 @@ namespace VSRAD.PackageTests.Server
 {
     public class ActionMacroEvaluationTests
     {
+        private static IMacroEvaluator MakeIdentityEvaluator()
+        {
+            var mock = new Mock<IMacroEvaluator>();
+            mock.Setup(e => e.EvaluateAsync(It.IsAny<string>())).Returns<string>(s => Task.FromResult(s));
+            return mock.Object;
+        }
+
+        private static IMacroEvaluator MakeEvaluator(string unevaluated, string result)
+        {
+            var mock = new Mock<IMacroEvaluator>();
+            mock.Setup(e => e.EvaluateAsync(It.IsAny<string>())).Returns<string>(s => Task.FromResult(s == unevaluated ? result : unevaluated));
+            return mock.Object;
+        }
+
+        [Fact]
+        public async Task CopyFileStepEmptyPathsTestAsync()
+        {
+            var profile = new ProfileOptions();
+            var a = new ActionProfileOptions { Name = "A" };
+
+            a.Steps.Add(new CopyFileStep { SourcePath = "", TargetPath = "target" });
+            var ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => a.EvaluateAsync(MakeIdentityEvaluator(), profile));
+            Assert.Equal("No source path specified for Copy File step", ex.Description);
+            ((CopyFileStep)a.Steps[0]).SourcePath = "$(MissingMacro)";
+            ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => a.EvaluateAsync(MakeEvaluator("$(MissingMacro)", ""), profile));
+            Assert.Equal("The source path specified for Copy File step (\"$(MissingMacro)\") evaluates to an empty string", ex.Description);
+
+            ((CopyFileStep)a.Steps[0]).SourcePath = "source";
+            ((CopyFileStep)a.Steps[0]).TargetPath = "";
+            ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => a.EvaluateAsync(MakeIdentityEvaluator(), profile));
+            Assert.Equal("No target path specified for Copy File step", ex.Description);
+            ((CopyFileStep)a.Steps[0]).TargetPath = "$(MissingMacro)";
+            ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => a.EvaluateAsync(MakeEvaluator("$(MissingMacro)", ""), profile));
+            Assert.Equal("The target path specified for Copy File step (\"$(MissingMacro)\") evaluates to an empty string", ex.Description);
+        }
+
+        [Fact]
+        public async Task ExecuteStepEmptyExecutableTestAsync()
+        {
+            var profile = new ProfileOptions();
+            var a = new ActionProfileOptions { Name = "A" };
+
+            a.Steps.Add(new ExecuteStep { Executable = "" });
+            var ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => a.EvaluateAsync(MakeIdentityEvaluator(), profile));
+            Assert.Equal("No executable specified for Execute step", ex.Description);
+            ((ExecuteStep)a.Steps[0]).Executable = "$(MissingMacro)";
+            ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => a.EvaluateAsync(MakeEvaluator("$(MissingMacro)", ""), profile));
+            Assert.Equal("The executable specified for Execute step (\"$(MissingMacro)\") evaluates to an empty string", ex.Description);
+        }
+
+        [Fact]
+        public async Task OpenInEditorStepEmptyPathTestAsync()
+        {
+            var profile = new ProfileOptions();
+            var a = new ActionProfileOptions { Name = "A" };
+
+            a.Steps.Add(new OpenInEditorStep { Path = "" });
+            var ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => a.EvaluateAsync(MakeIdentityEvaluator(), profile));
+            Assert.Equal("No path specified for Open in Editor step", ex.Description);
+            ((OpenInEditorStep)a.Steps[0]).Path = "$(MissingMacro)";
+            ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => a.EvaluateAsync(MakeEvaluator("$(MissingMacro)", ""), profile));
+            Assert.Equal("The path specified for Open in Editor step (\"$(MissingMacro)\") evaluates to an empty string", ex.Description);
+        }
+
         [Fact]
         public async Task RunActionStepDetectsLoopsTestAsync()
         {
             var profile = new ProfileOptions();
             var a = new ActionProfileOptions { Name = "A" };
-            a.Steps.Add(new ExecuteStep());
+            a.Steps.Add(new ExecuteStep { Executable = "-" });
             a.Steps.Add(new RunActionStep { Name = "A_nested" });
             var aNested = new ActionProfileOptions { Name = "A_nested" };
-            aNested.Steps.Add(new CopyFileStep());
+            aNested.Steps.Add(new CopyFileStep { SourcePath = "-", TargetPath = "-" });
             aNested.Steps.Add(new RunActionStep { Name = "B" });
             var b = new ActionProfileOptions { Name = "B" };
+            b.Steps.Add(new OpenInEditorStep { Path = "-" });
             b.Steps.Add(new RunActionStep { Name = "A" });
-            b.Steps.Add(new OpenInEditorStep());
 
             profile.Actions.Add(a);
             profile.Actions.Add(aNested);
             profile.Actions.Add(b);
 
-            var ex = await Assert.ThrowsAsync<Exception>(async () => await a.EvaluateAsync(new Mock<IMacroEvaluator>().Object, profile));
-            Assert.Equal("Encountered a circular action: A_nested -> B -> A -> A_nested", ex.Message);
+            var ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => a.EvaluateAsync(MakeIdentityEvaluator(), profile));
+            Assert.Equal("A", ex.SourceAction);
+            Assert.Equal(@"Encountered a circular dependency between Run Action steps: ""A"" -> ""A_nested"" -> ""B"" -> ""A""", ex.Description);
+        }
+
+        [Fact]
+        public async Task RunActionStepRefersToSelfTestAsync()
+        {
+            var profile = new ProfileOptions();
+            var a = new ActionProfileOptions { Name = "A" };
+            a.Steps.Add(new RunActionStep { Name = "A" });
+            profile.Actions.Add(a);
+            var ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => a.EvaluateAsync(MakeIdentityEvaluator(), profile));
+            Assert.Equal("A", ex.SourceAction);
+            Assert.Equal(@"Encountered a circular dependency between Run Action steps: ""A"" -> ""A""", ex.Description);
         }
 
         [Fact]
@@ -46,22 +122,33 @@ namespace VSRAD.PackageTests.Server
             profile.Actions.Add(b);
             profile.Actions.Add(c);
 
-            var ex = await Assert.ThrowsAsync<Exception>(async () => await a.EvaluateAsync(new Mock<IMacroEvaluator>().Object, profile));
-            Assert.Equal("Action D not found, required by B -> C -> D", ex.Message);
+            var ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => a.EvaluateAsync(MakeIdentityEvaluator(), profile));
+            Assert.Equal("A", ex.SourceAction);
+            Assert.Equal(@"Action ""D"" is specified in a Run Action step but was not found, required by ""A"" -> ""B"" -> ""C""", ex.Description);
 
-            ex = await Assert.ThrowsAsync<Exception>(async () => await c.EvaluateAsync(new Mock<IMacroEvaluator>().Object, profile));
-            Assert.Equal("Action D not found", ex.Message);
+            ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => c.EvaluateAsync(MakeIdentityEvaluator(), profile));
+            Assert.Equal("C", ex.SourceAction);
+            Assert.Equal(@"Action ""D"" is specified in a Run Action step but was not found, required by ""C""", ex.Description);
         }
 
         [Fact]
-        public async Task RunActionStepRefersToSelfTestAsync()
+        public async Task RunActionUnconfiguredTestAsync()
         {
             var profile = new ProfileOptions();
             var a = new ActionProfileOptions { Name = "A" };
-            a.Steps.Add(new RunActionStep { Name = "A" });
+            a.Steps.Add(new RunActionStep { Name = "B" });
+            var b = new ActionProfileOptions { Name = "B" };
+            b.Steps.Add(new RunActionStep { Name = "" });
             profile.Actions.Add(a);
-            var ex = await Assert.ThrowsAsync<Exception>(async () => await a.EvaluateAsync(new Mock<IMacroEvaluator>().Object, profile));
-            Assert.Equal("Encountered a circular action: A -> A", ex.Message);
+            profile.Actions.Add(b);
+
+            var ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => a.EvaluateAsync(MakeIdentityEvaluator(), profile));
+            Assert.Equal("A", ex.SourceAction);
+            Assert.Equal(@"No action specified for Run Action step, required by ""A"" -> ""B""", ex.Description);
+
+            ex = await Assert.ThrowsAsync<ActionEvaluationException>(() => b.EvaluateAsync(MakeIdentityEvaluator(), profile));
+            Assert.Equal("B", ex.SourceAction);
+            Assert.Equal(@"No action specified for Run Action step, required by ""B""", ex.Description);
         }
     }
 }

--- a/VSRAD.PackageTests/Server/ActionMacroEvaluationTests.cs
+++ b/VSRAD.PackageTests/Server/ActionMacroEvaluationTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using VSRAD.Package.Options;
 using VSRAD.Package.ProjectSystem.Macros;
+using VSRAD.Package.Utils;
 using Xunit;
 
 namespace VSRAD.PackageTests.Server
@@ -11,14 +12,14 @@ namespace VSRAD.PackageTests.Server
         private static IMacroEvaluator MakeIdentityEvaluator()
         {
             var mock = new Mock<IMacroEvaluator>();
-            mock.Setup(e => e.EvaluateAsync(It.IsAny<string>())).Returns<string>(s => Task.FromResult(s));
+            mock.Setup(e => e.EvaluateAsync(It.IsAny<string>())).Returns<string>(s => Task.FromResult<Result<string>>(s));
             return mock.Object;
         }
 
         private static IMacroEvaluator MakeEvaluator(string unevaluated, string result)
         {
             var mock = new Mock<IMacroEvaluator>();
-            mock.Setup(e => e.EvaluateAsync(It.IsAny<string>())).Returns<string>(s => Task.FromResult(s == unevaluated ? result : unevaluated));
+            mock.Setup(e => e.EvaluateAsync(It.IsAny<string>())).Returns<string>(s => Task.FromResult<Result<string>>(s == unevaluated ? result : unevaluated));
             return mock.Object;
         }
 

--- a/VSRAD.PackageTests/Server/FileSynchronizationManagerTests.cs
+++ b/VSRAD.PackageTests/Server/FileSynchronizationManagerTests.cs
@@ -10,6 +10,7 @@ using VSRAD.Package.Options;
 using VSRAD.Package.ProjectSystem;
 using VSRAD.Package.ProjectSystem.Macros;
 using VSRAD.Package.Server;
+using VSRAD.Package.Utils;
 using Xunit;
 
 namespace VSRAD.PackageTests.Server
@@ -142,9 +143,9 @@ namespace VSRAD.PackageTests.Server
             project.Setup((p) => p.RootPath).Returns(_projectRoot);
 
             var evaluator = new Mock<IMacroEvaluator>(MockBehavior.Strict);
-            evaluator.Setup((e) => e.EvaluateAsync(_deployDirectory)).Returns(Task.FromResult(_deployDirectory));
-            evaluator.Setup((e) => e.EvaluateAsync("$(" + CleanProfileMacros.LocalWorkDir + ")")).Returns(Task.FromResult(""));
-            evaluator.Setup((e) => e.EvaluateAsync("$(" + CleanProfileMacros.RemoteWorkDir + ")")).Returns(Task.FromResult(""));
+            evaluator.Setup((e) => e.EvaluateAsync(_deployDirectory)).Returns(Task.FromResult<Result<string>>(_deployDirectory));
+            evaluator.Setup((e) => e.EvaluateAsync("$(" + CleanProfileMacros.LocalWorkDir + ")")).Returns(Task.FromResult<Result<string>>(""));
+            evaluator.Setup((e) => e.EvaluateAsync("$(" + CleanProfileMacros.RemoteWorkDir + ")")).Returns(Task.FromResult<Result<string>>(""));
             project.Setup((p) => p.GetMacroEvaluatorAsync(It.IsAny<uint[]>(), It.IsAny<string[]>())).Returns(Task.FromResult(evaluator.Object));
 
             sourceManager = sourceManager ?? new Mock<IProjectSourceManager>().Object;

--- a/VSRAD.PackageTests/TestHelper.cs
+++ b/VSRAD.PackageTests/TestHelper.cs
@@ -8,6 +8,7 @@ using VSRAD.Package;
 using VSRAD.Package.Options;
 using VSRAD.Package.ProjectSystem;
 using VSRAD.Package.ProjectSystem.Macros;
+using VSRAD.Package.Utils;
 
 #pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
 
@@ -45,9 +46,9 @@ namespace VSRAD.PackageTests
             var evaluator = new Mock<IMacroEvaluator>();
             if (macros != null)
                 foreach (var macro in macros)
-                    evaluator.Setup((e) => e.GetMacroValueAsync(macro.Key)).Returns(Task.FromResult(macro.Value));
-            evaluator.Setup((e) => e.EvaluateAsync(It.IsAny<string>())).Returns<string>((val) => Task.FromResult(val));
-            evaluator.Setup((e) => e.EvaluateAsync("$(" + CleanProfileMacros.RemoteWorkDir + ")")).Returns(Task.FromResult(remoteWorkDir));
+                    evaluator.Setup((e) => e.GetMacroValueAsync(macro.Key)).Returns(Task.FromResult<Result<string>>(macro.Value));
+            evaluator.Setup((e) => e.EvaluateAsync(It.IsAny<string>())).Returns<string>((val) => Task.FromResult<Result<string>>(val));
+            evaluator.Setup((e) => e.EvaluateAsync("$(" + CleanProfileMacros.RemoteWorkDir + ")")).Returns(Task.FromResult<Result<string>>(remoteWorkDir));
 
             mock.Setup((p) => p.GetMacroEvaluatorAsync(It.IsAny<uint[]>(), It.IsAny<string[]>())).Returns(Task.FromResult(evaluator.Object));
             return mock;


### PR DESCRIPTION
Profile editor:
* Evaluate macros in step descriptions (159681f)
* Prevent freezes when step configuration is invalid (aae92d1, 4c75bc3)

Macro/action evaluation:
* Show descriptive error messages for missing parameters in step configuration (0f72b03)
* If working directory is not specified for `Execute` step, set it to *General* -> *Local Working Directory* / *Remote Working Directory* depending on step environment (0c31bda)
* Add `$(RadActiveSourceDir)` and `$(RadActiveSourceFullPath)` macros, change `$(RadActiveSourceFile)` to evaluate to file name only -- previously, it evaluated to a project-relative file path, which could cause "File does not belong to the current project" errors (43190a9)

Debug server:
* Deploy project files before running actions (d69bc76)
* Restore backward compatibility: older extension versions should work with the new server (9527841, c207f67)