### PR TITLE
Restore error highlighting in source files

### DIFF
--- a/VSRAD.Package/ProjectSystem/ErrorListManager.cs
+++ b/VSRAD.Package/ProjectSystem/ErrorListManager.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Tagging;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
@@ -46,6 +47,7 @@ namespace VSRAD.Package.ProjectSystem
 
             _errorListProvider.Tasks.Clear();
 
+            var errors = new List<ErrorTask>();
             var messages = await _buildErrorProcessor.ExtractMessagesAsync(stderr, null);
             foreach (var message in messages)
             {
@@ -64,11 +66,11 @@ namespace VSRAD.Package.ProjectSystem
                     _errorListProvider.Navigate(task, Guid.Parse(/*EnvDTE.Constants.vsViewKindCode*/"{7651A701-06E5-11D1-8EBD-00A0C90F26EA}"));
                     task.Line--;
                 };
-
                 _errorListProvider.Tasks.Add(task);
+                errors.Add(task);
             }
 
-            ErrorTagger?.ErrorListUpdated();
+            ErrorTagger?.ErrorListUpdated(errors);
         }
 
         private bool _errorTaggerInitialized;

--- a/VSRAD.Package/ProjectSystem/ErrorListManager.cs
+++ b/VSRAD.Package/ProjectSystem/ErrorListManager.cs
@@ -39,6 +39,8 @@ namespace VSRAD.Package.ProjectSystem
             _buildErrorProcessor = buildErrorProcessor;
             _project = project;
             _unconfiguredProject = unconfiguredProject;
+
+            _project.Unloaded += () => _errorListProvider.Tasks.Clear();
         }
 
         public async Task AddToErrorListAsync(string stderr)


### PR DESCRIPTION
Error highlighting in source files used to be applied after project build. Since #110, we don't use MSBuild anymore, so errors are never highlighted.

This PR switches from DTE events to communication between extensions (see eef66fe). When the syntax extension is not installed or an older version is in use, no error is raised and no highlighting is applied. In future, we might want to show a warning but it needs to be nondisruptive (not a message box).