### PR TITLE
[Syntax] fixed quick info token line text description for multiple to…

### DIFF
--- a/VSRAD.Syntax/IntelliSense/IntellisenseTokenDescription.cs
+++ b/VSRAD.Syntax/IntelliSense/IntellisenseTokenDescription.cs
@@ -62,11 +62,15 @@ namespace VSRAD.Syntax.IntelliSense
                     var navigationToken = token.NavigationToken;
                     var analysisToken = navigationToken.AnalysisToken;
                     var typeName = analysisToken.Type.GetName();
+
+                    var spanBeforeToken = new SnapshotSpan(token.Line.Start, navigationToken.GetStart());
+                    var spanAfterToken = new SnapshotSpan(navigationToken.GetEnd(), token.Line.End);
                     elements.Add(new ClassifiedTextElement(new ClassifiedTextRun[]
                     {
                         new ClassifiedTextRun(RadAsmTokenType.Identifier.GetClassificationTypeName(), $"({typeName}) "),
+                        new ClassifiedTextRun(RadAsmTokenType.Structural.GetClassificationTypeName(), $"{spanBeforeToken.GetText()}"),
                         GetNameElement(navigationToken),
-                        new ClassifiedTextRun(RadAsmTokenType.Structural.GetClassificationTypeName(), $": {token.LineText}"),
+                        new ClassifiedTextRun(RadAsmTokenType.Structural.GetClassificationTypeName(), $"{spanAfterToken.GetText()}"),
                     }));
                 }
 
@@ -174,7 +178,7 @@ namespace VSRAD.Syntax.IntelliSense
             else if (type == RadAsmTokenType.Instruction)
             {
                 var definition = new DefinitionToken(token);
-                description = definition.LineText;
+                description = definition.Line.GetText();
             }
 
             return description;

--- a/VSRAD.Syntax/IntelliSense/Navigation/NavigationList/DefinitionToken.cs
+++ b/VSRAD.Syntax/IntelliSense/Navigation/NavigationList/DefinitionToken.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using Microsoft.VisualStudio.Text;
+using System.Text;
 using VSRAD.Syntax.Parser;
 
 namespace VSRAD.Syntax.IntelliSense.Navigation.NavigationList
@@ -7,8 +8,8 @@ namespace VSRAD.Syntax.IntelliSense.Navigation.NavigationList
     {
         public NavigationToken NavigationToken { get; }
         public string FilePath { get; }
-        public int LineNumber { get; }
-        public string LineText { get; }
+        public int LineNumber => Line.LineNumber;
+        public ITextSnapshotLine Line { get; }
 
         public DefinitionToken(NavigationToken navigationToken)
         {
@@ -22,9 +23,7 @@ namespace VSRAD.Syntax.IntelliSense.Navigation.NavigationList
                 FilePath = null;
             }
 
-            var line = NavigationToken.Snapshot.GetLineFromPosition(NavigationToken.AnalysisToken.TrackingToken.GetStart(NavigationToken.Snapshot));
-            LineNumber = line.LineNumber;
-            LineText = line.GetText();
+            Line = NavigationToken.Snapshot.GetLineFromPosition(NavigationToken.AnalysisToken.TrackingToken.GetStart(NavigationToken.Snapshot));
         }
 
         public override string ToString()
@@ -39,7 +38,7 @@ namespace VSRAD.Syntax.IntelliSense.Navigation.NavigationList
             sb.Append(LineNumber + 1);
             sb.Append("): ");
 
-            sb.Append(LineText);
+            sb.Append(Line.GetText());
             return sb.ToString();
         }
     }

--- a/VSRAD.Syntax/IntelliSense/Navigation/NavigationList/NavigationListItem.cs
+++ b/VSRAD.Syntax/IntelliSense/Navigation/NavigationList/NavigationListItem.cs
@@ -18,7 +18,7 @@ namespace VSRAD.Syntax.IntelliSense.Navigation.NavigationList
     {
         public DefinitionToken DefinitionToken { get; }
         public NavigationListDefinitionItem(DefinitionToken definitionToken) 
-            : base($"{definitionToken.LineNumber + 1}: {definitionToken.LineText}")
+            : base($"{definitionToken.LineNumber + 1}: {definitionToken.Line.GetText()}")
         {
             DefinitionToken = definitionToken;
         }

--- a/VSRAD.Syntax/IntelliSense/Navigation/NavigationToken.cs
+++ b/VSRAD.Syntax/IntelliSense/Navigation/NavigationToken.cs
@@ -16,8 +16,11 @@ namespace VSRAD.Syntax.IntelliSense.Navigation
             Snapshot = version;
         }
 
-        public int GetEnd() =>
-            AnalysisToken.TrackingToken.GetEnd(Snapshot);
+        public SnapshotPoint GetStart() =>
+            new SnapshotPoint(Snapshot, AnalysisToken.TrackingToken.GetStart(Snapshot));
+
+        public SnapshotPoint GetEnd() =>
+            new SnapshotPoint(Snapshot, AnalysisToken.TrackingToken.GetEnd(Snapshot));
 
         public string GetText() =>
             AnalysisToken.TrackingToken.GetText(Snapshot);

--- a/VSRAD.Syntax/IntelliSense/Navigation/NavigationTokenService.cs
+++ b/VSRAD.Syntax/IntelliSense/Navigation/NavigationTokenService.cs
@@ -100,7 +100,7 @@ namespace VSRAD.Syntax.IntelliSense
         public void GoToPoint(NavigationToken point)
         {
             if (point != NavigationToken.Empty)
-                GoToPoint(new SnapshotPoint(point.Snapshot, point.GetEnd()));
+                GoToPoint(point.GetEnd());
         }
 
         public IReadOnlyList<NavigationToken> GetNaviationItem(TextExtent extent, bool searchWithInclude = false)


### PR DESCRIPTION
The previous format of quick info with multiple tokens was:
 > (instruction) **instruction_name**: instruction_name parameters ... (line text is used)

Currently only line text is used, but with token highlighting in that line:
> (instruction) **instruction_name** parameters ...

Example:
<img width="449" alt="Capture" src="https://user-images.githubusercontent.com/40007198/89110852-9ed19500-d457-11ea-8d73-9dbd530d024f.PNG">

