### PR TITLE
Prevent configuration file corruption

### DIFF
--- a/VSRAD.Package/Options/ProjectOptions.cs
+++ b/VSRAD.Package/Options/ProjectOptions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Windows.Forms;
 using VSRAD.Package.ProjectSystem.Profiles;
 using VSRAD.Package.Utils;
@@ -95,11 +96,12 @@ namespace VSRAD.Package.Options
 
         public void Write(string path)
         {
+            var serializedOptions = JsonConvert.SerializeObject(this, Formatting.Indented);
             try
             {
-                File.WriteAllText(path, JsonConvert.SerializeObject(this, Formatting.Indented));
+                WriteAtomic(path, serializedOptions);
             }
-            catch (UnauthorizedAccessException e)
+            catch (UnauthorizedAccessException)
             {
                 DialogResult res = MessageBox.Show($"RAD Debug is unable to save configuration, because {path} is read-only. Make it writable?", "Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
                 if (res == DialogResult.OK)
@@ -113,12 +115,37 @@ namespace VSRAD.Package.Options
                         Errors.ShowWarning("Cannot make file writable: " + ex.Message);
                         return;
                     }
-                    File.WriteAllText(path, JsonConvert.SerializeObject(this, Formatting.Indented));
+                    WriteAtomic(path, serializedOptions);
                 }
             }
             catch (SystemException e)
             {
                 Errors.ShowWarning("Project options could not be saved: " + e.Message);
+            }
+        }
+
+        private static void WriteAtomic(string destPath, string contents)
+        {
+            // Source and destination files for File.Replace need to be located on the same volume,
+            // and since the project can be located anywhere, we can't use Path.GetTempFileName
+            var tmpPath = destPath + ".tmp";
+
+            // Specify WriteThrough to skip caching and write directly to disk
+            using (var tmp = File.Create(tmpPath, 4096, FileOptions.WriteThrough))
+            {
+                var data = Encoding.UTF8.GetBytes(contents);
+                tmp.Write(data, 0, data.Length);
+            }
+
+            try
+            {
+                // Atomically replace file contents
+                File.Replace(tmpPath, destPath, null);
+            }
+            catch (FileNotFoundException)
+            {
+                // Destination file does not exist
+                File.Move(tmpPath, destPath);
             }
         }
         #endregion


### PR DESCRIPTION
Resolves #154 

Currently, project configuration is saved using `File.WriteAllText`, which does not flush file contents to disk, so a system hang/crash can leave the file in a corrupted state (filled with zero bytes).

To ensure that the configuration file always remains in a valid state, we first create a temporary file (`.conf.json.tmp`), then rename it to `.conf.json` after the data is written to disk.