### PR TITLE
Continue action exec on err

### DIFF
--- a/VSRAD.Package/Commands/ActionsMenuCommand.cs
+++ b/VSRAD.Package/Commands/ActionsMenuCommand.cs
@@ -129,7 +129,7 @@ namespace VSRAD.Package.Commands
                 await _deployManager.SynchronizeRemoteAsync().ConfigureAwait(false);
 
                 var runner = new ActionRunner(_channel, _serviceProvider, env);
-                var result = await runner.RunAsync(action.Name, action.Steps, Enumerable.Empty<BuiltinActionFile>()).ConfigureAwait(false);
+                var result = await runner.RunAsync(action.Name, action.Steps, Enumerable.Empty<BuiltinActionFile>(), _project.Options.Profile.General.ContinueActionExecOnError).ConfigureAwait(false);
                 var actionError = await _actionLogger.LogActionWithWarningsAsync(result).ConfigureAwait(false);
                 if (actionError is Error runError)
                     Errors.Show(runError);

--- a/VSRAD.Package/Options/ProfileOptions.cs
+++ b/VSRAD.Package/Options/ProfileOptions.cs
@@ -125,6 +125,9 @@ namespace VSRAD.Package.Options
         private bool _copySources = true;
         public bool CopySources { get => _copySources; set => SetField(ref _copySources, value); }
 
+        private bool _continueActionExecOnError = false;
+        public bool ContinueActionExecOnError { get => _continueActionExecOnError; set => SetField(ref _continueActionExecOnError, value); }
+
         private string _deployDirectory = "$(" + CleanProfileMacros.RemoteWorkDir + ")";
         public string DeployDirectory { get => _deployDirectory; set => SetField(ref _deployDirectory, value); }
 

--- a/VSRAD.Package/ProjectSystem/ActionLogger.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLogger.cs
@@ -57,7 +57,7 @@ namespace VSRAD.Package.ProjectSystem
             for (int i = 0; i < run.Steps.Count; ++i)
             {
                 var step = run.Steps[i];
-                if (prevStepsSucceeded)
+                if (prevStepsSucceeded || run.ContinueOnError)
                 {
                     var result = run.StepResults[i];
                     log.AppendFormat("{0}=> [{1}] {2} {3} in {4}ms\r\n", logIndent, i, step, result.Successful ? "SUCCEEDED" : "FAILED", run.StepRunMillis[i]);

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml
@@ -122,6 +122,7 @@
                                 <RowDefinition Height="26"/>
                                 <RowDefinition Height="26"/>
                                 <RowDefinition Height="26"/>
+                                <RowDefinition Height="26"/>
                             </Grid.RowDefinitions>
                             <Label Content="Profile Name:" VerticalContentAlignment="Center" Margin="0,0" Padding="4,0" Height="22" Grid.Row="0" Grid.Column="0"/>
                             <TextBox Height="22" VerticalContentAlignment="Center" Grid.Row="0" Grid.Column="1">
@@ -181,6 +182,11 @@
                             <TextBox Height="22" VerticalContentAlignment="Center" Grid.Row="7" Grid.Column="1"
                                      Text="{Binding AdditionalSources, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                      ToolTip="Semicolon-separated list of of out-of-project paths to deploy on remote machine" />
+
+                            <Label Content="Continue action execution on errors:" VerticalContentAlignment="Center" Margin="0,0" Padding="4,0" Height="22" Grid.Row="8" Grid.Column="0"/>
+                            <CheckBox VerticalContentAlignment="Center" Height="22" Grid.Row="8" Grid.Column="1"
+                                      IsChecked="{Binding ContinueActionExecOnError, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                      ToolTip="Continue action execution on errors"/>
                         </Grid>
                     </ScrollViewer>
                 </DataTemplate>

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml
@@ -183,10 +183,12 @@
                                      Text="{Binding AdditionalSources, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                      ToolTip="Semicolon-separated list of of out-of-project paths to deploy on remote machine" />
 
-                            <Label Content="Continue action execution on errors:" VerticalContentAlignment="Center" Margin="0,0" Padding="4,0" Height="22" Grid.Row="8" Grid.Column="0"/>
-                            <CheckBox VerticalContentAlignment="Center" Height="22" Grid.Row="8" Grid.Column="1"
+                            <StackPanel Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal">
+                                <Label Content="Continue action execution on errors:" VerticalContentAlignment="Center" Margin="0,0" Padding="4,0" Height="22" HorizontalContentAlignment="Left"/>
+                                <CheckBox VerticalContentAlignment="Center" Height="22"
                                       IsChecked="{Binding ContinueActionExecOnError, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                       ToolTip="Continue action execution on errors"/>
+                            </StackPanel>
                         </Grid>
                     </ScrollViewer>
                 </DataTemplate>

--- a/VSRAD.Package/Server/ActionRunResult.cs
+++ b/VSRAD.Package/Server/ActionRunResult.cs
@@ -17,6 +17,7 @@ namespace VSRAD.Package.Server
         public StepResult[] StepResults { get; }
 
         public bool Successful => StepResults.All(r => r.Successful);
+        public bool ContinueOnError;
 
         private readonly Stopwatch _stopwatch;
         private long _lastRecordedTime;

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -59,7 +59,7 @@ namespace VSRAD.Package.Server
                         throw new NotImplementedException();
                 }
                 runStats.RecordStep(i, result);
-                if (!result.Successful)
+                if (!result.Successful)         // TODO: insert check continue on error check?
                     break;
             }
 

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -164,7 +164,7 @@ namespace VSRAD.Package.Server
                 case ExecutionStatus.Completed when response.ExitCode == 0:
                     return new StepResult(true, "", log.ToString(), errorListOutput: new string[] { stdout, stderr });
                 case ExecutionStatus.Completed:
-                    return new StepResult(true, $"{step.Executable} process exited with a non-zero code ({response.ExitCode}). Check your application or debug script output in Output -> RAD Debug.", log.ToString(), errorListOutput: new string[] { stdout, stderr });
+                    return new StepResult(false, $"{step.Executable} process exited with a non-zero code ({response.ExitCode}). Check your application or debug script output in Output -> RAD Debug.", log.ToString(), errorListOutput: new string[] { stdout, stderr });
                 case ExecutionStatus.TimedOut:
                     return new StepResult(false, $"Execution timeout is exceeded. {step.Executable} process on the {machine} machine is terminated.", log.ToString());
                 default:

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -34,6 +34,7 @@ namespace VSRAD.Package.Server
         public async Task<ActionRunResult> RunAsync(string actionName, IReadOnlyList<IActionStep> steps, IEnumerable<BuiltinActionFile> auxFiles, bool continueOnError)
         {
             var runStats = new ActionRunResult(actionName, steps);
+            runStats.ContinueOnError = continueOnError;
 
             await FillInitialTimestampsAsync(steps, auxFiles);
             runStats.RecordInitTimestampFetch();

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -31,7 +31,7 @@ namespace VSRAD.Package.Server
         public DateTime GetInitialFileTimestamp(string file) =>
             _initialTimestamps.TryGetValue(file, out var timestamp) ? timestamp : default;
 
-        public async Task<ActionRunResult> RunAsync(string actionName, IReadOnlyList<IActionStep> steps, IEnumerable<BuiltinActionFile> auxFiles, bool continueOnError)
+        public async Task<ActionRunResult> RunAsync(string actionName, IReadOnlyList<IActionStep> steps, IEnumerable<BuiltinActionFile> auxFiles, bool continueOnError = true)
         {
             var runStats = new ActionRunResult(actionName, steps);
             runStats.ContinueOnError = continueOnError;

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -31,7 +31,7 @@ namespace VSRAD.Package.Server
         public DateTime GetInitialFileTimestamp(string file) =>
             _initialTimestamps.TryGetValue(file, out var timestamp) ? timestamp : default;
 
-        public async Task<ActionRunResult> RunAsync(string actionName, IReadOnlyList<IActionStep> steps, IEnumerable<BuiltinActionFile> auxFiles)
+        public async Task<ActionRunResult> RunAsync(string actionName, IReadOnlyList<IActionStep> steps, IEnumerable<BuiltinActionFile> auxFiles, bool continueOnError)
         {
             var runStats = new ActionRunResult(actionName, steps);
 
@@ -53,13 +53,13 @@ namespace VSRAD.Package.Server
                         result = await DoOpenInEditorAsync(openInEditor);
                         break;
                     case RunActionStep runAction:
-                        result = await DoRunActionAsync(runAction);
+                        result = await DoRunActionAsync(runAction, continueOnError);
                         break;
                     default:
                         throw new NotImplementedException();
                 }
                 runStats.RecordStep(i, result);
-                if (!result.Successful)         // TODO: insert check continue on error check?
+                if (!result.Successful && !continueOnError)
                     break;
             }
 
@@ -179,9 +179,9 @@ namespace VSRAD.Package.Server
             return new StepResult(true, "", "");
         }
 
-        private async Task<StepResult> DoRunActionAsync(RunActionStep step)
+        private async Task<StepResult> DoRunActionAsync(RunActionStep step, bool continueOnError)
         {
-            var subActionResult = await RunAsync(step.Name, step.EvaluatedSteps, Enumerable.Empty<BuiltinActionFile>());
+            var subActionResult = await RunAsync(step.Name, step.EvaluatedSteps, Enumerable.Empty<BuiltinActionFile>(), continueOnError);
             return new StepResult(subActionResult.Successful, "", "", subActionResult);
         }
 

--- a/VSRAD.Package/Server/DebugSession.cs
+++ b/VSRAD.Package/Server/DebugSession.cs
@@ -46,7 +46,7 @@ namespace VSRAD.Package.Server
 
             var runner = new ActionRunner(_channel, _serviceProvider, env);
             var auxFiles = new[] { options.OutputFile, options.WatchesFile, options.StatusFile };
-            var result = await runner.RunAsync(ActionProfileOptions.BuiltinActionDebug, options.Steps, auxFiles).ConfigureAwait(false);
+            var result = await runner.RunAsync(ActionProfileOptions.BuiltinActionDebug, options.Steps, auxFiles, _project.Options.Profile.General.ContinueActionExecOnError).ConfigureAwait(false);
 
             if (!result.Successful && !_project.Options.Profile.General.ContinueActionExecOnError)
                 return new DebugRunResult(result, null, null);

--- a/VSRAD.Package/Server/DebugSession.cs
+++ b/VSRAD.Package/Server/DebugSession.cs
@@ -48,7 +48,7 @@ namespace VSRAD.Package.Server
             var auxFiles = new[] { options.OutputFile, options.WatchesFile, options.StatusFile };
             var result = await runner.RunAsync(ActionProfileOptions.BuiltinActionDebug, options.Steps, auxFiles).ConfigureAwait(false);
 
-            if (!result.Successful)
+            if (!result.Successful && !_project.Options.Profile.General.ContinueActionExecOnError)
                 return new DebugRunResult(result, null, null);
 
             var fetchCommands = new List<ICommand>();

--- a/VSRAD.PackageTests/Server/DebugSessionTests.cs
+++ b/VSRAD.PackageTests/Server/DebugSessionTests.cs
@@ -67,7 +67,7 @@ namespace VSRAD.PackageTests.Server
 
             var session = new DebugSession(project, channel.Object, new Mock<IFileSynchronizationManager>().Object, null);
             var result = await session.ExecuteAsync(new[] { 13u }, new ReadOnlyCollection<string>(new[] { "jill", "julianne" }.ToList()));
-            Assert.True(channel.AllInteractionsHandled);
+            Assert.False(channel.AllInteractionsHandled);
             Assert.Null(result.Error);
             Assert.Equal("va11 process exited with a non-zero code (33). Check your application or debug script output in Output -> RAD Debug.", result.ActionResult.StepResults[0].Warning);
         }


### PR DESCRIPTION
Added `Continue action execution on errors` checkbox.

If enabled: on any step non-zero exit code user gets warning, however further steps is trying to be executed
If disabled: on any step non-zero exit code user gets error and action execution stops