### PR TITLE
Navigable quickInfo text elements

### DIFF
--- a/VSRAD.Syntax/IntelliSense/Completion/CompletionSource.cs
+++ b/VSRAD.Syntax/IntelliSense/Completion/CompletionSource.cs
@@ -19,11 +19,16 @@ namespace VSRAD.Syntax.IntelliSense.Completion
     {
         public const string CompletionItemKey = nameof(CompletionItem);
         private readonly DocumentAnalysis _documentAnalysis;
+        private readonly IIntellisenseDescriptionBuilder _descriptionBuilder;
         private readonly IReadOnlyList<Providers.CompletionProvider> _completionProviders;
 
-        public CompletionSource(DocumentAnalysis documentAnalysis, IReadOnlyList<Providers.CompletionProvider> providers)
+        public CompletionSource(
+            DocumentAnalysis documentAnalysis, 
+            IIntellisenseDescriptionBuilder descriptionBuilder, 
+            IReadOnlyList<Providers.CompletionProvider> providers)
         {
             _documentAnalysis = documentAnalysis;
+            _descriptionBuilder = descriptionBuilder;
             _completionProviders = providers;
         }
 
@@ -56,7 +61,7 @@ namespace VSRAD.Syntax.IntelliSense.Completion
         public Task<object> GetDescriptionAsync(IAsyncCompletionSession session, CompletionItem item, CancellationToken token)
         {
             var completionItem = (RadCompletionItem)item.Properties[CompletionItemKey];
-            return Task.FromResult(IntellisenseTokenDescription.GetColorizedDescription(completionItem.Tokens));
+            return Task.FromResult(_descriptionBuilder.GetColorizedDescription(completionItem.Tokens));
         }
 
         private async Task<ImmutableArray<RadCompletionContext>> ComputeNonEmptyCompletionContextsAsync(SnapshotPoint triggerLocation, SnapshotSpan applicableToSpan)

--- a/VSRAD.Syntax/IntelliSense/Completion/CompletionSourceProvider.cs
+++ b/VSRAD.Syntax/IntelliSense/Completion/CompletionSourceProvider.cs
@@ -17,16 +17,19 @@ namespace VSRAD.Syntax.IntelliSense.Completion
     {
         private readonly DocumentAnalysisProvoder _documentAnalysisProvoder;
         private readonly OptionsProvider _optionsEventProvider;
+        private readonly IIntellisenseDescriptionBuilder _descriptionBuilder;
         private readonly IReadOnlyList<CompletionProvider> _providers;
 
         [ImportingConstructor]
         public CompletionSourceProvider(
             OptionsProvider optionsEventProvider,
             InstructionListManager instructionListManager,
-            DocumentAnalysisProvoder documentAnalysisProvoder)
+            DocumentAnalysisProvoder documentAnalysisProvoder,
+            IIntellisenseDescriptionBuilder descriptionBuilder)
         {
             _documentAnalysisProvoder = documentAnalysisProvoder;
             _optionsEventProvider = optionsEventProvider;
+            _descriptionBuilder = descriptionBuilder;
 
             _providers = new List<CompletionProvider>()
             {
@@ -42,7 +45,7 @@ namespace VSRAD.Syntax.IntelliSense.Completion
                 throw new ArgumentNullException(nameof(textView));
 
             var documentAnalysis = _documentAnalysisProvoder.CreateDocumentAnalysis(textView.TextBuffer);
-            return new CompletionSource(documentAnalysis, _providers);
+            return new CompletionSource(documentAnalysis, _descriptionBuilder, _providers);
         }
     }
 }

--- a/VSRAD.Syntax/IntelliSense/Navigation/NavigationList/DefinitionToken.cs
+++ b/VSRAD.Syntax/IntelliSense/Navigation/NavigationList/DefinitionToken.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.VisualStudio.Text;
-using System.Text;
+﻿using System.Text;
+using VSRAD.Syntax.Parser;
 
 namespace VSRAD.Syntax.IntelliSense.Navigation.NavigationList
 {
@@ -13,9 +13,9 @@ namespace VSRAD.Syntax.IntelliSense.Navigation.NavigationList
         public DefinitionToken(NavigationToken navigationToken)
         {
             NavigationToken = navigationToken;
-            if (NavigationToken.Snapshot.TextBuffer.Properties.TryGetProperty<ITextDocument>(typeof(ITextDocument), out var document))
+            if (NavigationToken.Snapshot.TextBuffer.Properties.TryGetProperty<DocumentInfo>(typeof(DocumentInfo), out var document))
             {
-                FilePath = document.FilePath;
+                FilePath = document.Path;
             }
             else
             {

--- a/VSRAD.Syntax/IntelliSense/QuickInfo/QuickInfoSource.cs
+++ b/VSRAD.Syntax/IntelliSense/QuickInfo/QuickInfoSource.cs
@@ -4,23 +4,26 @@ using System.Threading;
 using System.Threading.Tasks;
 using VSRAD.Syntax.Helpers;
 using VSRAD.Syntax.Parser;
-using VSRAD.Syntax.Parser.Tokens;
 
 namespace VSRAD.Syntax.IntelliSense.QuickInfo
 {
     internal class QuickInfoSource : IAsyncQuickInfoSource
     {
         private readonly INavigationTokenService _navigationService;
+        private readonly IIntellisenseDescriptionBuilder _descriptionBuilder;
         private readonly ITextBuffer _textBuffer;
         private readonly DocumentAnalysis _documentAnalysis;
 
-        public QuickInfoSource(ITextBuffer textBuffer, 
+        public QuickInfoSource(
+            ITextBuffer textBuffer, 
             DocumentAnalysis documentAnalysis,
-            INavigationTokenService navigationService)
+            INavigationTokenService navigationService,
+            IIntellisenseDescriptionBuilder descriptionBuilder)
         {
             _textBuffer = textBuffer;
             _documentAnalysis = documentAnalysis;
             _navigationService = navigationService;
+            _descriptionBuilder = descriptionBuilder;
         }
 
         public Task<QuickInfoItem> GetQuickInfoItemAsync(IAsyncQuickInfoSession session, CancellationToken cancellationToken)
@@ -34,7 +37,7 @@ namespace VSRAD.Syntax.IntelliSense.QuickInfo
             var navigationTokens = _navigationService.GetNaviationItem(extent);
             if (navigationTokens.Count > 0)
             {
-                var dataElement = IntellisenseTokenDescription.GetColorizedDescription(navigationTokens);
+                var dataElement = _descriptionBuilder.GetColorizedDescription(navigationTokens);
                 if (dataElement == null)
                     return Task.FromResult<QuickInfoItem>(null);
 

--- a/VSRAD.Syntax/IntelliSense/QuickInfo/QuickInfoSourceProvider.cs
+++ b/VSRAD.Syntax/IntelliSense/QuickInfo/QuickInfoSourceProvider.cs
@@ -15,13 +15,16 @@ namespace VSRAD.Syntax.IntelliSense.QuickInfo
     {
         private readonly DocumentAnalysisProvoder _documentAnalysisProvoder;
         private readonly INavigationTokenService _navigationService;
+        private readonly IIntellisenseDescriptionBuilder _descriptionBuilder;
 
         [ImportingConstructor]
         public QuickInfoSourceProvider(DocumentAnalysisProvoder documentAnalysisProvoder,
-            INavigationTokenService navigationService)
+            INavigationTokenService navigationService,
+            IIntellisenseDescriptionBuilder descriptionBuilder)
         {
             _documentAnalysisProvoder = documentAnalysisProvoder;
             _navigationService = navigationService;
+            _descriptionBuilder = descriptionBuilder;
         }
 
         public IAsyncQuickInfoSource TryCreateQuickInfoSource(ITextBuffer textBuffer)
@@ -30,7 +33,7 @@ namespace VSRAD.Syntax.IntelliSense.QuickInfo
                 throw new ArgumentNullException(nameof(textBuffer));
 
             var documentAnalysis = _documentAnalysisProvoder.CreateDocumentAnalysis(textBuffer);
-            return textBuffer.Properties.GetOrCreateSingletonProperty(() => new QuickInfoSource(textBuffer, documentAnalysis, _navigationService));
+            return textBuffer.Properties.GetOrCreateSingletonProperty(() => new QuickInfoSource(textBuffer, documentAnalysis, _navigationService, _descriptionBuilder));
         }
     }
 }

--- a/VSRAD.Syntax/Parser/Tokens/TokenType.cs
+++ b/VSRAD.Syntax/Parser/Tokens/TokenType.cs
@@ -1,4 +1,7 @@
-﻿namespace VSRAD.Syntax.Parser.Tokens
+﻿using Microsoft.VisualStudio.Language.StandardClassification;
+using System.Collections.Generic;
+
+namespace VSRAD.Syntax.Parser.Tokens
 {
     public enum RadAsmTokenType
     {
@@ -19,6 +22,8 @@
         RcurveBracket,
         Whitespace,
         Keyword,
+        Preprocessor,
+        Unknown,
         FunctionName,
         FunctionReference,
         FunctionParameter,
@@ -29,9 +34,6 @@
         GlobalVariable,
         GlobalVariableReference,
         LocalVariable,
-        Include,
-        Preprocessor,
-        Unknown,
     }
 
     public static class RadAsmTokenTypeExtension
@@ -56,5 +58,41 @@
                     return "unknown";
             }
         }
+
+        private static readonly Dictionary<RadAsmTokenType, string> _classificationTypeNames = new Dictionary<RadAsmTokenType, string>()
+        {
+            { RadAsmTokenType.Comment, PredefinedClassificationTypeNames.Comment },
+            { RadAsmTokenType.Identifier, PredefinedClassificationTypeNames.Identifier },
+            { RadAsmTokenType.String, PredefinedClassificationTypeNames.String },
+            { RadAsmTokenType.Number, PredefinedClassificationTypeNames.Number },
+            { RadAsmTokenType.Operation, PredefinedClassificationTypeNames.Operator },
+            { RadAsmTokenType.Structural, PredefinedClassificationTypeNames.FormalLanguage },
+            { RadAsmTokenType.Comma, PredefinedClassificationTypeNames.FormalLanguage },
+            { RadAsmTokenType.Semi, PredefinedClassificationTypeNames.FormalLanguage },
+            { RadAsmTokenType.Colon, PredefinedClassificationTypeNames.FormalLanguage },
+            { RadAsmTokenType.Lparen, PredefinedClassificationTypeNames.FormalLanguage },
+            { RadAsmTokenType.Rparen, PredefinedClassificationTypeNames.FormalLanguage },
+            { RadAsmTokenType.LsquareBracket, PredefinedClassificationTypeNames.FormalLanguage },
+            { RadAsmTokenType.RsquareBracket, PredefinedClassificationTypeNames.FormalLanguage },
+            { RadAsmTokenType.LcurveBracket, PredefinedClassificationTypeNames.FormalLanguage },
+            { RadAsmTokenType.RcurveBracket, PredefinedClassificationTypeNames.FormalLanguage },
+            { RadAsmTokenType.Whitespace, PredefinedClassificationTypeNames.WhiteSpace },
+            { RadAsmTokenType.Keyword, PredefinedClassificationTypeNames.Keyword },
+            { RadAsmTokenType.Preprocessor, PredefinedClassificationTypeNames.PreprocessorKeyword },
+            { RadAsmTokenType.Unknown, PredefinedClassificationTypeNames.Other },
+            { RadAsmTokenType.FunctionName, SyntaxHighlighter.PredefinedClassificationTypeNames.Functions },
+            { RadAsmTokenType.FunctionReference, SyntaxHighlighter.PredefinedClassificationTypeNames.Functions },
+            { RadAsmTokenType.FunctionParameter, SyntaxHighlighter.PredefinedClassificationTypeNames.Arguments },
+            { RadAsmTokenType.FunctionParameterReference, SyntaxHighlighter.PredefinedClassificationTypeNames.Arguments },
+            { RadAsmTokenType.Label, SyntaxHighlighter.PredefinedClassificationTypeNames.Labels },
+            { RadAsmTokenType.LabelReference, SyntaxHighlighter.PredefinedClassificationTypeNames.Labels },
+            { RadAsmTokenType.GlobalVariable, PredefinedClassificationTypeNames.FormalLanguage },
+            { RadAsmTokenType.GlobalVariableReference, PredefinedClassificationTypeNames.FormalLanguage },
+            { RadAsmTokenType.LocalVariable, PredefinedClassificationTypeNames.FormalLanguage },
+            { RadAsmTokenType.Instruction, SyntaxHighlighter.PredefinedClassificationTypeNames.Instructions },
+        };
+
+        public static string GetClassificationTypeName(this RadAsmTokenType tokenType) =>
+            _classificationTypeNames[tokenType];
     }
 }

--- a/VSRAD.Syntax/SyntaxHighlighter/Classifier.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/Classifier.cs
@@ -77,17 +77,16 @@ namespace VSRAD.Syntax.SyntaxHighlighter
 
             _tokenClassification = new Dictionary<RadAsmTokenType, IClassificationType>()
             {
-                { RadAsmTokenType.Instruction, registryService.GetClassificationType(PredefinedClassificationTypeNames.Instructions) },
-                { RadAsmTokenType.FunctionName, registryService.GetClassificationType(PredefinedClassificationTypeNames.Functions) },
-                { RadAsmTokenType.FunctionReference, registryService.GetClassificationType(PredefinedClassificationTypeNames.Functions) },
-                { RadAsmTokenType.FunctionParameter, registryService.GetClassificationType(PredefinedClassificationTypeNames.Arguments) },
-                { RadAsmTokenType.FunctionParameterReference, registryService.GetClassificationType(PredefinedClassificationTypeNames.Arguments) },
-                { RadAsmTokenType.Label, registryService.GetClassificationType(PredefinedClassificationTypeNames.Labels) },
-                { RadAsmTokenType.LabelReference, registryService.GetClassificationType(PredefinedClassificationTypeNames.Labels) },
+                { RadAsmTokenType.Instruction, registryService.GetClassificationType(RadAsmTokenType.Instruction.GetClassificationTypeName()) },
+                { RadAsmTokenType.FunctionName, registryService.GetClassificationType(RadAsmTokenType.FunctionName.GetClassificationTypeName()) },
+                { RadAsmTokenType.FunctionReference, registryService.GetClassificationType(RadAsmTokenType.FunctionReference.GetClassificationTypeName()) },
+                { RadAsmTokenType.FunctionParameter, registryService.GetClassificationType(RadAsmTokenType.FunctionParameter.GetClassificationTypeName()) },
+                { RadAsmTokenType.FunctionParameterReference, registryService.GetClassificationType(RadAsmTokenType.FunctionParameterReference.GetClassificationTypeName()) },
+                { RadAsmTokenType.Label, registryService.GetClassificationType(RadAsmTokenType.Label.GetClassificationTypeName()) },
+                { RadAsmTokenType.LabelReference, registryService.GetClassificationType(RadAsmTokenType.LabelReference.GetClassificationTypeName()) },
                 { RadAsmTokenType.GlobalVariable, typeService.FormalLanguage },
                 { RadAsmTokenType.GlobalVariableReference, typeService.FormalLanguage },
                 { RadAsmTokenType.LocalVariable, typeService.FormalLanguage },
-                { RadAsmTokenType.Include, typeService.StringLiteral },
             };
         }
 


### PR DESCRIPTION
Text elements now support navigation in the QuickInfo tooltip. 
It's works for
 * instructions
 * variables
 * function parameters
 * functions (the function signature is shown and navigation is available for the function name and parameters)

> <img width="495" alt="pr" src="https://user-images.githubusercontent.com/40007198/88281864-1897af00-ccf1-11ea-9c1e-50791d8d58de.PNG">
