### PR TITLE
Unevaluated watches handling fixes

### DIFF
--- a/VSRAD.Package/DebugVisualizer/ColumnStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/ColumnStyling.cs
@@ -52,11 +52,5 @@ namespace VSRAD.Package.DebugVisualizer
                 }
             }
         }
-
-        public static void GrayOutColumns(IReadOnlyList<DataGridViewColumn> columns, FontAndColorState fontAndColor, uint groupSize)
-        {
-            for (int i = 0; i < groupSize; i++)
-                columns[i].DefaultCellStyle.BackColor = fontAndColor.HighlightBackground[(int)DataHighlightColor.Inactive];
-        }
     }
 }

--- a/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
@@ -23,13 +23,6 @@ namespace VSRAD.Package.DebugVisualizer
         private ColumnStates[] _columnState = new ColumnStates[512];
         public ColumnStates[] ColumnState { get => _columnState; }
 
-        public void GrayOutColumns(uint groupSize)
-        {
-            GroupSize = groupSize;
-            for (int i = 0; i < groupSize; i++)
-                _columnState[i] |= ColumnStates.Inactive;
-        }
-
         public void Recompute(VisualizerOptions options, ColumnStylingOptions styling, uint groupSize, Server.WatchView system)
         {
             GroupSize = groupSize;

--- a/VSRAD.Package/DebugVisualizer/RowStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/RowStyling.cs
@@ -14,7 +14,7 @@ namespace VSRAD.Package.DebugVisualizer
             var rowBg = DataHighlightColor.None;
             var inactiveBg = colors.HighlightBackground[(int)DataHighlightColor.Inactive];
             var watch = (string)row.Cells[VisualizerTable.NameColumnIndex].Value;
-            var isUnevaluated = !string.IsNullOrWhiteSpace(watch) && watch != "System" && !watches.Contains(watch);
+            var isUnevaluated = watches != null ? !string.IsNullOrWhiteSpace(watch) && watch != "System" && !watches.Contains(watch) : true;
 
             if (isUnevaluated)
             {

--- a/VSRAD.Package/DebugVisualizer/RowStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/RowStyling.cs
@@ -37,5 +37,10 @@ namespace VSRAD.Package.DebugVisualizer
             row.DefaultCellStyle.BackColor = bgColor;
             row.DefaultCellStyle.Tag = (rowFg, rowBg);
         }
+
+        public static void GrayOutRow(FontAndColorState colors, DataGridViewRow row)
+        {
+            row.DefaultCellStyle.BackColor = colors.HighlightBackground[(int)DataHighlightColor.Inactive];
+        }
     }
 }

--- a/VSRAD.Package/DebugVisualizer/RowStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/RowStyling.cs
@@ -14,7 +14,7 @@ namespace VSRAD.Package.DebugVisualizer
             var rowBg = DataHighlightColor.None;
             var inactiveBg = colors.HighlightBackground[(int)DataHighlightColor.Inactive];
             var watch = (string)row.Cells[VisualizerTable.NameColumnIndex].Value;
-            var isUnevaluated = watches != null ? !string.IsNullOrWhiteSpace(watch) && watch != "System" && !watches.Contains(watch) : true;
+            var isUnevaluated = watches == null || !string.IsNullOrWhiteSpace(watch) && watch != "System" && !watches.Contains(watch);
 
             if (isUnevaluated)
             {

--- a/VSRAD.Package/DebugVisualizer/RowStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/RowStyling.cs
@@ -8,10 +8,20 @@ namespace VSRAD.Package.DebugVisualizer
 {
     public sealed class RowStyling
     {
-        public static void UpdateRowHighlight(DataGridViewRow row, FontAndColorState colors, DataHighlightColor? changeFg = null, DataHighlightColor? changeBg = null)
+        public static void UpdateRowHighlight(DataGridViewRow row, FontAndColorState colors, ReadOnlyCollection<string> watches, DataHighlightColor? changeFg = null, DataHighlightColor? changeBg = null)
         {
             var rowFg = DataHighlightColor.None;
             var rowBg = DataHighlightColor.None;
+            var inactiveBg = colors.HighlightBackground[(int)DataHighlightColor.Inactive];
+            var watch = (string)row.Cells[VisualizerTable.NameColumnIndex].Value;
+            var isUnevaluated = !string.IsNullOrWhiteSpace(watch) && watch != "System" && !watches.Contains(watch);
+
+            if (isUnevaluated)
+            {
+                row.DefaultCellStyle.BackColor = inactiveBg;
+                return;
+            }
+
             if (row.DefaultCellStyle.Tag is ValueTuple<DataHighlightColor, DataHighlightColor> existingColors)
                 (rowFg, rowBg) = existingColors;
 
@@ -26,21 +36,6 @@ namespace VSRAD.Package.DebugVisualizer
             row.DefaultCellStyle.ForeColor = fgColor;
             row.DefaultCellStyle.BackColor = bgColor;
             row.DefaultCellStyle.Tag = (rowFg, rowBg);
-        }
-
-        public static void GrayOutUnevaluatedWatches(IEnumerable<DataGridViewRow> rows, FontAndColorState colors, ReadOnlyCollection<string> watches)
-        {
-            var inactiveBg = colors.HighlightBackground[(int)DataHighlightColor.Inactive];
-            foreach (var row in rows)
-            {
-                var watch = (string)row.Cells[VisualizerTable.NameColumnIndex].Value;
-                var isUnevaluated = !string.IsNullOrWhiteSpace(watch) && watch != "System" && !watches.Contains(watch);
-
-                if (isUnevaluated)
-                    row.DefaultCellStyle.BackColor = inactiveBg;
-                else if (row.DefaultCellStyle.BackColor == inactiveBg) // used to be unevaluated
-                    UpdateRowHighlight(row, colors, changeFg: null, changeBg: null); // restore old highlight
-            }
         }
     }
 }

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -10,7 +10,6 @@ namespace VSRAD.Package.DebugVisualizer
     {
         private readonly VisualizerTable _table;
         private readonly VisualizerContext _context;
-        private readonly FontAndColorProvider _fontAndColor;
 
         public VisualizerControl(IToolWindowIntegration integration)
         {
@@ -27,7 +26,6 @@ namespace VSRAD.Package.DebugVisualizer
             integration.ProjectOptions.VisualizerAppearance.PropertyChanged += OptionsChanged;
 
             var tableFontAndColor = new FontAndColorProvider();
-            _fontAndColor = tableFontAndColor;
             tableFontAndColor.FontAndColorInfoChanged += RefreshDataStyling;
             _table = new VisualizerTable(
                 _context.Options.VisualizerColumnStyling,
@@ -54,16 +52,8 @@ namespace VSRAD.Package.DebugVisualizer
         private void RefreshDataStyling() =>
             _table.ApplyDataStyling(_context.Options, _context.GroupSize, _context.BreakData?.GetSystem());
 
-        private void GrayOutWatches()
-        {
-            if (_table.ShowSystemRow)
-                RowStyling.GrayOutRow(_fontAndColor.FontAndColorState, _table.Rows[0]);
-
-            foreach (System.Windows.Forms.DataGridViewRow row in _table.DataRows)
-            {
-                RowStyling.GrayOutRow(_fontAndColor.FontAndColorState, row);
-            }
-        }
+        private void GrayOutWatches() =>
+            _table.GrayOutColumns();
 
         private void ContextPropertyChanged(object sender, PropertyChangedEventArgs e)
         {

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -32,7 +32,8 @@ namespace VSRAD.Package.DebugVisualizer
                 _context.Options.VisualizerColumnStyling,
                 _context.Options.VisualizerAppearance,
                 tableFontAndColor,
-                getGroupSize: () => _context.GroupSize);
+                getGroupSize: () => _context.GroupSize,
+                getValidWatches: () => _context.BreakData.Watches);
             _table.WatchStateChanged += (newWatchState, invalidatedRows) =>
             {
                 _context.Options.DebuggerOptions.Watches.Clear();
@@ -76,7 +77,7 @@ namespace VSRAD.Package.DebugVisualizer
             if (e.Warning != null)
                 Errors.ShowWarning(e.Warning);
 
-            _table.ApplyWatchStyling(_context.BreakData.Watches);
+            _table.ApplyWatchStyling();
             RefreshDataStyling();
 
             foreach (System.Windows.Forms.DataGridViewRow row in _table.Rows)

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-using System.Windows;
 using System.Windows.Controls;
 using VSRAD.Package.ProjectSystem;
 using VSRAD.Package.Server;
@@ -11,6 +10,7 @@ namespace VSRAD.Package.DebugVisualizer
     {
         private readonly VisualizerTable _table;
         private readonly VisualizerContext _context;
+        private readonly FontAndColorProvider _fontAndColor;
 
         public VisualizerControl(IToolWindowIntegration integration)
         {
@@ -27,6 +27,7 @@ namespace VSRAD.Package.DebugVisualizer
             integration.ProjectOptions.VisualizerAppearance.PropertyChanged += OptionsChanged;
 
             var tableFontAndColor = new FontAndColorProvider();
+            _fontAndColor = tableFontAndColor;
             tableFontAndColor.FontAndColorInfoChanged += RefreshDataStyling;
             _table = new VisualizerTable(
                 _context.Options.VisualizerColumnStyling,
@@ -53,8 +54,16 @@ namespace VSRAD.Package.DebugVisualizer
         private void RefreshDataStyling() =>
             _table.ApplyDataStyling(_context.Options, _context.GroupSize, _context.BreakData?.GetSystem());
 
-        private void GrayOutWatches() =>
-            _table.GrayOutColumns(_context.GroupSize);
+        private void GrayOutWatches()
+        {
+            if (_table.ShowSystemRow)
+                RowStyling.GrayOutRow(_fontAndColor.FontAndColorState, _table.Rows[0]);
+
+            foreach (System.Windows.Forms.DataGridViewRow row in _table.DataRows)
+            {
+                RowStyling.GrayOutRow(_fontAndColor.FontAndColorState, row);
+            }
+        }
 
         private void ContextPropertyChanged(object sender, PropertyChangedEventArgs e)
         {

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -53,7 +53,7 @@ namespace VSRAD.Package.DebugVisualizer
             _table.ApplyDataStyling(_context.Options, _context.GroupSize, _context.BreakData?.GetSystem());
 
         private void GrayOutWatches() =>
-            _table.GrayOutColumns();
+            _table.GrayOutRows();
 
         private void ContextPropertyChanged(object sender, PropertyChangedEventArgs e)
         {

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -33,7 +33,7 @@ namespace VSRAD.Package.DebugVisualizer
                 _context.Options.VisualizerAppearance,
                 tableFontAndColor,
                 getGroupSize: () => _context.GroupSize,
-                getValidWatches: () => _context.BreakData.Watches);
+                getValidWatches: () => _context?.BreakData?.Watches);
             _table.WatchStateChanged += (newWatchState, invalidatedRows) =>
             {
                 _context.Options.DebuggerOptions.Watches.Clear();

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -308,7 +308,7 @@ namespace VSRAD.Package.DebugVisualizer
 
         #region Styling
 
-        public void GrayOutColumns()
+        public void GrayOutRows()
         {
             if (ShowSystemRow)
                 RowStyling.GrayOutRow(_fontAndColor.FontAndColorState, Rows[0]);
@@ -362,7 +362,6 @@ namespace VSRAD.Package.DebugVisualizer
                 _fontAndColor.FontAndColorState);
             columnStyling.Apply(_state.DataColumns);
 
-            
             foreach (DataGridViewRow row in Rows)
                 RowStyling.UpdateRowHighlight(row, _fontAndColor.FontAndColorState, _getValidWatches());
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -309,7 +309,7 @@ namespace VSRAD.Package.DebugVisualizer
         #region Styling
 
         public void GrayOutColumns()
-        {;
+        {
             if (ShowSystemRow)
                 RowStyling.GrayOutRow(_fontAndColor.FontAndColorState, Rows[0]);
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -190,6 +190,7 @@ namespace VSRAD.Package.DebugVisualizer
             Rows[index].Cells[NameColumnIndex].Value = watch.Name;
             Rows[index].HeaderCell.Value = watch.Type.ShortName();
             Rows[index].HeaderCell.Tag = watch.IsAVGPR;
+            Rows[index].DefaultCellStyle.BackColor = _fontAndColor.FontAndColorState.HighlightBackground[(int)DataHighlightColor.Inactive];
             LockWatchRowForEditing(Rows[index], canBeRemoved);
         }
 
@@ -259,6 +260,7 @@ namespace VSRAD.Package.DebugVisualizer
                         Rows[e.RowIndex].Cells[NameColumnIndex].Value = rowWatchName.Trim();
                     Rows[e.RowIndex].HeaderCell.Value = VariableType.Hex.ShortName();
                     Rows[e.RowIndex].HeaderCell.Tag = IsAVGPR(rowWatchName); // avgpr
+                    RowStyling.UpdateRowHighlight(row, _fontAndColor.FontAndColorState, _getValidWatches());
                     LockWatchRowForEditing(row);
                     PrepareNewWatchRow();
                     RaiseWatchStateChanged(new[] { row });

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -308,9 +308,16 @@ namespace VSRAD.Package.DebugVisualizer
 
         #region Styling
 
-        public void GrayOutColumns(uint groupSize)
-        {
-            _computedStyling.GrayOutColumns(groupSize);
+        public void GrayOutColumns()
+        {;
+            if (ShowSystemRow)
+                RowStyling.GrayOutRow(_fontAndColor.FontAndColorState, Rows[0]);
+
+            foreach (DataGridViewRow row in DataRows)
+            {
+                RowStyling.GrayOutRow(_fontAndColor.FontAndColorState, row);
+            }
+
             Invalidate();
         }
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -314,7 +314,8 @@ namespace VSRAD.Package.DebugVisualizer
 
         public void ApplyWatchStyling()
         {
-            foreach (DataGridViewRow row in Rows) RowStyling.UpdateRowHighlight(row, _fontAndColor.FontAndColorState, _getValidWatches());
+            foreach (DataGridViewRow row in Rows)
+                RowStyling.UpdateRowHighlight(row, _fontAndColor.FontAndColorState, _getValidWatches());
         }
 
         public void ApplyRowHighlight(int rowIndex, DataHighlightColor? changeFg = null, DataHighlightColor? changeBg = null)

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -363,7 +363,8 @@ namespace VSRAD.Package.DebugVisualizer
             columnStyling.Apply(_state.DataColumns);
 
             foreach (DataGridViewRow row in Rows)
-                RowStyling.UpdateRowHighlight(row, _fontAndColor.FontAndColorState, _getValidWatches());
+                if (row.Index != NewWatchRowIndex)
+                    RowStyling.UpdateRowHighlight(row, _fontAndColor.FontAndColorState, _getValidWatches());
 
             _disableColumnWidthChangeHandler = false;
             ((Control)this).ResumeDrawing();


### PR DESCRIPTION
* Fixed unevaluated watches painting
* Gray out all watches before debug session start
* Properly gray out watches if debug session was unsuccessfull