### PR TITLE
fixed no data source in this context error

### DIFF
--- a/VSRAD.Package/BuildSystem/Rules/RADDebugger.xaml
+++ b/VSRAD.Package/BuildSystem/Rules/RADDebugger.xaml
@@ -5,4 +5,7 @@
 	DisplayName="RAD Debugger"
 	Description="RAD Debugger"
 	xmlns="http://schemas.microsoft.com/build/2009/properties">
+    <Rule.DataSource>
+        <DataSource Persistence="UserFile" />
+    </Rule.DataSource>
 </Rule>


### PR DESCRIPTION
Addresses #147 

Fixes "No data source in this context" error when using RAD debugger in VisualC projects.

Note that you'll have to copy new version of `RADDebugger.xaml` to the `ImportAfter/` directory to apply the fix