### PR TITLE
Error parser fixes

### DIFF
--- a/VSRAD.Package/BuildTools/BuildErrorProcessor.cs
+++ b/VSRAD.Package/BuildTools/BuildErrorProcessor.cs
@@ -10,7 +10,7 @@ namespace VSRAD.Package.BuildTools
 {
     public interface IBuildErrorProcessor
     {
-        Task<IEnumerable<Message>> ExtractMessagesAsync(string output, string preprocessedSource);
+        Task<IEnumerable<Message>> ExtractMessagesAsync(IEnumerable<string> outputs, string preprocessedSource);
     }
 
     [Export(typeof(IBuildErrorProcessor))]
@@ -25,9 +25,9 @@ namespace VSRAD.Package.BuildTools
             _sourceManager = sourceManager;
         }
 
-        public async Task<IEnumerable<Message>> ExtractMessagesAsync(string output, string preprocessedSource)
+        public async Task<IEnumerable<Message>> ExtractMessagesAsync(IEnumerable<string> outputs, string preprocessedSource)
         {
-            var messages = Errors.Parser.ParseStderr(output);
+            var messages = Errors.Parser.ParseStderr(outputs);
             if (messages.Count > 0)
             {
                 var projectSources = (await _sourceManager.ListProjectFilesAsync()).Select(f => f.relativePath);

--- a/VSRAD.Package/BuildTools/Errors/Parser.cs
+++ b/VSRAD.Package/BuildTools/Errors/Parser.cs
@@ -12,10 +12,10 @@ namespace VSRAD.Package.BuildTools.Errors
 
         public static ICollection<Message> ParseStderr(IEnumerable<string> outputs)
         {
-            var messages = new LinkedList<Message>();
-
+            var combinedMessages = new List<Message>();
             foreach (var output in outputs)
             {
+                var messages = new LinkedList<Message>();
                 var format = ErrorFormat.Undefined;
                 using (var reader = new StringReader(output))
                 {
@@ -41,8 +41,9 @@ namespace VSRAD.Package.BuildTools.Errors
                             messages.Last.Value.Text += Environment.NewLine + line;
                     }
                 }
+                combinedMessages.AddRange(messages);
             }
-            return messages;
+            return combinedMessages;
         }
 
         private static readonly Regex ClangErrorRegex = new Regex(

--- a/VSRAD.Package/BuildTools/Errors/Parser.cs
+++ b/VSRAD.Package/BuildTools/Errors/Parser.cs
@@ -59,10 +59,10 @@ namespace VSRAD.Package.BuildTools.Errors
         }
 
         private static readonly Regex ScriptErrorRegex = new Regex(
-            @"\*(?<kind>[EW]),(?<code>[^:(]+)(?>\s\((?<file>[^:]+):(?<line>\d+)\))?:\s(?<text>.+)", RegexOptions.Compiled);
+            @"\*(?<kind>[EW]),(?<code>[^:(]+)(?>\s\((?<file>.+):(?<line>\d+)\))?:\s(?<text>.+)", RegexOptions.Compiled);
 
         private static readonly Regex ScriptErrorLocationInTextRegex = new Regex(
-            @"(?<text>.+)\s\((?<file>[^:]+):(?<line>\d+)\)", RegexOptions.Compiled);
+            @"(?<text>.+)\s\((?<file>.+):(?<line>\d+)\)", RegexOptions.Compiled);
 
         private static Message ParseScriptMessage(string header)
         {

--- a/VSRAD.Package/BuildTools/Errors/Parser.cs
+++ b/VSRAD.Package/BuildTools/Errors/Parser.cs
@@ -10,32 +10,36 @@ namespace VSRAD.Package.BuildTools.Errors
     {
         private enum ErrorFormat { Clang, Script, Undefined };
 
-        public static ICollection<Message> ParseStderr(string stderr)
+        public static ICollection<Message> ParseStderr(IEnumerable<string> outputs)
         {
             var messages = new LinkedList<Message>();
-            var format = ErrorFormat.Undefined;
-            using (var reader = new StringReader(stderr))
+
+            foreach (var output in outputs)
             {
-                string line;
-                while ((line = reader.ReadLine()) != null)
+                var format = ErrorFormat.Undefined;
+                using (var reader = new StringReader(output))
                 {
-                    Message message;
-                    if ((message = ParseKeywordMessage(line)) == null)
-                        switch (format)
-                        {
-                            case ErrorFormat.Clang: message = ParseClangMessage(line); break;
-                            case ErrorFormat.Script: message = ParseScriptMessage(line); break;
-                            default:
-                                if ((message = ParseClangMessage(line)) != null)
-                                    format = ErrorFormat.Clang;
-                                else if ((message = ParseScriptMessage(line)) != null)
-                                    format = ErrorFormat.Script;
-                                break;
-                        }
-                    if (message != null)
-                        messages.AddLast(message);
-                    else if (messages.Last != null)
-                        messages.Last.Value.Text += Environment.NewLine + line;
+                    string line;
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        Message message;
+                        if ((message = ParseKeywordMessage(line)) == null)
+                            switch (format)
+                            {
+                                case ErrorFormat.Clang: message = ParseClangMessage(line); break;
+                                case ErrorFormat.Script: message = ParseScriptMessage(line); break;
+                                default:
+                                    if ((message = ParseClangMessage(line)) != null)
+                                        format = ErrorFormat.Clang;
+                                    else if ((message = ParseScriptMessage(line)) != null)
+                                        format = ErrorFormat.Script;
+                                    break;
+                            }
+                        if (message != null)
+                            messages.AddLast(message);
+                        else if (messages.Last != null)
+                            messages.Last.Value.Text += Environment.NewLine + line;
+                    }
                 }
             }
             return messages;

--- a/VSRAD.Package/ProjectSystem/ActionLogger.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLogger.cs
@@ -36,7 +36,9 @@ namespace VSRAD.Package.ProjectSystem
 
             var logString = log.ToString();
             await _outputWriter.PrintMessageAsync(title, logString);
-            await _errorList.AddToErrorListAsync(logString);
+
+            var errorListOutput = runResult.GetStepOutputs();
+            await _errorList.AddToErrorListAsync(errorListOutput);
 
             if (warnings.Length == 0)
                 return null;

--- a/VSRAD.Package/ProjectSystem/ErrorListManager.cs
+++ b/VSRAD.Package/ProjectSystem/ErrorListManager.cs
@@ -14,7 +14,7 @@ namespace VSRAD.Package.ProjectSystem
 {
     public interface IErrorListManager
     {
-        Task AddToErrorListAsync(string contents);
+        Task AddToErrorListAsync(IEnumerable<string> outputs);
     }
 
     [Export(typeof(IErrorListManager))]
@@ -43,14 +43,12 @@ namespace VSRAD.Package.ProjectSystem
             _project.Unloaded += () => _errorListProvider.Tasks.Clear();
         }
 
-        public async Task AddToErrorListAsync(string stderr)
+        public async Task AddToErrorListAsync(IEnumerable<string> outputs)
         {
-            if (stderr == null) return;
-
             _errorListProvider.Tasks.Clear();
 
             var errors = new List<ErrorTask>();
-            var messages = await _buildErrorProcessor.ExtractMessagesAsync(stderr, null);
+            var messages = await _buildErrorProcessor.ExtractMessagesAsync(outputs, null);
             foreach (var message in messages)
             {
                 var document = string.IsNullOrEmpty(message.SourceFile) // make unclickable error otherwise it will refer to the project root

--- a/VSRAD.Package/Server/ActionRunResult.cs
+++ b/VSRAD.Package/Server/ActionRunResult.cs
@@ -75,13 +75,13 @@ namespace VSRAD.Package.Server
         public string[] ErrorListOutput { get; }
         public ActionRunResult SubAction { get; }
 
-        public StepResult(bool successful, string warning, string log, string[] errorListOutput = null, ActionRunResult subAction = null)
+        public StepResult(bool successful, string warning, string log, ActionRunResult subAction = null, string[] errorListOutput = null)
         {
             Successful = successful;
             Warning = warning;
             Log = log;
-            ErrorListOutput = errorListOutput;
             SubAction = subAction;
+            ErrorListOutput = errorListOutput;
         }
 
         public bool Equals(StepResult result) =>

--- a/VSRAD.Package/Server/ActionRunResult.cs
+++ b/VSRAD.Package/Server/ActionRunResult.cs
@@ -42,6 +42,22 @@ namespace VSRAD.Package.Server
         public void FinishRun() =>
             TotalMillis = _stopwatch.ElapsedMilliseconds;
 
+        public IEnumerable<string> GetStepOutputs()
+        {
+            // recursive algorithm to get action outputs
+            // if there are loops in the actions, it will be detected before the action starts
+            foreach (var result in StepResults)
+            {
+                if (result.ErrorListOutput != null)
+                    foreach (var output in result.ErrorListOutput)
+                        yield return output;
+
+                if (result.SubAction != null)
+                    foreach (var output in result.SubAction.GetStepOutputs())
+                        yield return output;
+            }
+        }
+
         private long MeasureInterval()
         {
             var currentTime = _stopwatch.ElapsedMilliseconds;
@@ -56,20 +72,22 @@ namespace VSRAD.Package.Server
         public bool Successful { get; }
         public string Warning { get; }
         public string Log { get; }
+        public string[] ErrorListOutput { get; }
         public ActionRunResult SubAction { get; }
 
-        public StepResult(bool successful, string warning, string log, ActionRunResult subAction = null)
+        public StepResult(bool successful, string warning, string log, string[] errorListOutput = null, ActionRunResult subAction = null)
         {
             Successful = successful;
             Warning = warning;
             Log = log;
+            ErrorListOutput = errorListOutput;
             SubAction = subAction;
         }
 
         public bool Equals(StepResult result) =>
-            Successful == result.Successful && Warning == result.Warning && Log == result.Log && SubAction == result.SubAction;
+            Successful == result.Successful && Warning == result.Warning && Log == result.Log && ErrorListOutput == result.ErrorListOutput && SubAction == result.SubAction;
         public override bool Equals(object obj) => obj is StepResult result && Equals(result);
-        public override int GetHashCode() => (Successful, Warning, Log, SubAction).GetHashCode();
+        public override int GetHashCode() => (Successful, Warning, Log, ErrorListOutput, SubAction).GetHashCode();
         public static bool operator ==(StepResult left, StepResult right) => left.Equals(right);
         public static bool operator !=(StepResult left, StepResult right) => !(left == right);
     }

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -182,7 +182,7 @@ namespace VSRAD.Package.Server
         private async Task<StepResult> DoRunActionAsync(RunActionStep step)
         {
             var subActionResult = await RunAsync(step.Name, step.EvaluatedSteps, Enumerable.Empty<BuiltinActionFile>());
-            return new StepResult(subActionResult.Successful, "", "", subAction: subActionResult);
+            return new StepResult(subActionResult.Successful, "", "", subActionResult);
         }
 
         private async Task FillInitialTimestampsAsync(IReadOnlyList<IActionStep> steps, IEnumerable<BuiltinActionFile> auxFiles)

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -162,9 +162,9 @@ namespace VSRAD.Package.Server
             switch (response.Status)
             {
                 case ExecutionStatus.Completed when response.ExitCode == 0:
-                    return new StepResult(true, "", log.ToString());
+                    return new StepResult(true, "", log.ToString(), errorListOutput: new string[] { stdout, stderr });
                 case ExecutionStatus.Completed:
-                    return new StepResult(true, $"{step.Executable} process exited with a non-zero code ({response.ExitCode}). Check your application or debug script output in Output -> RAD Debug.", log.ToString());
+                    return new StepResult(true, $"{step.Executable} process exited with a non-zero code ({response.ExitCode}). Check your application or debug script output in Output -> RAD Debug.", log.ToString(), errorListOutput: new string[] { stdout, stderr });
                 case ExecutionStatus.TimedOut:
                     return new StepResult(false, $"Execution timeout is exceeded. {step.Executable} process on the {machine} machine is terminated.", log.ToString());
                 default:
@@ -182,7 +182,7 @@ namespace VSRAD.Package.Server
         private async Task<StepResult> DoRunActionAsync(RunActionStep step)
         {
             var subActionResult = await RunAsync(step.Name, step.EvaluatedSteps, Enumerable.Empty<BuiltinActionFile>());
-            return new StepResult(subActionResult.Successful, "", "", subActionResult);
+            return new StepResult(subActionResult.Successful, "", "", subAction: subActionResult);
         }
 
         private async Task FillInitialTimestampsAsync(IReadOnlyList<IActionStep> steps, IEnumerable<BuiltinActionFile> auxFiles)

--- a/VSRAD.Package/Server/RemoteCommandExecutor.cs
+++ b/VSRAD.Package/Server/RemoteCommandExecutor.cs
@@ -70,7 +70,7 @@ namespace VSRAD.Package.Server
                 await _outputWriter.PrintMessageAsync($"[{_outputTag}] Captured stdout ({status})", stdout).ConfigureAwait(false);
                 await _outputWriter.PrintMessageAsync($"[{_outputTag}] Captured stderr ({status})", stderr).ConfigureAwait(false);
                 if (_errorListManager != null)
-                    await _errorListManager.AddToErrorListAsync(stderr).ConfigureAwait(false);
+                    await _errorListManager.AddToErrorListAsync(new string[] { stderr }).ConfigureAwait(false);
             }
 
             switch (result.Status)

--- a/VSRAD.PackageTests/BuildTools/BuildToolsServerTest.cs
+++ b/VSRAD.PackageTests/BuildTools/BuildToolsServerTest.cs
@@ -34,7 +34,7 @@ namespace VSRAD.Package.BuildTools
             var deployManager = new Mock<IFileSynchronizationManager>();
             var errorProcessor = new Mock<IBuildErrorProcessor>(MockBehavior.Strict);
             errorProcessor
-                .Setup((e) => e.ExtractMessagesAsync("stderr", It.IsAny<string>()))
+                .Setup((e) => e.ExtractMessagesAsync(new string[] { "stderr" }, It.IsAny<string>()))
                 .Returns(Task.FromResult<IEnumerable<Message>>(Array.Empty<Message>()));
             var server = StartBuildServer(projectMock, channel.Object, deployManager.Object, errorProcessor.Object);
 

--- a/VSRAD.PackageTests/BuildTools/Errors/LineMapperTests.cs
+++ b/VSRAD.PackageTests/BuildTools/Errors/LineMapperTests.cs
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
         [Fact]
         public void ParseErrorsWithPreprocessedTest()
         {
-            var messages = ParseStderr(ErrString);
+            var messages = ParseStderr(new string[] { ErrString });
             UpdateErrorLocations(messages, PpString, new string[] { "source.c", "code.c" });
             Assert.Equal(2, messages.First().Line);
             Assert.Equal("code.c", messages.First().SourceFile);
@@ -92,14 +92,14 @@ int main(int argc, char** argv)
         [Fact]
         public void EmptyLineTest()
         {
-            var messages = ParseStderr(@"
+            var messages = ParseStderr(new string[] { @"
 *E,fatal: undefined reference to 'printf' (<stdin>:3)
 *W,undefined: 1 undefined references found
 *E,syntax error (<stdin>:12): at symbol 'printf'
     parse error: syntax error, unexpected T_PAAMAYIM_NEKUDOTAYIM
     did you really mean to use the scope resolution op here?
 *E,fatal (auth.c:35): Uncaught error: Undefined variable: user
-").ToArray();
+" }).ToArray();
             UpdateErrorLocations(messages, PpString, new string[] { "source.c", "code.c" });
             Assert.Equal(0, messages[1].Line);
 

--- a/VSRAD.PackageTests/BuildTools/Errors/ParserTests.cs
+++ b/VSRAD.PackageTests/BuildTools/Errors/ParserTests.cs
@@ -7,10 +7,7 @@ namespace VSRAD.PackageTests.BuildTools.Errors
 {
     public class ParserTests
     {
-        [Fact]
-        public void ClangErrorTest()
-        {
-            var messages = ParseStderr(@"
+        public const string ClangStderr = @"
 input.s:267:27: error: expected absolute expression
       s_sub_u32         s[loop_xss], s[loop_x], 1
                           ^
@@ -21,7 +18,12 @@ host.c:4:2: warning: implicitly declaring library function 'printf' with type 'i
         printf(""h"");
         ^
 host.c:4:2: note: include the header<stdio.h> or explicitly provide a declaration for 'printf'
-").ToList();
+";
+
+        [Fact]
+        public void ClangErrorTest()
+        {
+            var messages = ParseStderr(new string[] { ClangStderr }).ToList();
 
             Assert.Equal(MessageKind.Error, messages[0].Kind);
             Assert.Equal(27, messages[0].Column);
@@ -77,7 +79,7 @@ host.c:4:2: note: include the header<stdio.h> or explicitly provide a declaratio
         [Fact]
         public void ScriptErrorTest()
         {
-            var messages = ParseStderr(ScriptStderr).ToArray();
+            var messages = ParseStderr(new string[] { ScriptStderr }).ToArray();
             Assert.Equal(ScriptExpectedMessages, messages);
         }
 
@@ -102,8 +104,16 @@ WARNING: you are incredibly beautiful!
         [Fact]
         public void KeywordErrorTest()
         {
-            var messages = ParseStderr(KeywordStderr).ToArray();
+            var messages = ParseStderr(new string[] { KeywordStderr }).ToArray();
             Assert.Equal(KeywordErrorExpectedMessages, messages);
+        }
+
+        [Fact]
+        public void SeveralOutputsErrorTest()
+        {
+            var messages = ParseStderr(new string[] { KeywordStderr, ScriptStderr }).ToArray();
+            var expectedMessages = KeywordErrorExpectedMessages.Concat(ScriptExpectedMessages).ToArray();
+            Assert.Equal(expectedMessages, messages);
         }
     }
 }

--- a/VSRAD.PackageTests/Server/RemoteCommandExecutorTests.cs
+++ b/VSRAD.PackageTests/Server/RemoteCommandExecutorTests.cs
@@ -122,7 +122,7 @@ namespace VSRAD.PackageTests.Server
         private static IErrorListManager MockErrorListManager()
         {
             var errorListManager = new Mock<IErrorListManager>();
-            errorListManager.Setup((m) => m.AddToErrorListAsync("")).Returns(Task.CompletedTask);
+            errorListManager.Setup((m) => m.AddToErrorListAsync(new string[] { })).Returns(Task.CompletedTask);
             return errorListManager.Object;
         }
     }


### PR DESCRIPTION
* fixed regex to detect errors containing windows filepaths
* now the step outputs are parsed (to detect errors) separately for each step