### PR TITLE
Status file

### DIFF
--- a/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
@@ -42,7 +42,7 @@ namespace VSRAD.Package.DebugVisualizer
             if (system == null)
                 return;
 
-            var wfrontSize = options.WaveSize;
+            var wfrontSize = Math.Min(options.WaveSize, GroupSize);
             for (int wfrontOffset = 0; wfrontOffset < GroupSize; wfrontOffset += (int)wfrontSize)
             {
                 if (options.CheckMagicNumber && system[wfrontOffset] != options.MagicNumber)

--- a/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
@@ -42,7 +42,7 @@ namespace VSRAD.Package.DebugVisualizer
             if (system == null)
                 return;
 
-            var wfrontSize = options.WaveSize;
+            var wfrontSize = options.WaveSize == 0 ? 64 : options.WaveSize;
             for (int wfrontOffset = 0; wfrontOffset < GroupSize; wfrontOffset += (int)wfrontSize)
             {
                 if (options.CheckMagicNumber && system[wfrontOffset] != options.MagicNumber)

--- a/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
@@ -42,7 +42,7 @@ namespace VSRAD.Package.DebugVisualizer
             if (system == null)
                 return;
 
-            var wfrontSize = options.WaveSize == 0 ? 64 : options.WaveSize;
+            var wfrontSize = options.WaveSize;
             for (int wfrontOffset = 0; wfrontOffset < GroupSize; wfrontOffset += (int)wfrontSize)
             {
                 if (options.CheckMagicNumber && system[wfrontOffset] != options.MagicNumber)

--- a/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
@@ -42,8 +42,8 @@ namespace VSRAD.Package.DebugVisualizer
             if (system == null)
                 return;
 
-            var wfrontSize = Math.Min(64, GroupSize);
-            for (int wfrontOffset = 0; wfrontOffset < GroupSize; wfrontOffset += 64)
+            var wfrontSize = options.WaveSize;
+            for (int wfrontOffset = 0; wfrontOffset < GroupSize; wfrontOffset += (int)wfrontSize)
             {
                 if (options.CheckMagicNumber && system[wfrontOffset] != options.MagicNumber)
                 {

--- a/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
+++ b/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
@@ -79,21 +79,24 @@ namespace VSRAD.Package.DebugVisualizer
 
         public void UpdateOnBreak(BreakState breakState)
         {
-            _updateOptions = false;
+            if (!string.IsNullOrEmpty(_projectOptions.Profile.Debugger.StatusFile.Path))
+            {
+                _updateOptions = false;
 
-            _projectOptions.VisualizerOptions.NDRange3D = breakState.NDRange3D;
-            _projectOptions.VisualizerOptions.WaveSize = breakState.WaveSize;
+                _projectOptions.VisualizerOptions.NDRange3D = breakState.NDRange3D;
+                _projectOptions.VisualizerOptions.WaveSize = breakState.WaveSize;
 
-            DimX = breakState.DimX;
-            DimY = breakState.DimY;
-            DimZ = breakState.DimZ;
+                DimX = breakState.DimX;
+                DimY = breakState.DimY;
+                DimZ = breakState.DimZ;
 
-            _projectOptions.DebuggerOptions.NGroups = breakState.NDRange3D
-                ? breakState.DimX * breakState.DimY * breakState.DimZ
-                : breakState.DimX;
-            _projectOptions.DebuggerOptions.GroupSize = breakState.GroupSize;
+                _projectOptions.DebuggerOptions.NGroups = breakState.NDRange3D
+                    ? breakState.DimX * breakState.DimY * breakState.DimZ
+                    : breakState.DimX;
+                _projectOptions.DebuggerOptions.GroupSize = breakState.GroupSize;
 
-            _updateOptions = true;
+                _updateOptions = true;
+            }
             Update();
         }
 

--- a/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
+++ b/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
@@ -52,6 +52,8 @@ namespace VSRAD.Package.DebugVisualizer
         private string _error;
         public bool HasErrors => _error != null;
 
+        private bool _updateOptions = true;
+
         private readonly Options.ProjectOptions _projectOptions;
 
         public GroupIndexSelector(Options.ProjectOptions options)
@@ -69,7 +71,7 @@ namespace VSRAD.Package.DebugVisualizer
                 {
                     case nameof(Options.DebuggerOptions.GroupSize):
                     case nameof(Options.DebuggerOptions.NGroups):
-                        Update();
+                        if (_updateOptions) Update();
                         break;
                 }
             };
@@ -77,16 +79,20 @@ namespace VSRAD.Package.DebugVisualizer
 
         public void UpdateOnBreak(BreakState breakState)
         {
+            _updateOptions = false;
+
             _projectOptions.VisualizerOptions.NDRange3D = breakState.NDRange3D;
 
             _dimX = breakState.DimX;
             _dimY = breakState.DimY;
             _dimZ = breakState.DimZ;
 
-            // assign NGroups after all others because it calls Update()
             _projectOptions.DebuggerOptions.NGroups = breakState.NDRange3D
                 ? breakState.DimX * breakState.DimY * breakState.DimZ
                 : breakState.DimX;
+            _projectOptions.DebuggerOptions.GroupSize = breakState.GroupSize;
+
+            _updateOptions = true;
             // TODO: handle wavesize
             Update();
         }

--- a/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
+++ b/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
@@ -83,9 +83,9 @@ namespace VSRAD.Package.DebugVisualizer
 
             _projectOptions.VisualizerOptions.NDRange3D = breakState.NDRange3D;
 
-            _dimX = breakState.DimX;
-            _dimY = breakState.DimY;
-            _dimZ = breakState.DimZ;
+            DimX = breakState.DimX;
+            DimY = breakState.DimY;
+            DimZ = breakState.DimZ;
 
             _projectOptions.DebuggerOptions.NGroups = breakState.NDRange3D
                 ? breakState.DimX * breakState.DimY * breakState.DimZ
@@ -129,7 +129,7 @@ namespace VSRAD.Package.DebugVisualizer
 
             field = value;
 
-            Update();
+            if (_updateOptions) Update();
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
             return true;

--- a/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
+++ b/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using VSRAD.Package.Server;
 
 namespace VSRAD.Package.DebugVisualizer
 {
@@ -72,6 +73,22 @@ namespace VSRAD.Package.DebugVisualizer
                         break;
                 }
             };
+        }
+
+        public void UpdateOnBreak(BreakState breakState)
+        {
+            _projectOptions.VisualizerOptions.NDRange3D = breakState.NDRange3D;
+
+            _dimX = breakState.DimX;
+            _dimY = breakState.DimY;
+            _dimZ = breakState.DimZ;
+
+            // assign NGroups after all others because it calls Update()
+            _projectOptions.DebuggerOptions.NGroups = breakState.NDRange3D
+                ? breakState.DimX * breakState.DimY * breakState.DimZ
+                : breakState.DimX;
+            // TODO: handle wavesize
+            Update();
         }
 
         private uint LimitIndex(uint index, uint limit) =>

--- a/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
+++ b/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
@@ -82,6 +82,7 @@ namespace VSRAD.Package.DebugVisualizer
             _updateOptions = false;
 
             _projectOptions.VisualizerOptions.NDRange3D = breakState.NDRange3D;
+            _projectOptions.VisualizerOptions.WaveSize = breakState.WaveSize;
 
             DimX = breakState.DimX;
             DimY = breakState.DimY;
@@ -93,7 +94,6 @@ namespace VSRAD.Package.DebugVisualizer
             _projectOptions.DebuggerOptions.GroupSize = breakState.GroupSize;
 
             _updateOptions = true;
-            // TODO: handle wavesize
             Update();
         }
 

--- a/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
+++ b/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
@@ -79,21 +79,21 @@ namespace VSRAD.Package.DebugVisualizer
 
         public void UpdateOnBreak(BreakState breakState)
         {
-            if (!string.IsNullOrEmpty(_projectOptions.Profile.Debugger.StatusFile.Path))
+            if (breakState.DispatchParameters is BreakStateDispatchParameters dispatchParams)
             {
                 _updateOptions = false;
 
-                _projectOptions.VisualizerOptions.NDRange3D = breakState.NDRange3D;
-                _projectOptions.VisualizerOptions.WaveSize = breakState.WaveSize;
+                _projectOptions.VisualizerOptions.NDRange3D = dispatchParams.NDRange3D;
+                _projectOptions.VisualizerOptions.WaveSize = dispatchParams.WaveSize;
 
-                DimX = breakState.DimX;
-                DimY = breakState.DimY;
-                DimZ = breakState.DimZ;
+                DimX = dispatchParams.DimX;
+                DimY = dispatchParams.DimY;
+                DimZ = dispatchParams.DimZ;
 
-                _projectOptions.DebuggerOptions.NGroups = breakState.NDRange3D
-                    ? breakState.DimX * breakState.DimY * breakState.DimZ
-                    : breakState.DimX;
-                _projectOptions.DebuggerOptions.GroupSize = breakState.GroupSize;
+                _projectOptions.DebuggerOptions.NGroups = dispatchParams.NDRange3D
+                    ? dispatchParams.DimX * dispatchParams.DimY * dispatchParams.DimZ
+                    : dispatchParams.DimX;
+                _projectOptions.DebuggerOptions.GroupSize = dispatchParams.GroupSize;
 
                 _updateOptions = true;
             }

--- a/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
@@ -95,7 +95,7 @@ namespace VSRAD.Package.DebugVisualizer
                 e.DataGroupCount, _breakState.ExecutedAt.ToString("HH:mm:ss"), _breakState.TotalElapsedMilliseconds, _breakState.ExecElapsedMilliseconds);
             if (!string.IsNullOrEmpty(_breakState.StatusString))
             {
-                status.Append(", status:");
+                status.Append(", status: ");
                 status.Append(_breakState.StatusString);
             }
             Status = status.ToString();

--- a/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
@@ -60,25 +60,7 @@ namespace VSRAD.Package.DebugVisualizer
             _breakState = breakState;
             WatchesValid = breakState != null;
             if (WatchesValid)
-            {
-                UpdateProjectState(breakState);
-                GroupIndex.Update();
-            }
-        }
-
-        private void UpdateProjectState(BreakState breakState)
-        {
-            Options.VisualizerOptions.NDRange3D = breakState.NDRange3D;
-
-            Options.DebuggerOptions.GroupSize = breakState.DimX;
-            GroupIndex.DimX = breakState.DimX;
-            GroupIndex.DimY = breakState.DimY;
-            GroupIndex.DimZ = breakState.DimZ;
-
-            Options.DebuggerOptions.NGroups = breakState.NDRange3D
-                ? breakState.DimX * breakState.DimY * breakState.DimZ
-                : breakState.DimX;
-            // TODO: handle wavesize
+                GroupIndex.UpdateOnBreak(breakState);
         }
 
         private void GroupIndexChanged(object sender, GroupIndexChangedEventArgs e)

--- a/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
@@ -93,10 +93,10 @@ namespace VSRAD.Package.DebugVisualizer
             var status = new StringBuilder();
             status.AppendFormat("{0} groups, last run at {1}, total: {2}ms, execute: {3}ms",
                 e.DataGroupCount, _breakState.ExecutedAt.ToString("HH:mm:ss"), _breakState.TotalElapsedMilliseconds, _breakState.ExecElapsedMilliseconds);
-            if (!string.IsNullOrEmpty(_breakState.StatusString))
+            if (_breakState.DispatchParameters?.StatusString is string statusStr && statusStr.Length != 0)
             {
                 status.Append(", status: ");
-                status.Append(_breakState.StatusString);
+                status.Append(statusStr);
             }
             Status = status.ToString();
             GroupIndexEditable = true;

--- a/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Text;
 using System.Threading.Tasks;
-using System.Xml.Serialization;
 using VSRAD.Package.ProjectSystem;
 using VSRAD.Package.Server;
 using VSRAD.Package.Utils;
@@ -60,22 +58,27 @@ namespace VSRAD.Package.DebugVisualizer
         private void EnterBreak(BreakState breakState)
         {
             _breakState = breakState;
-            UpdateProjectState(breakState);
             WatchesValid = breakState != null;
             if (WatchesValid)
+            {
+                UpdateProjectState(breakState);
                 GroupIndex.Update();
+            }
         }
 
         private void UpdateProjectState(BreakState breakState)
         {
-            if (breakState == null) return;
+            Options.VisualizerOptions.NDRange3D = breakState.NDRange3D;
 
-            Options.VisualizerOptions.NDRange3D = breakState.GridY != 0 && breakState.GridZ != 0;
-            Options.DebuggerOptions.GroupSize = breakState.GroupX;
-            GroupIndex.DimX = breakState.GridX;
-            GroupIndex.DimY = breakState.GridY;
-            GroupIndex.DimZ = breakState.GridZ;
-            // TODO: handle 3d group sizes and wavesize
+            Options.DebuggerOptions.GroupSize = breakState.DimX;
+            GroupIndex.DimX = breakState.DimX;
+            GroupIndex.DimY = breakState.DimY;
+            GroupIndex.DimZ = breakState.DimZ;
+
+            Options.DebuggerOptions.NGroups = breakState.NDRange3D
+                ? breakState.DimX * breakState.DimY * breakState.DimZ
+                : breakState.DimX;
+            // TODO: handle wavesize
         }
 
         private void GroupIndexChanged(object sender, GroupIndexChangedEventArgs e)

--- a/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml.Serialization;
 using VSRAD.Package.ProjectSystem;
 using VSRAD.Package.Server;
 using VSRAD.Package.Utils;
@@ -59,9 +60,22 @@ namespace VSRAD.Package.DebugVisualizer
         private void EnterBreak(BreakState breakState)
         {
             _breakState = breakState;
+            UpdateProjectState(breakState);
             WatchesValid = breakState != null;
             if (WatchesValid)
                 GroupIndex.Update();
+        }
+
+        private void UpdateProjectState(BreakState breakState)
+        {
+            if (breakState == null) return;
+
+            Options.VisualizerOptions.NDRange3D = breakState.GridY != 0 && breakState.GridZ != 0;
+            Options.DebuggerOptions.GroupSize = breakState.GroupX;
+            GroupIndex.DimX = breakState.GridX;
+            GroupIndex.DimY = breakState.GridY;
+            GroupIndex.DimZ = breakState.GridZ;
+            // TODO: handle 3d group sizes and wavesize
         }
 
         private void GroupIndexChanged(object sender, GroupIndexChangedEventArgs e)

--- a/VSRAD.Package/Options/VisualizerOptions.cs
+++ b/VSRAD.Package/Options/VisualizerOptions.cs
@@ -26,7 +26,7 @@ namespace VSRAD.Package.Options
         public uint LaneGrouping { get =>  _laneGrouping; set => SetField(ref _laneGrouping, value); }
 
         private uint _waveSize = 64;
-        public uint WaveSize { get => _waveSize; set => SetField(ref _waveSize, value); }
+        public uint WaveSize { get => _waveSize; set => SetField(ref _waveSize, Math.Max(value, 1)); }  // < 1 causes VS hang
 
         private bool _checkMagicNumber = true;
         public bool CheckMagicNumber { get => _checkMagicNumber; set => SetField(ref _checkMagicNumber, value); }

--- a/VSRAD.Package/Options/VisualizerOptions.cs
+++ b/VSRAD.Package/Options/VisualizerOptions.cs
@@ -25,6 +25,9 @@ namespace VSRAD.Package.Options
         private uint _laneGrouping = 0;
         public uint LaneGrouping { get =>  _laneGrouping; set => SetField(ref _laneGrouping, value); }
 
+        private uint _waveSize = 64;
+        public uint WaveSize { get => _waveSize; set => SetField(ref _waveSize, value); }
+
         private bool _checkMagicNumber = true;
         public bool CheckMagicNumber { get => _checkMagicNumber; set => SetField(ref _checkMagicNumber, value); }
 

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -37,11 +37,11 @@ namespace VSRAD.Package.Server
                 var groupY = uint.Parse(match.Groups["gp_y"].Value);
                 var groupZ = uint.Parse(match.Groups["gp_z"].Value);
 
+                NDRange3D = gridY != 0 && gridZ != 0;
                 GroupSize = groupX;
                 DimX = gridX / groupX;
-                DimY = gridY / groupY;
-                DimZ = gridZ / groupZ;
-                NDRange3D = gridY != 0 && gridZ != 0;
+                DimY = NDRange3D ? gridY / groupY : 0;
+                DimZ = NDRange3D ? gridZ / groupZ : 0;
                 WaveSize = uint.Parse(match.Groups["wv"].Value);
                 StatusString = match.Groups["comment"].Value;
             }

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -15,6 +15,7 @@ namespace VSRAD.Package.Server
         public uint DimX { get; }
         public uint DimY { get; }
         public uint DimZ { get; }
+        public uint GroupSize { get; } // TODO: handle 3d group sizes
         public bool NDRange3D { get; }
 
         private static readonly Regex StatusFileRegex = new Regex(@"grid size \((?<gd_x>\d+), (?<gd_y>\d+), (?<gd_z>\d+)\)\s+group size \((?<gp_x>\d+), (?<gp_y>\d+), (?<gp_z>\d+)\)\s+wave size (?<wv>\d+)\s+comment (?<comment>.+)", RegexOptions.Compiled);
@@ -36,6 +37,7 @@ namespace VSRAD.Package.Server
                 var groupY = uint.Parse(match.Groups["gp_y"].Value);
                 var groupZ = uint.Parse(match.Groups["gp_z"].Value);
 
+                GroupSize = groupX;
                 DimX = gridX / groupX;
                 DimY = gridY / groupY;
                 DimZ = gridZ / groupZ;

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -1,95 +1,21 @@
 ﻿using System;
-using System.Text.RegularExpressions;
-using VSRAD.Package.Utils;
 
 namespace VSRAD.Package.Server
 {
     public sealed class BreakState
     {
         public BreakStateData Data { get; }
+        public BreakStateDispatchParameters DispatchParameters { get; }
         public long TotalElapsedMilliseconds { get; }
-        public long ExecElapsedMilliseconds { get; }
-        public string StatusString { get; }
-        public int ExitCode { get; }
+        public long ExecElapsedMilliseconds { get; } = 0; // TODO: is this obsolete?
+        public int ExitCode { get; } = 0; // TODO: is this obsolete?
         public DateTime ExecutedAt { get; } = DateTime.Now;
-        public uint WaveSize { get; }
-        public uint DimX { get; }
-        public uint DimY { get; }
-        public uint DimZ { get; }
-        public uint GroupSize { get; } // TODO: handle 3d group sizes
-        public bool NDRange3D { get; }
-        public bool StatusFileSet { get; }
 
-        private static readonly Regex StatusFileRegex = new Regex(@"grid size \((?<gd_x>\d+), (?<gd_y>\d+), (?<gd_z>\d+)\)\s+group size \((?<gp_x>\d+), (?<gp_y>\d+), (?<gp_z>\d+)\)\s+wave size (?<wv>\d+)\s+comment (?<comment>.+)", RegexOptions.Compiled);
-       
-        private BreakState(BreakStateData breakStateData, long totalElapsedMilliseconds, bool statusFileSet,
-            uint waveSize = 0, uint dimX = 0, uint dimY = 0, uint dimZ = 0, uint groupSize = 0, bool ndRange3d = false, string status = "")
+        public BreakState(BreakStateData breakStateData, BreakStateDispatchParameters dispatchParameters, long totalElapsedMilliseconds)
         {
             Data = breakStateData;
+            DispatchParameters = dispatchParameters;
             TotalElapsedMilliseconds = totalElapsedMilliseconds;
-            ExecElapsedMilliseconds = 0;
-            ExitCode = 0;
-            StatusFileSet = statusFileSet;
-
-            if (statusFileSet)
-            {
-                WaveSize = waveSize;
-                DimX = dimX;
-                DimY = dimY;
-                DimZ = dimZ;
-                GroupSize = groupSize;
-                NDRange3D = ndRange3d;
-                StatusString = status;
-            }
-        }
-
-        public static Result<BreakState> Create(BreakStateData breakStateData, long totalElapsedMilliseconds, string statusFileContents)
-        {
-            var match = StatusFileRegex.Match(statusFileContents);
-
-            if (!match.Success)
-            {
-                if (!string.IsNullOrEmpty(statusFileContents))
-                    return new Error("Could not set dispatch parameters from the status file. Make sure that the status file contents match the format.");
-                return new BreakState(breakStateData, totalElapsedMilliseconds, statusFileSet: false);
-            }
-
-            var gridX = uint.Parse(match.Groups["gd_x"].Value);
-            var gridY = uint.Parse(match.Groups["gd_y"].Value);
-            var gridZ = uint.Parse(match.Groups["gd_z"].Value);
-            var groupX = uint.Parse(match.Groups["gp_x"].Value);
-            var groupY = uint.Parse(match.Groups["gp_y"].Value);
-            var groupZ = uint.Parse(match.Groups["gp_z"].Value);
-            var waveSize = uint.Parse(match.Groups["wv"].Value);
-            var ndRange3D = gridY != 0 && gridZ != 0;
-            var statusString = match.Groups["comment"].Value;
-
-            if (groupX == 0)
-                return new Error("Could not set dispatch parameters from the status file. GroupX cannot be zero.");
-
-            if (gridX == 0)
-                return new Error("Could not set dispatch parameters from the status file. GridX cannot be zero.");
-
-            if (waveSize == 0)
-                return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be zero.");
-
-            if (ndRange3D && (groupY == 0 || groupZ == 0))
-                return new Error("Could not set dispatch parameters from the status file. If GridY and GridZ is set, GroupY and GroupZ cannot be zero.");
-
-            if (ndRange3D && (groupY > gridY || groupZ > gridZ))
-                return new Error("Could not set dispatch parameters from the status file. If GridY and GridZ is set, GroupY and GroupZ cannot be bigger than correspond Grid value.");
-
-            if (groupX > gridX)
-                return new Error("Could not set dispatch parameters from the status file. GroupX cannot be bigger than GridX.");
-
-            if (waveSize > groupX)
-                return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be bigger than GroupX.");
-
-            var dimX = gridX / groupX;
-            var dimY = ndRange3D ? gridY / groupY : 0;
-            var dimZ = ndRange3D ? gridZ / groupZ : 0;
-
-            return new BreakState(breakStateData, totalElapsedMilliseconds, statusFileSet: true, waveSize, dimX, dimY, dimZ, groupX, ndRange3D, statusString);
         }
     }
 }

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -29,10 +29,7 @@ namespace VSRAD.Package.Server
 
             var match = StatusFileRegex.Match(statusFileContents);
 
-            if (match.Success
-                && uint.Parse(match.Groups["gp_x"].Value) != 0
-                && uint.Parse(match.Groups["wv"].Value) != 0
-                && uint.Parse(match.Groups["gd_x"].Value) != 0)
+            if (match.Success)
             {
                 var gridX = uint.Parse(match.Groups["gd_x"].Value);
                 var gridY = uint.Parse(match.Groups["gd_y"].Value);
@@ -44,7 +41,7 @@ namespace VSRAD.Package.Server
                 NDRange3D = gridY != 0 && gridZ != 0;
 
                 if ((NDRange3D && (groupY == 0 || groupZ == 0 || groupY > gridY || groupZ > gridZ))
-                    || groupX > gridX || WaveSize > groupX)
+                    || groupX > gridX || WaveSize > groupX || groupX == 0 || WaveSize == 0 || gridX == 0)
                     throw new ArgumentException();
 
                 GroupSize = groupX;

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -28,6 +28,7 @@ namespace VSRAD.Package.Server
             ExitCode = 0;
 
             var match = StatusFileRegex.Match(statusFileContents);
+
             if (match.Success)
             {
                 var gridX = uint.Parse(match.Groups["gd_x"].Value);
@@ -36,14 +37,18 @@ namespace VSRAD.Package.Server
                 var groupX = uint.Parse(match.Groups["gp_x"].Value);
                 var groupY = uint.Parse(match.Groups["gp_y"].Value);
                 var groupZ = uint.Parse(match.Groups["gp_z"].Value);
+                WaveSize = uint.Parse(match.Groups["wv"].Value);
 
                 NDRange3D = gridY != 0 && gridZ != 0;
                 GroupSize = groupX;
                 DimX = gridX / groupX;
                 DimY = NDRange3D ? gridY / groupY : 0;
                 DimZ = NDRange3D ? gridZ / groupZ : 0;
-                WaveSize = uint.Parse(match.Groups["wv"].Value);
                 StatusString = match.Groups["comment"].Value;
+            }
+            else if (!string.IsNullOrEmpty(statusFileContents))
+            {
+                Errors.ShowWarning("Could not set dispatch parameters from the status file. Make sure that the status file contents match the format.");
             }
         }
     }

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 
 namespace VSRAD.Package.Server
 {
@@ -10,14 +11,35 @@ namespace VSRAD.Package.Server
         public string StatusString { get; }
         public int ExitCode { get; }
         public DateTime ExecutedAt { get; } = DateTime.Now;
+        public uint GridX;
+        public uint GridY;
+        public uint GridZ;
+        public uint GroupX;
+        public uint GroupY;
+        public uint GroupZ;
+        public uint WaveSize;
 
-        public BreakState(BreakStateData breakStateData, long totalElapsedMilliseconds, string statusString)
+        private static readonly Regex StatuFileRegex = new Regex(@"grid size \((?<gd_x>\d+), (?<gd_y>\d+), (?<gd_z>\d+)\)\s+group size \((?<gp_x>\d+), (?<gp_y>\d+), (?<gp_z>\d+)\)\s+wave size (?<wv>\d+)\s+comment (?<comment>.+)", RegexOptions.Compiled);
+
+        public BreakState(BreakStateData breakStateData, long totalElapsedMilliseconds, string statusFileContents)
         {
             Data = breakStateData;
             TotalElapsedMilliseconds = totalElapsedMilliseconds;
             ExecElapsedMilliseconds = 0;
-            StatusString = statusString;
             ExitCode = 0;
+
+            var match = StatuFileRegex.Match(statusFileContents);
+            if (match.Success)
+            {
+                GridX = uint.Parse(match.Groups["gd_x"].Value);
+                GridY = uint.Parse(match.Groups["gd_y"].Value);
+                GridZ = uint.Parse(match.Groups["gd_z"].Value);
+                GroupX = uint.Parse(match.Groups["gp_x"].Value);
+                GroupY = uint.Parse(match.Groups["gp_y"].Value);
+                GroupZ = uint.Parse(match.Groups["gp_z"].Value);
+                WaveSize = uint.Parse(match.Groups["wv"].Value);
+                StatusString = match.Groups["comment"].Value;
+            }
         }
     }
 }

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -11,15 +11,13 @@ namespace VSRAD.Package.Server
         public string StatusString { get; }
         public int ExitCode { get; }
         public DateTime ExecutedAt { get; } = DateTime.Now;
-        public uint GridX;
-        public uint GridY;
-        public uint GridZ;
-        public uint GroupX;
-        public uint GroupY;
-        public uint GroupZ;
-        public uint WaveSize;
+        public uint WaveSize { get; }
+        public uint DimX { get; }
+        public uint DimY { get; }
+        public uint DimZ { get; }
+        public bool NDRange3D { get; }
 
-        private static readonly Regex StatuFileRegex = new Regex(@"grid size \((?<gd_x>\d+), (?<gd_y>\d+), (?<gd_z>\d+)\)\s+group size \((?<gp_x>\d+), (?<gp_y>\d+), (?<gp_z>\d+)\)\s+wave size (?<wv>\d+)\s+comment (?<comment>.+)", RegexOptions.Compiled);
+        private static readonly Regex StatusFileRegex = new Regex(@"grid size \((?<gd_x>\d+), (?<gd_y>\d+), (?<gd_z>\d+)\)\s+group size \((?<gp_x>\d+), (?<gp_y>\d+), (?<gp_z>\d+)\)\s+wave size (?<wv>\d+)\s+comment (?<comment>.+)", RegexOptions.Compiled);
 
         public BreakState(BreakStateData breakStateData, long totalElapsedMilliseconds, string statusFileContents)
         {
@@ -28,15 +26,20 @@ namespace VSRAD.Package.Server
             ExecElapsedMilliseconds = 0;
             ExitCode = 0;
 
-            var match = StatuFileRegex.Match(statusFileContents);
+            var match = StatusFileRegex.Match(statusFileContents);
             if (match.Success)
             {
-                GridX = uint.Parse(match.Groups["gd_x"].Value);
-                GridY = uint.Parse(match.Groups["gd_y"].Value);
-                GridZ = uint.Parse(match.Groups["gd_z"].Value);
-                GroupX = uint.Parse(match.Groups["gp_x"].Value);
-                GroupY = uint.Parse(match.Groups["gp_y"].Value);
-                GroupZ = uint.Parse(match.Groups["gp_z"].Value);
+                var gridX = uint.Parse(match.Groups["gd_x"].Value);
+                var gridY = uint.Parse(match.Groups["gd_y"].Value);
+                var gridZ = uint.Parse(match.Groups["gd_z"].Value);
+                var groupX = uint.Parse(match.Groups["gp_x"].Value);
+                var groupY = uint.Parse(match.Groups["gp_y"].Value);
+                var groupZ = uint.Parse(match.Groups["gp_z"].Value);
+
+                DimX = gridX / groupX;
+                DimY = gridY / groupY;
+                DimZ = gridZ / groupZ;
+                NDRange3D = gridY != 0 && gridZ != 0;
                 WaveSize = uint.Parse(match.Groups["wv"].Value);
                 StatusString = match.Groups["comment"].Value;
             }

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -64,6 +64,15 @@ namespace VSRAD.Package.Server
             var ndRange3D = gridY != 0 && gridZ != 0;
             var statusString = match.Groups["comment"].Value;
 
+            if (groupX == 0)
+                return new Error("Could not set dispatch parameters from the status file. GroupX cannot be zero.");
+
+            if (gridX == 0)
+                return new Error("Could not set dispatch parameters from the status file. GridX cannot be zero.");
+
+            if (waveSize == 0)
+                return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be zero.");
+
             if (ndRange3D && (groupY == 0 || groupZ == 0))
                 return new Error("Could not set dispatch parameters from the status file. If GridY and GridZ is set, GroupY and GroupZ cannot be zero.");
 
@@ -75,15 +84,6 @@ namespace VSRAD.Package.Server
 
             if (waveSize > groupX)
                 return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be bigger than GroupX.");
-
-            if (groupX == 0)
-                return new Error("Could not set dispatch parameters from the status file. GroupX cannot be zero.");
-
-            if (gridX == 0)
-                return new Error("Could not set dispatch parameters from the status file. GridX cannot be zero.");
-
-            if (waveSize == 0)
-                return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be zero.");
 
             var dimX = gridX / groupX;
             var dimY = ndRange3D ? gridY / groupY : 0;

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+using VSRAD.Package.Utils;
 
 namespace VSRAD.Package.Server
 {
@@ -17,56 +18,78 @@ namespace VSRAD.Package.Server
         public uint DimZ { get; }
         public uint GroupSize { get; } // TODO: handle 3d group sizes
         public bool NDRange3D { get; }
+        public bool StatusFileSet { get; }
 
         private static readonly Regex StatusFileRegex = new Regex(@"grid size \((?<gd_x>\d+), (?<gd_y>\d+), (?<gd_z>\d+)\)\s+group size \((?<gp_x>\d+), (?<gp_y>\d+), (?<gp_z>\d+)\)\s+wave size (?<wv>\d+)\s+comment (?<comment>.+)", RegexOptions.Compiled);
-
-        private BreakState(BreakStateData breakStateData, long totalElapsedMilliseconds, string statusFileContents)
+       
+        private BreakState(BreakStateData breakStateData, long totalElapsedMilliseconds, bool statusFileSet,
+            uint waveSize = 0, uint dimX = 0, uint dimY = 0, uint dimZ = 0, uint groupSize = 0, bool ndRange3d = false, string status = "")
         {
             Data = breakStateData;
             TotalElapsedMilliseconds = totalElapsedMilliseconds;
             ExecElapsedMilliseconds = 0;
             ExitCode = 0;
+            StatusFileSet = statusFileSet;
 
-            var match = StatusFileRegex.Match(statusFileContents);
-
-            if (match.Success)
+            if (statusFileSet)
             {
-                var gridX = uint.Parse(match.Groups["gd_x"].Value);
-                var gridY = uint.Parse(match.Groups["gd_y"].Value);
-                var gridZ = uint.Parse(match.Groups["gd_z"].Value);
-                var groupX = uint.Parse(match.Groups["gp_x"].Value);
-                var groupY = uint.Parse(match.Groups["gp_y"].Value);
-                var groupZ = uint.Parse(match.Groups["gp_z"].Value);
-                WaveSize = uint.Parse(match.Groups["wv"].Value);
-                NDRange3D = gridY != 0 && gridZ != 0;
-
-                if ((NDRange3D && (groupY == 0 || groupZ == 0 || groupY > gridY || groupZ > gridZ))
-                    || groupX > gridX || WaveSize > groupX || groupX == 0 || WaveSize == 0 || gridX == 0)
-                    throw new ArgumentException();
-
-                GroupSize = groupX;
-                DimX = gridX / groupX;
-                DimY = NDRange3D ? gridY / groupY : 0;
-                DimZ = NDRange3D ? gridZ / groupZ : 0;
-                StatusString = match.Groups["comment"].Value;
-            }
-            else if (!string.IsNullOrEmpty(statusFileContents))
-            {
-                throw new ArgumentException();
+                WaveSize = waveSize;
+                DimX = dimX;
+                DimY = dimY;
+                DimZ = dimZ;
+                GroupSize = groupSize;
+                NDRange3D = ndRange3d;
+                StatusString = status;
             }
         }
 
-        public static BreakState GetBreakState(BreakStateData breakStateData, long totalElapsedMilliseconds, string statusFileContents)
+        public static Result<BreakState> Create(BreakStateData breakStateData, long totalElapsedMilliseconds, string statusFileContents)
         {
-            try
+            var match = StatusFileRegex.Match(statusFileContents);
+
+            if (!match.Success)
             {
-                return new BreakState(breakStateData, totalElapsedMilliseconds, statusFileContents);
+                if (!string.IsNullOrEmpty(statusFileContents))
+                    return new Error("Could not set dispatch parameters from the status file. Make sure that the status file contents match the format.");
+                return new BreakState(breakStateData, totalElapsedMilliseconds, statusFileSet: false);
             }
-            catch (ArgumentException)
-            {
-                Errors.ShowWarning("Could not set dispatch parameters from the status file. Make sure that the status file contents match the format.");
-                return null;
-            }
+
+            var gridX = uint.Parse(match.Groups["gd_x"].Value);
+            var gridY = uint.Parse(match.Groups["gd_y"].Value);
+            var gridZ = uint.Parse(match.Groups["gd_z"].Value);
+            var groupX = uint.Parse(match.Groups["gp_x"].Value);
+            var groupY = uint.Parse(match.Groups["gp_y"].Value);
+            var groupZ = uint.Parse(match.Groups["gp_z"].Value);
+            var waveSize = uint.Parse(match.Groups["wv"].Value);
+            var ndRange3D = gridY != 0 && gridZ != 0;
+            var statusString = match.Groups["comment"].Value;
+
+            if (ndRange3D && (groupY == 0 || groupZ == 0))
+                return new Error("Could not set dispatch parameters from the status file. If GridY and GridZ is set, GroupY and GroupZ cannot be zero.");
+
+            if (ndRange3D && (groupY > gridY || groupZ > gridZ))
+                return new Error("Could not set dispatch parameters from the status file. If GridY and GridZ is set, GroupY and GroupZ cannot be bigger than correspond Grid value.");
+
+            if (groupX > gridX)
+                return new Error("Could not set dispatch parameters from the status file. GroupX cannot be bigger than GridX.");
+
+            if (waveSize > groupX)
+                return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be bigger than GroupX.");
+
+            if (groupX == 0)
+                return new Error("Could not set dispatch parameters from the status file. GroupX cannot be zero.");
+
+            if (gridX == 0)
+                return new Error("Could not set dispatch parameters from the status file. GridX cannot be zero.");
+
+            if (waveSize == 0)
+                return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be zero.");
+
+            var dimX = gridX / groupX;
+            var dimY = ndRange3D ? gridY / groupY : 0;
+            var dimZ = ndRange3D ? gridZ / groupZ : 0;
+
+            return new BreakState(breakStateData, totalElapsedMilliseconds, statusFileSet: true, waveSize, dimX, dimY, dimZ, groupX, ndRange3D, statusString);
         }
     }
 }

--- a/VSRAD.Package/Server/BreakStateDispatchParameters.cs
+++ b/VSRAD.Package/Server/BreakStateDispatchParameters.cs
@@ -1,0 +1,77 @@
+﻿using System.Text.RegularExpressions;
+using VSRAD.Package.Utils;
+
+namespace VSRAD.Package.Server
+{
+    public sealed class BreakStateDispatchParameters
+    {
+        private static readonly Regex StatusFileRegex = new Regex(@"grid size \((?<gd_x>\d+), (?<gd_y>\d+), (?<gd_z>\d+)\)\s+group size \((?<gp_x>\d+), (?<gp_y>\d+), (?<gp_z>\d+)\)\s+wave size (?<wv>\d+)\s+comment (?<comment>.+)", RegexOptions.Compiled);
+
+        public uint WaveSize { get; }
+        public uint DimX { get; }
+        public uint DimY { get; }
+        public uint DimZ { get; }
+        public uint GroupSize { get; } // TODO: handle 3d group sizes
+        public bool NDRange3D { get; }
+        public string StatusString { get; }
+
+        private BreakStateDispatchParameters(uint waveSize, uint dimX, uint dimY, uint dimZ, uint groupSize, bool ndRange3d, string statusString)
+        {
+            WaveSize = waveSize;
+            DimX = dimX;
+            DimY = dimY;
+            DimZ = dimZ;
+            GroupSize = groupSize;
+            NDRange3D = ndRange3d;
+            StatusString = statusString;
+        }
+
+        public static Result<BreakStateDispatchParameters> Parse(string statusFileContents)
+        {
+            if (statusFileContents == null)
+                return (BreakStateDispatchParameters)null;
+
+            var match = StatusFileRegex.Match(statusFileContents);
+
+            if (!match.Success)
+                return new Error("Could not set dispatch parameters from the status file. Make sure that the status file contents match the format.");
+
+            var gridX = uint.Parse(match.Groups["gd_x"].Value);
+            var gridY = uint.Parse(match.Groups["gd_y"].Value);
+            var gridZ = uint.Parse(match.Groups["gd_z"].Value);
+            var groupX = uint.Parse(match.Groups["gp_x"].Value);
+            var groupY = uint.Parse(match.Groups["gp_y"].Value);
+            var groupZ = uint.Parse(match.Groups["gp_z"].Value);
+            var waveSize = uint.Parse(match.Groups["wv"].Value);
+            var ndRange3D = gridY != 0 && gridZ != 0;
+            var statusString = match.Groups["comment"].Value;
+
+            if (groupX == 0)
+                return new Error("Could not set dispatch parameters from the status file. GroupX cannot be zero.");
+
+            if (gridX == 0)
+                return new Error("Could not set dispatch parameters from the status file. GridX cannot be zero.");
+
+            if (waveSize == 0)
+                return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be zero.");
+
+            if (ndRange3D && (groupY == 0 || groupZ == 0))
+                return new Error("Could not set dispatch parameters from the status file. If GridY and GridZ is set, GroupY and GroupZ cannot be zero.");
+
+            if (ndRange3D && (groupY > gridY || groupZ > gridZ))
+                return new Error("Could not set dispatch parameters from the status file. If GridY and GridZ is set, GroupY and GroupZ cannot be bigger than correspond Grid value.");
+
+            if (groupX > gridX)
+                return new Error("Could not set dispatch parameters from the status file. GroupX cannot be bigger than GridX.");
+
+            if (waveSize > groupX)
+                return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be bigger than GroupX.");
+
+            var dimX = gridX / groupX;
+            var dimY = ndRange3D ? gridY / groupY : 0;
+            var dimZ = ndRange3D ? gridZ / groupZ : 0;
+
+            return new BreakStateDispatchParameters(waveSize, dimX, dimY, dimZ, groupX, ndRange3D, statusString);
+        }
+    }
+}

--- a/VSRAD.Package/Server/BreakStateDispatchParameters.cs
+++ b/VSRAD.Package/Server/BreakStateDispatchParameters.cs
@@ -46,32 +46,31 @@ namespace VSRAD.Package.Server
             var ndRange3D = gridY != 0 && gridZ != 0;
             var statusString = match.Groups["comment"].Value;
 
+            if (gridX == 0)
+                return new Error("Could not set dispatch parameters from the status file. GridX cannot be zero.");
             if (groupX == 0)
                 return new Error("Could not set dispatch parameters from the status file. GroupX cannot be zero.");
 
-            if (gridX == 0)
-                return new Error("Could not set dispatch parameters from the status file. GridX cannot be zero.");
-
             if (waveSize == 0)
                 return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be zero.");
+            if (waveSize > groupX)
+                return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be bigger than GroupX.");
 
             if (ndRange3D && (groupY == 0 || groupZ == 0))
-                return new Error("Could not set dispatch parameters from the status file. If GridY and GridZ is set, GroupY and GroupZ cannot be zero.");
-
-            if (ndRange3D && (groupY > gridY || groupZ > gridZ))
-                return new Error("Could not set dispatch parameters from the status file. If GridY and GridZ is set, GroupY and GroupZ cannot be bigger than correspond Grid value.");
+                return new Error("Could not set dispatch parameters from the status file. If GridY and GridZ are set, GroupY and GroupZ cannot be zero.");
 
             if (groupX > gridX)
                 return new Error("Could not set dispatch parameters from the status file. GroupX cannot be bigger than GridX.");
-
-            if (waveSize > groupX)
-                return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be bigger than GroupX.");
+            if (ndRange3D && groupY > gridY)
+                return new Error("Could not set dispatch parameters from the status file. GroupY cannot be bigger than GridY.");
+            if (ndRange3D && groupZ > gridZ)
+                return new Error("Could not set dispatch parameters from the status file. GroupZ cannot be bigger than GridZ.");
 
             var dimX = gridX / groupX;
             var dimY = ndRange3D ? gridY / groupY : 0;
             var dimZ = ndRange3D ? gridZ / groupZ : 0;
 
-            return new BreakStateDispatchParameters(waveSize, dimX, dimY, dimZ, groupX, ndRange3D, statusString);
+            return new BreakStateDispatchParameters(waveSize, dimX, dimY, dimZ, groupSize: groupX, ndRange3D, statusString);
         }
     }
 }

--- a/VSRAD.Package/Server/DebugSession.cs
+++ b/VSRAD.Package/Server/DebugSession.cs
@@ -96,7 +96,7 @@ namespace VSRAD.Package.Server
                 // TODO: refactor OutputFile away
                 var output = new OutputFile(directory: env.RemoteWorkDir, file: options.OutputFile.Path, options.BinaryOutput);
                 var data = new BreakStateData(watches, output, outputMeta.timestamp, outputMeta.byteCount, options.OutputOffset);
-                return new DebugRunResult(result, null, new BreakState(data, execTimer.ElapsedMilliseconds, statusString));
+                return new DebugRunResult(result, null, BreakState.GetBreakState(data, execTimer.ElapsedMilliseconds, statusString));
             }
         }
 

--- a/VSRAD.Package/Server/DebugSession.cs
+++ b/VSRAD.Package/Server/DebugSession.cs
@@ -96,7 +96,12 @@ namespace VSRAD.Package.Server
                 // TODO: refactor OutputFile away
                 var output = new OutputFile(directory: env.RemoteWorkDir, file: options.OutputFile.Path, options.BinaryOutput);
                 var data = new BreakStateData(watches, output, outputMeta.timestamp, outputMeta.byteCount, options.OutputOffset);
-                return new DebugRunResult(result, null, BreakState.GetBreakState(data, execTimer.ElapsedMilliseconds, statusString));
+
+                var breakStateResult = BreakState.Create(data, execTimer.ElapsedMilliseconds, statusString);
+                if (!breakStateResult.TryGetResult(out var breakState, out var debugResError))
+                    return new DebugRunResult(result, debugResError, null);
+                
+                return new DebugRunResult(result, null, breakState);
             }
         }
 

--- a/VSRAD.Package/Server/DebugSession.cs
+++ b/VSRAD.Package/Server/DebugSession.cs
@@ -75,7 +75,7 @@ namespace VSRAD.Package.Server
                 var watchArray = watchesString.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
                 watches = Array.AsReadOnly(watchArray);
             }
-            var statusString = "";
+            string statusString = null;
             if (!string.IsNullOrEmpty(options.StatusFile.Path))
             {
                 var initTimestamp = runner.GetInitialFileTimestamp(options.StatusFile.Path);
@@ -97,11 +97,11 @@ namespace VSRAD.Package.Server
                 var output = new OutputFile(directory: env.RemoteWorkDir, file: options.OutputFile.Path, options.BinaryOutput);
                 var data = new BreakStateData(watches, output, outputMeta.timestamp, outputMeta.byteCount, options.OutputOffset);
 
-                var breakStateResult = BreakState.Create(data, execTimer.ElapsedMilliseconds, statusString);
-                if (!breakStateResult.TryGetResult(out var breakState, out var debugResError))
-                    return new DebugRunResult(result, debugResError, null);
+                var dispatchParamsResult = BreakStateDispatchParameters.Parse(statusString);
+                if (!dispatchParamsResult.TryGetResult(out var dispatchParams, out error))
+                    return new DebugRunResult(result, error, null);
                 
-                return new DebugRunResult(result, null, breakState);
+                return new DebugRunResult(result, null, new BreakState(data, dispatchParams, execTimer.ElapsedMilliseconds));
             }
         }
 

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -214,6 +214,7 @@
     <Compile Include="Server\ActionRunner.cs" />
     <Compile Include="Server\ActionRunResult.cs" />
     <Compile Include="Server\BreakStateData.cs" />
+    <Compile Include="Server\BreakStateDispatchParameters.cs" />
     <Compile Include="Server\DebugRunResult.cs" />
     <Compile Include="ToolWindows\EvaluateSelectedControl.xaml.cs">
       <DependentUpon>EvaluateSelectedControl.xaml</DependentUpon>

--- a/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
@@ -93,5 +93,28 @@ namespace VSRAD.PackageTests.DebugVisualizer
             for (int i = 192; i < 256; i++)
                 Assert.True((styling.ColumnState[i] & ColumnStates.Inactive) != 0);
         }
+
+        [Fact]
+        public void MagicNumberWithNonConstatnWaveSizeTest()
+        {
+            var system = new uint[128];
+            system[0] = 0x7;
+            system[32] = 0x5;
+            system[64] = 0x7;
+            system[96] = 0x5;
+
+            var visualizerOptions = new VisualizerOptions { MaskLanes = false, CheckMagicNumber = true, MagicNumber = 0x7, WaveSize = 32 };
+            var styling = new ComputedColumnStyling();
+            styling.Recompute(visualizerOptions, new ColumnStylingOptions(), groupSize: 128, system: new WatchView(system));
+
+            for (int i = 0; i < 32; i++)
+                Assert.False((styling.ColumnState[i] & ColumnStates.Inactive) != 0);
+            for (int i = 32; i < 64; i++)
+                Assert.True((styling.ColumnState[i] & ColumnStates.Inactive) != 0);
+            for (int i = 64; i < 96; i++)
+                Assert.False((styling.ColumnState[i] & ColumnStates.Inactive) != 0);
+            for (int i = 96; i < 128; i++)
+                Assert.True((styling.ColumnState[i] & ColumnStates.Inactive) != 0);
+        }
     }
 }

--- a/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
@@ -95,7 +95,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
         }
 
         [Fact]
-        public void MagicNumberWithNonConstatnWaveSizeTest()
+        public void MagicNumberWithNonConstantWaveSizeTest()
         {
             var system = new uint[128];
             system[0] = 0x7;

--- a/VSRAD.PackageTests/Server/BreakStateDispatchParametersTests.cs
+++ b/VSRAD.PackageTests/Server/BreakStateDispatchParametersTests.cs
@@ -1,0 +1,101 @@
+﻿using VSRAD.Package.Server;
+using Xunit;
+
+namespace VSRAD.PackageTests.Server
+{
+    public sealed class BreakStateDispatchParametersTests
+    {
+        [Fact]
+        public void NDRangeTest()
+        {
+            var paramsResult = BreakStateDispatchParameters.Parse(@"
+grid size (8192, 0, 0)
+group size (512, 0, 0)
+wave size 64
+comment -");
+            Assert.True(paramsResult.TryGetResult(out var ps, out _));
+            Assert.False(ps.NDRange3D);
+            Assert.Equal<uint>(512, ps.GroupSize);
+            Assert.Equal<uint>(16, ps.DimX);
+            Assert.Equal<uint>(0, ps.DimY);
+            Assert.Equal<uint>(0, ps.DimZ);
+
+            paramsResult = BreakStateDispatchParameters.Parse(@"
+grid size (8192, 2048, 256)
+group size (512, 256, 128)
+wave size 64
+comment -");
+            Assert.True(paramsResult.TryGetResult(out ps, out _));
+            Assert.True(ps.NDRange3D);
+            Assert.Equal<uint>(512, ps.GroupSize);
+            Assert.Equal<uint>(16, ps.DimX);
+            Assert.Equal<uint>(8, ps.DimY);
+            Assert.Equal<uint>(2, ps.DimZ);
+
+            paramsResult = BreakStateDispatchParameters.Parse(@"
+grid size (8192, 1, 1)
+group size (512, 0, 0)
+wave size 64
+comment -");
+            Assert.False(paramsResult.TryGetResult(out _, out var error));
+            Assert.Equal("Could not set dispatch parameters from the status file. If GridY and GridZ are set, GroupY and GroupZ cannot be zero.", error.Message);
+        }
+
+        [Fact]
+        public void InvalidGridAndGroupSizeTest()
+        {
+            Assert.False(BreakStateDispatchParameters.Parse(@"
+grid size (0, 0, 0)
+group size (0, 0, 0)
+wave size 64
+comment -").TryGetResult(out _, out var error));
+            Assert.Equal("Could not set dispatch parameters from the status file. GridX cannot be zero.", error.Message);
+
+            Assert.False(BreakStateDispatchParameters.Parse(@"
+grid size (64, 0, 0)
+group size (0, 0, 0)
+wave size 64
+comment -").TryGetResult(out _, out error));
+            Assert.Equal("Could not set dispatch parameters from the status file. GroupX cannot be zero.", error.Message);
+
+            Assert.False(BreakStateDispatchParameters.Parse(@"
+grid size (128, 0, 0)
+group size (512, 0, 0)
+wave size 64
+comment -").TryGetResult(out _, out error));
+            Assert.Equal("Could not set dispatch parameters from the status file. GroupX cannot be bigger than GridX.", error.Message);
+
+            Assert.False(BreakStateDispatchParameters.Parse(@"
+grid size (512, 128, 1)
+group size (512, 512, 1)
+wave size 64
+comment -").TryGetResult(out _, out error));
+            Assert.Equal("Could not set dispatch parameters from the status file. GroupY cannot be bigger than GridY.", error.Message);
+
+            Assert.False(BreakStateDispatchParameters.Parse(@"
+grid size (512, 512, 1)
+group size (512, 512, 128)
+wave size 64
+comment -").TryGetResult(out _, out error));
+            Assert.Equal("Could not set dispatch parameters from the status file. GroupZ cannot be bigger than GridZ.", error.Message);
+        }
+
+        [Fact]
+        public void InvalidWaveSizeTest()
+        {
+            Assert.False(BreakStateDispatchParameters.Parse(@"
+grid size (128, 0, 0)
+group size (32, 0, 0)
+wave size 0
+comment -").TryGetResult(out _, out var error));
+            Assert.Equal("Could not set dispatch parameters from the status file. WaveSize cannot be zero.", error.Message);
+
+            Assert.False(BreakStateDispatchParameters.Parse(@"
+grid size (128, 0, 0)
+group size (32, 0, 0)
+wave size 64
+comment -").TryGetResult(out _, out error));
+            Assert.Equal("Could not set dispatch parameters from the status file. WaveSize cannot be bigger than GroupX.", error.Message);
+        }
+    }
+}

--- a/VSRAD.PackageTests/Server/DebugSessionTests.cs
+++ b/VSRAD.PackageTests/Server/DebugSessionTests.cs
@@ -48,6 +48,7 @@ namespace VSRAD.PackageTests.Server
             Assert.Collection(breakState.Data.Watches,
                 (first) => Assert.Equal("jill", first),
                 (second) => Assert.Equal("julianne", second));
+            Assert.Null(breakState.DispatchParameters);
         }
 
         [Fact]
@@ -87,6 +88,66 @@ namespace VSRAD.PackageTests.Server
 
             result = await session.ExecuteAsync(new[] { 13u }, null);
             Assert.Equal("Local debugger output paths are not supported in this version of RAD Debugger.", result.Error.Value.Message);
+        }
+
+        [Fact]
+        public async Task SuccessfulRunWithStatusFileTestAsync()
+        {
+            var channel = new MockCommunicationChannel();
+            var project = TestHelper.MakeProjectWithProfile(remoteWorkDir: "/remote/workdir").Object;
+            project.Options.SetProfiles(new Dictionary<string, ProfileOptions> { { "Default", new ProfileOptions() } }, activeProfile: "Default");
+            project.Options.Profile.Debugger.Steps.Add(new ExecuteStep { Executable = "va11" });
+            project.Options.Profile.Debugger.OutputFile.Path = "/glitch/city";
+            project.Options.Profile.Debugger.StatusFile.Path = "/glitch/city/status";
+
+            channel.ThenRespond(new[] { new MetadataFetched { Status = FetchStatus.FileNotFound }, new MetadataFetched { Status = FetchStatus.FileNotFound } }); // init timestamp fetch
+            channel.ThenRespond(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0 });
+            channel.ThenRespond(new IResponse[]
+            {
+                // status
+                new ResultRangeFetched { Status = FetchStatus.Successful, Data = Encoding.UTF8.GetBytes(@"
+grid size (8192, 0, 0)
+group size (512, 0, 0)
+wave size 32
+comment 115200"), Timestamp = DateTime.Now },
+                new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.Now } // output
+            });
+
+            var session = new DebugSession(project, channel.Object, new Mock<IFileSynchronizationManager>().Object, null);
+            var result = await session.ExecuteAsync(new[] { 13u }, new ReadOnlyCollection<string>(new[] { "watch" }.ToList()));
+            Assert.True(channel.AllInteractionsHandled);
+            Assert.Null(result.Error);
+            Assert.NotNull(result.BreakState.DispatchParameters);
+            Assert.Equal<uint>(8192 / 512, result.BreakState.DispatchParameters.DimX);
+            Assert.Equal<uint>(512, result.BreakState.DispatchParameters.GroupSize);
+            Assert.Equal<uint>(32, result.BreakState.DispatchParameters.WaveSize);
+            Assert.False(result.BreakState.DispatchParameters.NDRange3D);
+            Assert.Equal("115200", result.BreakState.DispatchParameters.StatusString);
+        }
+
+        [Fact]
+        public async Task EmptyStatusFileTestAsync()
+        {
+            var channel = new MockCommunicationChannel();
+            var project = TestHelper.MakeProjectWithProfile(remoteWorkDir: "/remote/workdir").Object;
+            project.Options.SetProfiles(new Dictionary<string, ProfileOptions> { { "Default", new ProfileOptions() } }, activeProfile: "Default");
+            project.Options.Profile.Debugger.Steps.Add(new ExecuteStep { Executable = "va11" });
+            project.Options.Profile.Debugger.OutputFile.Path = "/glitch/city";
+            project.Options.Profile.Debugger.StatusFile.Path = "/glitch/city/status";
+
+            channel.ThenRespond(new[] { new MetadataFetched { Status = FetchStatus.FileNotFound }, new MetadataFetched { Status = FetchStatus.FileNotFound } }); // init timestamp fetch
+            channel.ThenRespond(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0 });
+            channel.ThenRespond(new IResponse[]
+            {
+                new ResultRangeFetched { Status = FetchStatus.Successful, Data = Array.Empty<byte>(), Timestamp = DateTime.Now }, // status
+                new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.Now } // output
+            });
+
+            var session = new DebugSession(project, channel.Object, new Mock<IFileSynchronizationManager>().Object, null);
+            var result = await session.ExecuteAsync(new[] { 13u }, new ReadOnlyCollection<string>(new[] { "watch" }.ToList()));
+            Assert.True(channel.AllInteractionsHandled);
+            Assert.Null(result.BreakState);
+            Assert.Equal("Could not set dispatch parameters from the status file. Make sure that the status file contents match the format.", result.Error.Value.Message);
         }
     }
 }

--- a/VSRAD.PackageTests/VSRAD.PackageTests.csproj
+++ b/VSRAD.PackageTests/VSRAD.PackageTests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Server\ActionMacroEvaluationTests.cs" />
     <Compile Include="Server\ActionRunnerTests.cs" />
+    <Compile Include="Server\BreakStateDispatchParametersTests.cs" />
     <Compile Include="Server\BreakStateTests.cs" />
     <Compile Include="Server\DebugSessionTests.cs" />
     <Compile Include="Server\FileSynchronizationManagerTests.cs" />


### PR DESCRIPTION
Addresses #140
Addresses #141 

This PR expands the function of `status file`. Status file was used to provide some text that appears in `Debug Visualizer` after every debug run. Now it contains some dispatch parameters following this pattern:

```
grid size (512, 1, 1)
group size (64, 1, 1)
wave size 32
comment status string
```

In the example above following parameters are set:

* `grid size X` = 512, `grid size Y` = 1 and `grid size Z` = 1
* `group size X` = 64, `group size Y` = 1 and `group size Z` = 1
* `wave size` = 32
* `comment` = "status string"

This parameters affecting some project properties:

* `NDRange 3D` is set true if any of `grid size Y` and `grid size Z` is not zero
* `Group Size` is set according to `group size X` (3D group sizes is not supported yet)
* `DimX`, `DimY` and `DimZ` is set according to `grid size` / `group size` for perspective axis
* `NGroups` is equals `DimX` if `NDRange 3D` is false or as multiplication of all `Dim`'s otherwise
* `WaveSize` is set from status file which affects the magick number checker
  
In cases below you'll get corresponding error:

* The status file contents do not follow the right pattern
* Either `grid size X`, `group size X` or `wave size` equals zero
* `grid size Y` and `grid size Z` is not zero but `group size Y` or `group size Z` is
* Any `group size` is bigger than correspond `grid size`
* `wave size` is bigger than `group size X`