### PR TITLE
Wavemap

### DIFF
--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerContext.cs
@@ -50,7 +50,7 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
 
         private void SetupDataFetch(object sender, GroupFetchingEventArgs e)
         {
-            e.FetchWholeFile = _windowVisible;
+            e.FetchWholeFile = _windowVisible || e.FetchWholeFile; // wavemap can set this field too
         }
 
         private void DisplayFetchedData(object sender, GroupFetchedEventArgs e)

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerContext.cs
@@ -50,7 +50,7 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
 
         private void SetupDataFetch(object sender, GroupFetchingEventArgs e)
         {
-            e.FetchWholeFile = _windowVisible || e.FetchWholeFile; // wavemap can set this field too
+            e.FetchWholeFile |= _windowVisible;
         }
 
         private void DisplayFetchedData(object sender, GroupFetchedEventArgs e)

--- a/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
@@ -36,6 +36,9 @@ namespace VSRAD.Package.DebugVisualizer
         private bool _watchesValid = true;
         public bool WatchesValid { get => _watchesValid; set => SetField(ref _watchesValid, value); }
 
+        private int _canvasWidth = 100;
+        public int CanvasWidth { get => _canvasWidth; set => SetField(ref _canvasWidth, value); }
+
         private bool _groupIndexEditable = true;
         public bool GroupIndexEditable { get => _groupIndexEditable; set => SetField(ref _groupIndexEditable, value); }
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
@@ -39,6 +39,9 @@ namespace VSRAD.Package.DebugVisualizer
         private int _canvasWidth = 100;
         public int CanvasWidth { get => _canvasWidth; set => SetField(ref _canvasWidth, value); }
 
+        private int _canvasHeight = 10;
+        public int CanvasHeight { get => _canvasHeight; set => SetField(ref _canvasHeight, value); }
+
         private bool _groupIndexEditable = true;
         public bool GroupIndexEditable { get => _groupIndexEditable; set => SetField(ref _groupIndexEditable, value); }
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml
@@ -7,7 +7,7 @@
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
     <DockPanel>
-        <local:VisualizerHeaderControl DataContext="{Binding}" DockPanel.Dock="Top"/>
+        <local:VisualizerHeaderControl DataContext="{Binding}" DockPanel.Dock="Top" x:Name="HeaderHost"/>
         <local:VisualizerTableHost DockPanel.Dock="Bottom" x:Name="TableHost"/>
     </DockPanel>
 </UserControl>

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -24,7 +24,7 @@ namespace VSRAD.Package.DebugVisualizer
             DataContext = _context;
             InitializeComponent();
 
-            _wavemap = new WavemapCanvas(HeaderHost.WavemapCanvas);
+            _wavemap = new WavemapCanvas(HeaderHost.WavemapCanvas, 7);
 
             integration.AddWatch += AddWatch;
             integration.ProjectOptions.VisualizerOptions.PropertyChanged += OptionsChanged;

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Shapes;
 using VSRAD.Package.ProjectSystem;
 using VSRAD.Package.Server;
 using VSRAD.Package.Utils;
@@ -19,6 +21,14 @@ namespace VSRAD.Package.DebugVisualizer
             _context.GroupFetched += GroupFetched;
             DataContext = _context;
             InitializeComponent();
+
+            var r = new Rectangle();
+            r.Fill = new SolidColorBrush(Color.FromRgb(255, 0, 0));
+            r.Height = 20;
+            r.Width = 20;
+            Canvas.SetLeft(r, 0);
+            Canvas.SetTop(r, 0);
+            HeaderHost.WavemapCanvas.Children.Add(r);
 
             integration.AddWatch += AddWatch;
             integration.ProjectOptions.VisualizerOptions.PropertyChanged += OptionsChanged;

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -84,7 +84,7 @@ namespace VSRAD.Package.DebugVisualizer
             _table.ApplyWatchStyling();
             RefreshDataStyling();
 
-            _wavemap.SetData(_context.BreakData.GetWavemapView((int)_context.Options.DebuggerOptions.GroupSize / 2)); // depends on status-file branch
+            _wavemap.SetData(_context.BreakData.GetWavemapView(16)); // depends on status-file branch
 
             foreach (System.Windows.Forms.DataGridViewRow row in _table.Rows)
                 SetRowContentsFromBreakState(row);

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -22,13 +22,7 @@ namespace VSRAD.Package.DebugVisualizer
             DataContext = _context;
             InitializeComponent();
 
-            var r = new Rectangle();
-            r.Fill = new SolidColorBrush(Color.FromRgb(255, 0, 0));
-            r.Height = 20;
-            r.Width = 20;
-            Canvas.SetLeft(r, 0);
-            Canvas.SetTop(r, 0);
-            HeaderHost.WavemapCanvas.Children.Add(r);
+            SetupWavemapSample();
 
             integration.AddWatch += AddWatch;
             integration.ProjectOptions.VisualizerOptions.PropertyChanged += OptionsChanged;
@@ -53,6 +47,25 @@ namespace VSRAD.Package.DebugVisualizer
             _table.SetScalingMode(_context.Options.VisualizerAppearance.ScalingMode);
             TableHost.Setup(_table);
             RestoreSavedState();
+        }
+
+        private void SetupWavemapSample()
+        {
+            for (int y = 0; y < 2; ++y)
+            {
+                for (int i = 0, x = 1; i < 200; ++i, x += 6)
+                {
+                    var r = new Rectangle();
+                    r.Fill = Brushes.Gray;
+                    r.Height = 7;
+                    r.Width = 7;
+                    r.StrokeThickness = 1;
+                    r.Stroke = Brushes.Black;
+                    Canvas.SetLeft(r, x);
+                    Canvas.SetTop(r, 7 * y);
+                    HeaderHost.WavemapCanvas.Children.Add(r);
+                }
+            }
         }
 
         private void DebuggerOptionChanged(object sender, PropertyChangedEventArgs e)

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -22,7 +22,7 @@ namespace VSRAD.Package.DebugVisualizer
             DataContext = _context;
             InitializeComponent();
 
-            SetupWavemapSample();
+            _ = new WavemapCanvas(HeaderHost.WavemapCanvas);
 
             integration.AddWatch += AddWatch;
             integration.ProjectOptions.VisualizerOptions.PropertyChanged += OptionsChanged;
@@ -47,25 +47,6 @@ namespace VSRAD.Package.DebugVisualizer
             _table.SetScalingMode(_context.Options.VisualizerAppearance.ScalingMode);
             TableHost.Setup(_table);
             RestoreSavedState();
-        }
-
-        private void SetupWavemapSample()
-        {
-            for (int y = 0; y < 2; ++y)
-            {
-                for (int i = 0, x = 1; i < 200; ++i, x += 6)
-                {
-                    var r = new Rectangle();
-                    r.Fill = Brushes.Gray;
-                    r.Height = 7;
-                    r.Width = 7;
-                    r.StrokeThickness = 1;
-                    r.Stroke = Brushes.Black;
-                    Canvas.SetLeft(r, x);
-                    Canvas.SetTop(r, 7 * y);
-                    HeaderHost.WavemapCanvas.Children.Add(r);
-                }
-            }
         }
 
         private void DebuggerOptionChanged(object sender, PropertyChangedEventArgs e)

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -12,6 +12,7 @@ namespace VSRAD.Package.DebugVisualizer
     {
         private readonly VisualizerTable _table;
         private readonly VisualizerContext _context;
+        private readonly WavemapCanvas _wavemap;
 
         public VisualizerControl(IToolWindowIntegration integration)
         {
@@ -22,7 +23,7 @@ namespace VSRAD.Package.DebugVisualizer
             DataContext = _context;
             InitializeComponent();
 
-            _ = new WavemapCanvas(HeaderHost.WavemapCanvas);
+            _wavemap = new WavemapCanvas(HeaderHost.WavemapCanvas);
 
             integration.AddWatch += AddWatch;
             integration.ProjectOptions.VisualizerOptions.PropertyChanged += OptionsChanged;
@@ -82,6 +83,8 @@ namespace VSRAD.Package.DebugVisualizer
 
             _table.ApplyWatchStyling();
             RefreshDataStyling();
+
+            _wavemap.SetData(_context.BreakData.GetWavemapView((int)_context.Options.DebuggerOptions.GroupSize / 2)); // depends on status-file branch
 
             foreach (System.Windows.Forms.DataGridViewRow row in _table.Rows)
                 SetRowContentsFromBreakState(row);

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -20,6 +20,7 @@ namespace VSRAD.Package.DebugVisualizer
             _context.PropertyChanged += ContextPropertyChanged;
             _context.Options.DebuggerOptions.PropertyChanged += DebuggerOptionChanged;
             _context.GroupFetched += GroupFetched;
+            _context.GroupFetching += SetupDataFetch;
             DataContext = _context;
             InitializeComponent();
 
@@ -48,6 +49,11 @@ namespace VSRAD.Package.DebugVisualizer
             _table.SetScalingMode(_context.Options.VisualizerAppearance.ScalingMode);
             TableHost.Setup(_table);
             RestoreSavedState();
+        }
+
+        private void SetupDataFetch(object sender, GroupFetchingEventArgs e)
+        {
+            e.FetchWholeFile = _context.Options.VisualizerOptions.ShowWavemapField || e.FetchWholeFile; // slice visualizer can set this field too
         }
 
         private void DebuggerOptionChanged(object sender, PropertyChangedEventArgs e)

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -90,7 +90,7 @@ namespace VSRAD.Package.DebugVisualizer
             _table.ApplyWatchStyling();
             RefreshDataStyling();
 
-            _wavemap.SetData(_context.BreakData.GetWavemapView(16)); // depends on status-file branch
+            _wavemap.SetData(_context.BreakData.GetWavemapView((int)_context.Options.VisualizerOptions.WaveSize));
             _context.CanvasWidth = _wavemap.Width;
             _context.CanvasHeight = _wavemap.Height;
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -90,7 +90,9 @@ namespace VSRAD.Package.DebugVisualizer
             _table.ApplyWatchStyling();
             RefreshDataStyling();
 
-            _context.CanvasWidth = _wavemap.SetData(_context.BreakData.GetWavemapView(16)); // depends on status-file branch
+            _wavemap.SetData(_context.BreakData.GetWavemapView(16)); // depends on status-file branch
+            _context.CanvasWidth = _wavemap.Width;
+            _context.CanvasHeight = _wavemap.Height;
 
             foreach (System.Windows.Forms.DataGridViewRow row in _table.Rows)
                 SetRowContentsFromBreakState(row);

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -53,7 +53,7 @@ namespace VSRAD.Package.DebugVisualizer
 
         private void SetupDataFetch(object sender, GroupFetchingEventArgs e)
         {
-            e.FetchWholeFile = _context.Options.VisualizerOptions.ShowWavemapField || e.FetchWholeFile; // slice visualizer can set this field too
+            e.FetchWholeFile |= _context.Options.VisualizerOptions.ShowWavemapField;
         }
 
         private void DebuggerOptionChanged(object sender, PropertyChangedEventArgs e)

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -26,7 +26,7 @@ namespace VSRAD.Package.DebugVisualizer
             DataContext = _context;
             InitializeComponent();
 
-            _wavemap = new WavemapCanvas(HeaderHost.WavemapCanvas, 7);
+            _wavemap = new WavemapCanvas(HeaderHost.WavemapCanvas, _context.Options.VisualizerOptions.WavemapElementSize);
 
             integration.AddWatch += AddWatch;
             integration.ProjectOptions.VisualizerOptions.PropertyChanged += OptionsChanged;

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Shapes;
+using VSRAD.Package.Options;
 using VSRAD.Package.ProjectSystem;
 using VSRAD.Package.Server;
 using VSRAD.Package.Utils;
@@ -19,6 +20,7 @@ namespace VSRAD.Package.DebugVisualizer
             _context = integration.GetVisualizerContext();
             _context.PropertyChanged += ContextPropertyChanged;
             _context.Options.DebuggerOptions.PropertyChanged += DebuggerOptionChanged;
+            _context.Options.VisualizerOptions.PropertyChanged += HandleWavemapElementSize;
             _context.GroupFetched += GroupFetched;
             _context.GroupFetching += SetupDataFetch;
             DataContext = _context;
@@ -49,6 +51,16 @@ namespace VSRAD.Package.DebugVisualizer
             _table.SetScalingMode(_context.Options.VisualizerAppearance.ScalingMode);
             TableHost.Setup(_table);
             RestoreSavedState();
+        }
+
+        private void HandleWavemapElementSize(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(VisualizerOptions.WavemapElementSize))
+            {
+                _wavemap.RectangleSize = _context.Options.VisualizerOptions.WavemapElementSize;
+                _context.CanvasWidth = _wavemap.Width;
+                _context.CanvasHeight = _wavemap.Height;
+            }
         }
 
         private void SetupDataFetch(object sender, GroupFetchingEventArgs e)

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -90,7 +90,7 @@ namespace VSRAD.Package.DebugVisualizer
             _table.ApplyWatchStyling();
             RefreshDataStyling();
 
-            _wavemap.SetData(_context.BreakData.GetWavemapView(16)); // depends on status-file branch
+            _context.CanvasWidth = _wavemap.SetData(_context.BreakData.GetWavemapView(16)); // depends on status-file branch
 
             foreach (System.Windows.Forms.DataGridViewRow row in _table.Rows)
                 SetRowContentsFromBreakState(row);

--- a/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
@@ -118,10 +118,23 @@
                         </Style>
                     </RowDefinition.Style>
                 </RowDefinition>
+                <RowDefinition>
+                    <RowDefinition.Style>
+                        <Style TargetType="RowDefinition">
+                            <Setter Property="Height" Value="Auto" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Options.VisualizerOptions.ShowBreakArgsField}" Value="False">
+                                    <Setter Property="Height" Value="0" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </RowDefinition.Style>
+                </RowDefinition>
             </Grid.RowDefinitions>
             <Label Grid.Row="0" Grid.Column="0" Content="Columns:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
             <Label Grid.Row="1" Grid.Column="0" Content="App args:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
             <Label Grid.Row="2" Grid.Column="0" Content="Break args:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
+            <Label Grid.Row="3" Grid.Column="0" Content="Wavemap:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
             <TextBox Text="{Binding Options.VisualizerColumnStyling.VisibleColumns, UpdateSourceTrigger=PropertyChanged}"
                      Grid.Row="0" Grid.Column="1" Height="24" VerticalContentAlignment="Center"
                      Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
@@ -137,6 +150,7 @@
                      Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
                      Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
                      BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
+            <Canvas x:Name="WavemapCanvas" Grid.Row="3" Grid.Column="1"/>
         </Grid>
     </StackPanel>
 </UserControl>

--- a/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
@@ -152,7 +152,7 @@
                      Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
                      BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
             <ScrollViewer HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Hidden" Grid.Row="3" Grid.Column="1">
-                <Canvas x:Name="WavemapCanvas" Width="{Binding CanvasWidth}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,0,0,25"/>
+                <Canvas x:Name="WavemapCanvas" Width="{Binding CanvasWidth}" Height="{Binding CanvasHeight}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"/>
             </ScrollViewer>
         </Grid>
     </StackPanel>

--- a/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
@@ -151,7 +151,9 @@
                      Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
                      Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
                      BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
-            <Canvas x:Name="WavemapCanvas" Grid.Row="3" Grid.Column="1"/>
+            <ScrollViewer HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Hidden" Grid.Row="3" Grid.Column="1">
+                <Canvas x:Name="WavemapCanvas" Width="{Binding CanvasWidth}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,0,0,25"/>
+            </ScrollViewer>
         </Grid>
     </StackPanel>
 </UserControl>

--- a/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
@@ -15,6 +15,7 @@
             <MenuItem Header="Columns" IsChecked="{Binding Options.VisualizerOptions.ShowColumnsField, Mode=TwoWay}" IsCheckable="True"/>
             <MenuItem Header="App args" IsChecked="{Binding Options.VisualizerOptions.ShowAppArgsField, Mode=TwoWay}" IsCheckable="True"/>
             <MenuItem Header="Break args" IsChecked="{Binding Options.VisualizerOptions.ShowBreakArgsField, Mode=TwoWay}" IsCheckable="True"/>
+            <MenuItem Header="Wavemap" IsChecked="{Binding Options.VisualizerOptions.ShowWavemapField, Mode=TwoWay}" IsCheckable="True"/>
         </ContextMenu>
     </UserControl.ContextMenu>
     <UserControl.Resources>
@@ -123,7 +124,7 @@
                         <Style TargetType="RowDefinition">
                             <Setter Property="Height" Value="Auto" />
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding Options.VisualizerOptions.ShowBreakArgsField}" Value="False">
+                                <DataTrigger Binding="{Binding Options.VisualizerOptions.ShowWavemapField}" Value="False">
                                     <Setter Property="Height" Value="0" />
                                 </DataTrigger>
                             </Style.Triggers>

--- a/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
@@ -152,7 +152,7 @@
                      Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
                      BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
             <ScrollViewer HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Hidden" Grid.Row="3" Grid.Column="1">
-                <Canvas x:Name="WavemapCanvas" Width="{Binding CanvasWidth}" Height="{Binding CanvasHeight}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"/>
+                <Canvas x:Name="WavemapCanvas" Width="{Binding CanvasWidth}" Height="{Binding CanvasHeight}" VerticalAlignment="Stretch" HorizontalAlignment="Left"/>
             </ScrollViewer>
         </Grid>
     </StackPanel>

--- a/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
@@ -151,7 +151,7 @@
                      Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
                      Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
                      BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
-            <ScrollViewer HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Hidden" Grid.Row="3" Grid.Column="1">
+            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Hidden" Grid.Row="3" Grid.Column="1">
                 <Canvas x:Name="WavemapCanvas" Width="{Binding CanvasWidth}" Height="{Binding CanvasHeight}" VerticalAlignment="Stretch" HorizontalAlignment="Left"/>
             </ScrollViewer>
         </Grid>

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
@@ -41,8 +41,8 @@ namespace VSRAD.Package.DebugVisualizer
                 for (int j = 0; j < 2; ++j)
                 {
                     var r = GetWaveRectangleByCoordinates(j, i);
-                    _canvas.Children.OfType<Rectangle>().ElementAt(j * 200 + i).Fill = r.Fill;
-                    _canvas.Children.OfType<Rectangle>().ElementAt(j * 200 + i).ToolTip = r.ToolTip;
+                    _rectangles[j][i].Fill = r.Fill;
+                    _rectangles[j][i].ToolTip = r.ToolTip;
                 }
             }
             _canvas.InvalidateVisual();

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Windows.Shapes;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Windows.Shapes;
 using System.Windows.Controls;
 using System.Windows.Media;
 using VSRAD.Package.DebugVisualizer.Wavemap;
-using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Debugger.Interop;
-using VSRAD.Package.Server;
 
 namespace VSRAD.Package.DebugVisualizer
 {
@@ -26,7 +18,7 @@ namespace VSRAD.Package.DebugVisualizer
             {
                 for (int j = 0; j < 2; ++j)
                 {
-                    var r = GetWaveRectangleByCoordinates(j, i);
+                    var r = InitiateWaveRectangle(j, i);
                     _rectangles[j][i] = r;
                     _canvas.Children.Add(r);
                 }
@@ -37,28 +29,15 @@ namespace VSRAD.Package.DebugVisualizer
         {
             _view = view;
             for (int i = 0; i < 200; ++i)
-            {
                 for (int j = 0; j < 2; ++j)
-                {
-                    var r = GetWaveRectangleByCoordinates(j, i);
-                    _rectangles[j][i].Fill = r.Fill;
-                    _rectangles[j][i].ToolTip = r.ToolTip;
-                    _rectangles[j][i].Visibility = r.Visibility;
-                }
-            }
+                    UpdateWaveRectangle(j, i);
             _canvas.InvalidateVisual();
         }
 
-        private Rectangle GetWaveRectangleByCoordinates(int row, int column)
+        private Rectangle InitiateWaveRectangle(int row, int column)
         {
-            var validWave = _view != null && _view.IsValidWave(row, column);
             var r = new Rectangle();
-            r.ToolTip = new ToolTip() { Content = validWave ?
-                $"Group: {_view[row, column].GroupIdx}\nWave: {_view[row, column].WaveIdx}\nLine: {_view[row, column].BreakLine}"
-                : ""
-            };
-            r.Fill = validWave ? _view[row, column].BreakColor : Brushes.Gray;
-            r.Visibility = validWave ? System.Windows.Visibility.Visible : System.Windows.Visibility.Hidden;
+            r.Visibility =  System.Windows.Visibility.Hidden;
             r.Height = 7;
             r.Width = 7;
             r.StrokeThickness = 1;
@@ -66,6 +45,21 @@ namespace VSRAD.Package.DebugVisualizer
             Canvas.SetLeft(r, 1 + 6 * column);
             Canvas.SetTop(r, 1 + 6 * row);
             return r;
+        }
+
+        private void UpdateWaveRectangle(int row, int column)
+        {
+            var r = _rectangles[row][column];
+            var validWave = _view != null && _view.IsValidWave(row, column);
+            r.ToolTip = new ToolTip()
+            {
+                Content = validWave ?
+                    $"Group: {_view[row, column].GroupIdx}\nWave: {_view[row, column].WaveIdx}\nLine: {_view[row, column].BreakLine}"
+                    : ""
+            };
+
+            r.Fill = validWave ? _view[row, column].BreakColor : Brushes.Gray;
+            r.Visibility = validWave ? System.Windows.Visibility.Visible : System.Windows.Visibility.Hidden;
         }
     }
 }

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
@@ -121,17 +121,12 @@ namespace VSRAD.Package.DebugVisualizer
 
         private void UpdateWaveRectangle(int row, int column)
         {
+            if (_view == null) return;
             var r = _rectangles[row][column];
-            var validWave = _view != null && _view.IsValidWave(row, column);
-            r.ToolTip = new ToolTip()
-            {
-                Content = validWave ?
-                    $"Group: {_view[row, column].GroupIdx}\nWave: {_view[row, column].WaveIdx}\nLine: {_view[row, column].BreakLine}"
-                    : ""
-            };
-
-            r.Fill = validWave ? _view[row, column].BreakColor : Brushes.Gray;
-            r.Visibility = validWave ? System.Windows.Visibility.Visible : System.Windows.Visibility.Hidden;
+            var wave = _view[row, column];
+            r.ToolTip = new ToolTip() { Content = wave.ToolTipText };
+            r.Fill = wave.BreakColor;
+            r.Visibility = wave.IsVisible ? System.Windows.Visibility.Visible : System.Windows.Visibility.Hidden;
         }
     }
 }

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
@@ -34,10 +34,8 @@ namespace VSRAD.Package.DebugVisualizer
                 else
                 {
                     for (int i = view.WavesPerGroup; i < _rectangles.Count; ++i)
-                    {
                         for (int j = 0; j < view.GroupCount; ++j)
                             _rectangles[i][j].Visibility = System.Windows.Visibility.Hidden;
-                    }
                 }
             }
 
@@ -54,6 +52,12 @@ namespace VSRAD.Package.DebugVisualizer
                             _canvas.Children.Add(r);
                         }
                     }
+                }
+                else
+                {
+                    for (int i = 0; i < view.WavesPerGroup; ++i)
+                        for (int j = view.GroupCount; j < _rectangles[0].Count; ++j)
+                            _rectangles[i][j].Visibility = System.Windows.Visibility.Hidden;
                 }
             }
 

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
@@ -12,12 +12,36 @@ namespace VSRAD.Package.DebugVisualizer
         private readonly List<List<Rectangle>> _rectangles = new List<List<Rectangle>> { new List<Rectangle>(), new List<Rectangle>() };
         private WavemapView _view;
 
-        public int Height => _view.WavesPerGroup * 6 + 2; // 6 is rectangle width, +2 for borders
-        public int Width => _view.GroupCount * 6 + 2;
+        public int Height => _view.WavesPerGroup * (_rectangleSize - 1) + 2; // 6 is rectangle width, +2 for borders
+        public int Width => _view.GroupCount * (_rectangleSize - 1) + 2;
 
-        public WavemapCanvas(Canvas canvas)
+        private int _rectangleSize;
+        public int RectangleSize
+        {
+            get => _rectangleSize;
+            set => SetRectangleSize(value);
+        }
+
+        public WavemapCanvas(Canvas canvas, int rectangleSize)
         {
             _canvas = canvas;
+            _rectangleSize = rectangleSize;
+        }
+
+        private void SetRectangleSize(int size)
+        {
+            _rectangleSize = size;
+            for (int i = 0; i < _rectangles.Count; ++i)
+            {
+                for (int j = 0; j < _rectangles[i].Count; ++j)
+                {
+                    _rectangles[i][j].Height = size;
+                    _rectangles[i][j].Width = size;
+                    Canvas.SetLeft(_rectangles[i][j], 1 + (size - 1) * i);
+                    Canvas.SetTop(_rectangles[i][j], 1 + (size - 1) * j);
+                }
+            }
+            _canvas.InvalidateVisual();
         }
 
         public void SetData(WavemapView view)
@@ -69,16 +93,16 @@ namespace VSRAD.Package.DebugVisualizer
             _canvas.InvalidateVisual();
         }
 
-        private static Rectangle InitiateWaveRectangle(int row, int column)
+        private Rectangle InitiateWaveRectangle(int row, int column)
         {
             var r = new Rectangle();
             r.Visibility = System.Windows.Visibility.Hidden;
-            r.Height = 7;
-            r.Width = 7;
+            r.Height = _rectangleSize;
+            r.Width = _rectangleSize;
             r.StrokeThickness = 1;
             r.Stroke = Brushes.Black;
-            Canvas.SetLeft(r, 1 + 6 * column);
-            Canvas.SetTop(r, 1 + 6 * row);
+            Canvas.SetLeft(r, 1 + (_rectangleSize - 1) * column);
+            Canvas.SetTop(r, 1 + (_rectangleSize - 1) * row);
             return r;
         }
 

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
@@ -12,8 +12,8 @@ namespace VSRAD.Package.DebugVisualizer
         private readonly List<List<Rectangle>> _rectangles = new List<List<Rectangle>> { new List<Rectangle>(), new List<Rectangle>() };
         private WavemapView _view;
 
-        public int Height => _view.WavesPerGroup * (_rectangleSize - 1) + 2;
-        public int Width => _view.GroupCount * (_rectangleSize - 1) + 2;
+        public int Height => _view.WavesPerGroup == 0 ? 0 : _view.WavesPerGroup * (_rectangleSize - 1) + 2;
+        public int Width => _view.WavesPerGroup == 0 ? 0 : _view.GroupCount * (_rectangleSize - 1) + 2;
 
         private int _rectangleSize;
         public int RectangleSize
@@ -47,6 +47,19 @@ namespace VSRAD.Package.DebugVisualizer
         public void SetData(WavemapView view)
         {
             _view = view;
+
+            /*
+             * if waves per group is 0
+             * we just want to hide wavemap
+             * table without any reshaping
+             */
+            if (view.WavesPerGroup == 0)
+            {
+                foreach (var row in _rectangles)
+                    foreach (var el in row)
+                        el.Visibility = System.Windows.Visibility.Hidden;
+                return;
+            }
 
             if (view.WavesPerGroup != _rectangles.Count)
             {

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
@@ -124,7 +124,7 @@ namespace VSRAD.Package.DebugVisualizer
             if (_view == null) return;
             var r = _rectangles[row][column];
             var wave = _view[row, column];
-            r.ToolTip = new ToolTip() { Content = wave.ToolTipText };
+            r.ToolTip = new ToolTip() { Content = wave.IsVisible ? $"Group: {column}\nWave: {row}\nLine: {wave.BreakLine}" : "" };
             r.Fill = wave.BreakColor;
             r.Visibility = wave.IsVisible ? System.Windows.Visibility.Visible : System.Windows.Visibility.Hidden;
         }

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
@@ -12,7 +12,7 @@ namespace VSRAD.Package.DebugVisualizer
         private readonly List<List<Rectangle>> _rectangles = new List<List<Rectangle>> { new List<Rectangle>(), new List<Rectangle>() };
         private WavemapView _view;
 
-        public int Height => _view.WavesPerGroup * (_rectangleSize - 1) + 2; // 6 is rectangle width, +2 for borders
+        public int Height => _view.WavesPerGroup * (_rectangleSize - 1) + 2;
         public int Width => _view.GroupCount * (_rectangleSize - 1) + 2;
 
         private int _rectangleSize;
@@ -37,8 +37,8 @@ namespace VSRAD.Package.DebugVisualizer
                 {
                     _rectangles[i][j].Height = size;
                     _rectangles[i][j].Width = size;
-                    Canvas.SetLeft(_rectangles[i][j], 1 + (size - 1) * i);
-                    Canvas.SetTop(_rectangles[i][j], 1 + (size - 1) * j);
+                    Canvas.SetLeft(_rectangles[i][j], 1 + (size - 1) * j);
+                    Canvas.SetTop(_rectangles[i][j], 1 + (size - 1) * i);
                 }
             }
             _canvas.InvalidateVisual();

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
@@ -2,13 +2,15 @@
 using System.Windows.Controls;
 using System.Windows.Media;
 using VSRAD.Package.DebugVisualizer.Wavemap;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace VSRAD.Package.DebugVisualizer
 {
     class WavemapCanvas
     {
         private readonly Canvas _canvas;
-        private readonly Rectangle[][] _rectangles = { new Rectangle[200], new Rectangle[200] };
+        private readonly List<Rectangle[]> _rectangles = new List<Rectangle[]> { new Rectangle[200], new Rectangle[200] };
         private WavemapView _view;
 
         public WavemapCanvas(Canvas canvas)
@@ -28,8 +30,39 @@ namespace VSRAD.Package.DebugVisualizer
         public void SetData(WavemapView view)
         {
             _view = view;
+
+            if (view.WavesPerGroup != _rectangles.Count)
+            {
+                if (view.WavesPerGroup > _rectangles.Count)
+                {
+                    var rCount = _rectangles.Count;
+                    for (int i = rCount; i < view.WavesPerGroup; ++i)
+                    {
+                        _rectangles.Add(new Rectangle[200]);
+                    }
+
+                    for (int i = 0; i < 200; ++i)
+                    {
+                        for (int j = rCount; j < view.WavesPerGroup; ++j)
+                        {
+                            var r = InitiateWaveRectangle(j, i);
+                            _rectangles[j][i] = r;
+                            _canvas.Children.Add(r);
+                        }
+                    }
+                }
+                else
+                {
+                    for (int i = view.WavesPerGroup; i < _rectangles.Count; ++i)
+                    {
+                        for (int j = 0; j < 200; ++j)
+                            _rectangles[i][j].Visibility = System.Windows.Visibility.Hidden;
+                    }
+                }
+            }
+
             for (int i = 0; i < 200; ++i)
-                for (int j = 0; j < 2; ++j)
+                for (int j = 0; j < view.WavesPerGroup; ++j)
                     UpdateWaveRectangle(j, i);
             _canvas.InvalidateVisual();
         }

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
@@ -61,7 +61,7 @@ namespace VSRAD.Package.DebugVisualizer
                 else
                 {
                     for (int i = view.WavesPerGroup; i < _rectangles.Count; ++i)
-                        for (int j = 0; j < view.GroupCount; ++j)
+                        for (int j = 0; j < _rectangles[i].Count; ++j)
                             _rectangles[i][j].Visibility = System.Windows.Visibility.Hidden;
                 }
             }

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
@@ -12,12 +12,15 @@ namespace VSRAD.Package.DebugVisualizer
         private readonly List<List<Rectangle>> _rectangles = new List<List<Rectangle>> { new List<Rectangle>(), new List<Rectangle>() };
         private WavemapView _view;
 
+        public int Height => _view.WavesPerGroup * 6 + 2; // 6 is rectangle width, +2 for borders
+        public int Width => _view.GroupCount * 6 + 2;
+
         public WavemapCanvas(Canvas canvas)
         {
             _canvas = canvas;
         }
 
-        public int SetData(WavemapView view)
+        public void SetData(WavemapView view)
         {
             _view = view;
 
@@ -65,8 +68,6 @@ namespace VSRAD.Package.DebugVisualizer
                 for (int j = 0; j < view.WavesPerGroup; ++j)
                     UpdateWaveRectangle(j, i);
             _canvas.InvalidateVisual();
-
-            return view.GroupCount * 6 + 2; // 6 is rectangle width, +2 for borders
         }
 
         private static Rectangle InitiateWaveRectangle(int row, int column)

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
@@ -43,6 +43,7 @@ namespace VSRAD.Package.DebugVisualizer
                     var r = GetWaveRectangleByCoordinates(j, i);
                     _rectangles[j][i].Fill = r.Fill;
                     _rectangles[j][i].ToolTip = r.ToolTip;
+                    _rectangles[j][i].Visibility = r.Visibility;
                 }
             }
             _canvas.InvalidateVisual();
@@ -54,9 +55,10 @@ namespace VSRAD.Package.DebugVisualizer
             var r = new Rectangle();
             r.ToolTip = new ToolTip() { Content = validWave ?
                 $"Group: {_view[row, column].GroupIdx}\nWave: {_view[row, column].WaveIdx}\nLine: {_view[row, column].BreakLine}"
-                : "No data"
+                : ""
             };
             r.Fill = validWave ? _view[row, column].BreakColor : Brushes.Gray;
+            r.Visibility = validWave ? System.Windows.Visibility.Visible : System.Windows.Visibility.Hidden;
             r.Height = 7;
             r.Width = 7;
             r.StrokeThickness = 1;

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapCanvas.cs
@@ -42,25 +42,24 @@ namespace VSRAD.Package.DebugVisualizer
                 }
             }
 
-            if (_rectangles[0].Count != view.GroupCount)
+            for (int j = 0; j < _rectangles.Count; ++j)
             {
-                if (view.GroupCount > _rectangles[0].Count)
+                if (_rectangles[j].Count != view.GroupCount)
                 {
-                    for (int i = _rectangles[0].Count; i < view.GroupCount; ++i)
+                    if (view.GroupCount > _rectangles[j].Count)
                     {
-                        for (int j = 0; j < _rectangles.Count; ++j)
+                        for (int i = _rectangles[j].Count; i < view.GroupCount; ++i)
                         {
                             var r = InitiateWaveRectangle(j, i);
                             _rectangles[j].Add(r);
                             _canvas.Children.Add(r);
                         }
                     }
-                }
-                else
-                {
-                    for (int i = 0; i < view.WavesPerGroup; ++i)
-                        for (int j = view.GroupCount; j < _rectangles[0].Count; ++j)
-                            _rectangles[i][j].Visibility = System.Windows.Visibility.Hidden;
+                    else
+                    {
+                        for (int i = view.GroupCount; i < _rectangles[j].Count; ++i)
+                            _rectangles[j][i].Visibility = System.Windows.Visibility.Hidden;
+                    }
                 }
             }
 

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -42,7 +42,7 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
     {
         private readonly int _waveSize;
         private readonly int _laneDataSize;
-        private readonly int _wavesPerGroup;
+        public int WavesPerGroup { get; }
 
         private readonly uint[] _data;
 
@@ -53,7 +53,7 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
             _data = data;
             _waveSize = waveSize;
             _laneDataSize = laneDataSize;
-            _wavesPerGroup = groupSize / waveSize;
+            WavesPerGroup = groupSize / waveSize;
             _colorManager = new BreakpointColorManager();
         }
 
@@ -64,9 +64,9 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
         }
 
         public bool IsValidWave(int row, int column) =>
-            GetWaveFlatIndex(row, column) * _waveSize * _laneDataSize + _laneDataSize < _data.Length && row < _wavesPerGroup;
+            GetWaveFlatIndex(row, column) * _waveSize * _laneDataSize + _laneDataSize < _data.Length && row < WavesPerGroup;
 
-        private int GetWaveFlatIndex(int row, int column) => column * _wavesPerGroup + row;
+        private int GetWaveFlatIndex(int row, int column) => column * WavesPerGroup + row;
 
         private WaveInfo GetWaveInfoByRowAndColumn(int row, int column)
         {

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -11,6 +11,8 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
         public uint BreakLine;
         public int GroupIdx;
         public int WaveIdx;
+        public string ToolTipText;
+        public bool IsVisible;
     }
 #pragma warning restore CA1815
 
@@ -68,13 +70,25 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
             return _data[breakIndex];
         }
 
-        public bool IsValidWave(int row, int column) =>
+        private bool IsValidWave(int row, int column) =>
             GetWaveFlatIndex(row, column) * _waveSize * _laneDataSize + _laneDataSize < _data.Length && row < WavesPerGroup;
 
         private int GetWaveFlatIndex(int row, int column) => column * WavesPerGroup + row;
 
         private WaveInfo GetWaveInfoByRowAndColumn(int row, int column)
         {
+            if (!IsValidWave(row, column))
+                return new WaveInfo
+                {
+                    BreakColor = Brushes.Gray,
+                    BreakLine = 0,
+                    GroupIdx = 0,
+                    WaveIdx = 0,
+                    ToolTipText = "",
+                    IsVisible = false
+                };
+
+
             var flatIndex = GetWaveFlatIndex(row, column);
             var breakLine = GetBreakpointLine(flatIndex);
 
@@ -83,7 +97,9 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
                 BreakColor = _colorManager.GetColorForBreakpoint(breakLine),
                 BreakLine = breakLine,
                 GroupIdx = column,
-                WaveIdx = row
+                WaveIdx = row,
+                ToolTipText = $"Group: {column}\nWave: {row}\nLine: {breakLine}",
+                IsVisible = true
             };
         }
 

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -1,39 +1,74 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace VSRAD.Package.DebugVisualizer.Wavemap
 {
+    struct WaveInfo
+    {
+        Color BreakColor;
+        uint BreakLine;
+        uint GroupIdx;
+        uint WaveIdx;
+    }
+
+    class BreakpointColorManager
+    {
+        private readonly Dictionary<uint, Color> _breakpointColorMapping = new Dictionary<uint, Color>();
+        private readonly Color[] _colors = new Color[] { Color.Red, Color.Blue, Color.Green, Color.Yellow, Color.Cyan };
+        private uint _currentColorIndex;
+
+        private Color GetNextColor()
+        {
+            if (_currentColorIndex == _colors.Length) _currentColorIndex = 0;
+            return _colors[_currentColorIndex++];
+        }
+
+        public Color GetColorForBreakpoint(uint breakLine)
+        {
+            if (_breakpointColorMapping.TryGetValue(breakLine, out var color))
+            {
+                return color;
+            }
+            else
+            {
+                var c = GetNextColor();
+                _breakpointColorMapping.Add(breakLine, c);
+                return c;
+            }
+
+        }
+    }
+
     public sealed class WavemapView
     {
-        private readonly int _groupSize;
+        private readonly int _waveSize;
         private readonly int _laneDataSize;
-        private readonly int _groupCount;
 
         private readonly uint[] _data;
 
-        public WavemapView(uint[] data, int groupSize, int laneDataSize, int groupCount)
+        private readonly BreakpointColorManager _colorManager;
+
+        public WavemapView(uint[] data, int waveSize, int laneDataSize)
         {
             _data = data;
-            _groupSize = groupSize;
-            _groupCount = groupCount;
+            _waveSize = waveSize;
             _laneDataSize = laneDataSize;
+            _colorManager = new BreakpointColorManager();
         }
 
-        public bool IsActiveGroup(int groupIndex) => groupIndex < _groupCount;
-
-        public bool GroupExecuted(int groupIndex)
+        public uint GetBreakpointLine(int waveIndex)
         {
-            var execMaskIndex = groupIndex * _groupSize * _laneDataSize + (8 * _laneDataSize); // execmask is in 8-9 lane of system watch
-            return _data[execMaskIndex] != 0 || _data[execMaskIndex + _laneDataSize] != 0;
+            var breakIndex = waveIndex * _waveSize * _laneDataSize + _laneDataSize; // break line is in the first lane of system watch
+            return _data[breakIndex];
         }
 
-        public int GetBreakpointLine(int groupIndex)
+        public Color GetWaveColor(int waveIndex)
         {
-            var breakIndex = groupIndex * _groupSize * _laneDataSize + _laneDataSize; // break line is in the first lane of system watch
-            return (int)_data[breakIndex];
+            return _colorManager.GetColorForBreakpoint(GetBreakpointLine(waveIndex));
         }
     }
 }

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -11,7 +11,6 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
         public uint BreakLine;
         public int GroupIdx;
         public int WaveIdx;
-        public string ToolTipText;
         public bool IsVisible;
     }
 #pragma warning restore CA1815
@@ -84,7 +83,6 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
                     BreakLine = 0,
                     GroupIdx = 0,
                     WaveIdx = 0,
-                    ToolTipText = "",
                     IsVisible = false
                 };
 
@@ -98,7 +96,6 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
                 BreakLine = breakLine,
                 GroupIdx = column,
                 WaveIdx = row,
-                ToolTipText = $"Group: {column}\nWave: {row}\nLine: {breakLine}",
                 IsVisible = true
             };
         }

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VSRAD.Package.DebugVisualizer.Wavemap
 {

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -39,7 +39,6 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
                 _breakpointColorMapping.Add(breakLine, c);
                 return c;
             }
-
         }
     }
 

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -4,6 +4,7 @@ using System.Windows.Media;
 
 namespace VSRAD.Package.DebugVisualizer.Wavemap
 {
+#pragma warning disable CA1815 // the comparing of this structs is not a case, so disable warning that tells us to implement Equals()
     public struct WaveInfo
     {
         public Brush BreakColor;
@@ -11,6 +12,7 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
         public int GroupIdx;
         public int WaveIdx;
     }
+#pragma warning restore CA1815
 
     class BreakpointColorManager
     {

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -63,6 +63,9 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
             return _data[breakIndex];
         }
 
+        public bool IsValidWave(int row, int column) =>
+            GetWaveFlatIndex(row, column) * _waveSize * _laneDataSize + _laneDataSize < _data.Length && row < _wavesPerGroup;
+
         private int GetWaveFlatIndex(int row, int column) => column * _wavesPerGroup + row;
 
         private WaveInfo GetWaveInfoByRowAndColumn(int row, int column)

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
-using System.Drawing;
+using System.Windows.Media;
 
 namespace VSRAD.Package.DebugVisualizer.Wavemap
 {
     public struct WaveInfo
     {
-        public Color BreakColor;
+        public Brush BreakColor;
         public uint BreakLine;
         public int GroupIdx;
         public int WaveIdx;
@@ -13,17 +13,17 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
 
     class BreakpointColorManager
     {
-        private readonly Dictionary<uint, Color> _breakpointColorMapping = new Dictionary<uint, Color>();
-        private readonly Color[] _colors = new Color[] { Color.Red, Color.Blue, Color.Green, Color.Yellow, Color.Cyan };
+        private readonly Dictionary<uint, Brush> _breakpointColorMapping = new Dictionary<uint, Brush>();
+        private readonly Brush[] _colors = new Brush[] { Brushes.Red, Brushes.Blue, Brushes.Green, Brushes.Yellow, Brushes.Cyan };
         private uint _currentColorIndex;
 
-        private Color GetNextColor()
+        private Brush GetNextColor()
         {
             if (_currentColorIndex == _colors.Length) _currentColorIndex = 0;
             return _colors[_currentColorIndex++];
         }
 
-        public Color GetColorForBreakpoint(uint breakLine)
+        public Brush GetColorForBreakpoint(uint breakLine)
         {
             if (_breakpointColorMapping.TryGetValue(breakLine, out var color))
             {

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -29,5 +29,11 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
             var execMaskIndex = groupIndex * _groupSize * _laneDataSize + (8 * _laneDataSize); // execmask is in 8-9 lane of system watch
             return _data[execMaskIndex] != 0 || _data[execMaskIndex + _laneDataSize] != 0;
         }
+
+        public int GetBreakpointLine(int groupIndex)
+        {
+            var breakIndex = groupIndex * _groupSize * _laneDataSize + _laneDataSize; // break line is in the first lane of system watch
+            return (int)_data[breakIndex];
+        }
     }
 }

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VSRAD.Package.DebugVisualizer.Wavemap
+{
+    public sealed class WavemapView
+    {
+        private readonly int _groupSize;
+        private readonly int _laneDataSize;
+        private readonly int _groupCount;
+
+        private readonly uint[] _data;
+
+        public WavemapView(uint[] data, int groupSize, int laneDataSize, int groupCount)
+        {
+            _data = data;
+            _groupSize = groupSize;
+            _groupCount = groupCount;
+            _laneDataSize = laneDataSize;
+        }
+
+        public bool IsActiveGroup(int groupIndex) => groupIndex < _groupCount;
+
+        public bool GroupExecuted(int groupIndex)
+        {
+            var execMaskIndex = groupIndex * _groupSize * _laneDataSize + (8 * _laneDataSize); // execmask is in 8-9 lane of system watch
+            return _data[execMaskIndex] != 0 || _data[execMaskIndex + _laneDataSize] != 0;
+        }
+    }
+}

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Data;
 using System.Windows.Media;
 
 namespace VSRAD.Package.DebugVisualizer.Wavemap
@@ -43,17 +44,19 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
         private readonly int _waveSize;
         private readonly int _laneDataSize;
         public int WavesPerGroup { get; }
+        public int GroupCount { get; }
 
         private readonly uint[] _data;
 
         private readonly BreakpointColorManager _colorManager;
 
-        public WavemapView(uint[] data, int waveSize, int laneDataSize, int groupSize)
+        public WavemapView(uint[] data, int waveSize, int laneDataSize, int groupSize, int groupCount)
         {
             _data = data;
             _waveSize = waveSize;
             _laneDataSize = laneDataSize;
             WavesPerGroup = groupSize / waveSize;
+            GroupCount = groupCount;
             _colorManager = new BreakpointColorManager();
         }
 

--- a/VSRAD.Package/DebugVisualizer/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/WavemapCanvas.cs
@@ -30,8 +30,10 @@ namespace VSRAD.Package.DebugVisualizer
             {
                 for (int i = 0, x = 1; i < 200; ++i, x += 6)
                 {
+                    var wave = _wiew[y, i];
                     var r = new Rectangle();
-                    r.Fill = _wiew[y, i].BreakColor;
+                    r.ToolTip = new ToolTip() { Content = $"Group: {wave.GroupIdx}\nWave: {wave.WaveIdx}\nLine: {wave.BreakLine}" };
+                    r.Fill = wave.BreakColor;
                     r.Height = 7;
                     r.Width = 7;
                     r.StrokeThickness = 1;

--- a/VSRAD.Package/DebugVisualizer/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/WavemapCanvas.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using System.Windows.Controls;
 using System.Windows.Media;
 using VSRAD.Package.DebugVisualizer.Wavemap;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Debugger.Interop;
 
 namespace VSRAD.Package.DebugVisualizer
 {
@@ -20,8 +22,8 @@ namespace VSRAD.Package.DebugVisualizer
         {
             _canvas = canvas;
 
-            var _data = new uint[7200];
-            for (uint i = 3, j = 313; i < 7200; i += 18, j += 313)
+            var _data = new uint[7000];
+            for (uint i = 3, j = 313; i < 7000; i += 18, j += 313)
                 _data[i] = j;
 
             _wiew = new WavemapView(_data, 6, 3, 12);
@@ -39,16 +41,19 @@ namespace VSRAD.Package.DebugVisualizer
 
         private Rectangle GetWaveRectangleByCoordinates(int row, int column)
         {
-            var wave = _wiew[row, column];
+            var validWave = _wiew.IsValidWave(row, column);
             var r = new Rectangle();
-            r.ToolTip = new ToolTip() { Content = $"Group: {wave.GroupIdx}\nWave: {wave.WaveIdx}\nLine: {wave.BreakLine}" };
-            r.Fill = wave.BreakColor;
+            r.ToolTip = new ToolTip() { Content = validWave ?
+                $"Group: {_wiew[row, column].GroupIdx}\nWave: {_wiew[row, column].WaveIdx}\nLine: {_wiew[row, column].BreakLine}"
+                : "No data"
+            };
+            r.Fill = validWave ? _wiew[row, column].BreakColor : Brushes.Gray;
             r.Height = 7;
             r.Width = 7;
             r.StrokeThickness = 1;
             r.Stroke = Brushes.Black;
             Canvas.SetLeft(r, 1 + 6 * column);
-            Canvas.SetTop(r, 1 + 7 * row);
+            Canvas.SetTop(r, 1 + 6 * row);
             return r;
         }
     }

--- a/VSRAD.Package/DebugVisualizer/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/WavemapCanvas.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Controls;
 using System.Windows.Media;
+using VSRAD.Package.DebugVisualizer.Wavemap;
 
 namespace VSRAD.Package.DebugVisualizer
 {
@@ -13,16 +14,24 @@ namespace VSRAD.Package.DebugVisualizer
     {
         private readonly Canvas _canvas;
         private readonly Rectangle[][] _rectangles = { new Rectangle[200], new Rectangle[200] };
+        private readonly WavemapView _wiew;
 
         public WavemapCanvas(Canvas canvas)
         {
             _canvas = canvas;
+
+            var _data = new uint[7200];
+            for (uint i = 3, j = 313; i < 7200; i += 18, j += 313)
+                _data[i] = j;
+
+            _wiew = new WavemapView(_data, 6, 3, 12);
+
             for (int y = 0; y < 2; ++y)
             {
                 for (int i = 0, x = 1; i < 200; ++i, x += 6)
                 {
                     var r = new Rectangle();
-                    r.Fill = Brushes.Gray;
+                    r.Fill = _wiew[y, i].BreakColor;
                     r.Height = 7;
                     r.Width = 7;
                     r.StrokeThickness = 1;

--- a/VSRAD.Package/DebugVisualizer/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/WavemapCanvas.cs
@@ -9,6 +9,7 @@ using System.Windows.Media;
 using VSRAD.Package.DebugVisualizer.Wavemap;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Debugger.Interop;
+using VSRAD.Package.Server;
 
 namespace VSRAD.Package.DebugVisualizer
 {
@@ -16,18 +17,11 @@ namespace VSRAD.Package.DebugVisualizer
     {
         private readonly Canvas _canvas;
         private readonly Rectangle[][] _rectangles = { new Rectangle[200], new Rectangle[200] };
-        private readonly WavemapView _wiew;
+        private WavemapView _view;
 
         public WavemapCanvas(Canvas canvas)
         {
             _canvas = canvas;
-
-            var _data = new uint[7000];
-            for (uint i = 3, j = 313; i < 7000; i += 18, j += 313)
-                _data[i] = j;
-
-            _wiew = new WavemapView(_data, 6, 3, 12);
-
             for (int i = 0; i < 200; ++i)
             {
                 for (int j = 0; j < 2; ++j)
@@ -39,15 +33,30 @@ namespace VSRAD.Package.DebugVisualizer
             }
         }
 
+        public void SetData(WavemapView view)
+        {
+            _view = view;
+            for (int i = 0; i < 200; ++i)
+            {
+                for (int j = 0; j < 2; ++j)
+                {
+                    var r = GetWaveRectangleByCoordinates(j, i);
+                    _canvas.Children.OfType<Rectangle>().ElementAt(j * 200 + i).Fill = r.Fill;
+                    _canvas.Children.OfType<Rectangle>().ElementAt(j * 200 + i).ToolTip = r.ToolTip;
+                }
+            }
+            _canvas.InvalidateVisual();
+        }
+
         private Rectangle GetWaveRectangleByCoordinates(int row, int column)
         {
-            var validWave = _wiew.IsValidWave(row, column);
+            var validWave = _view != null && _view.IsValidWave(row, column);
             var r = new Rectangle();
             r.ToolTip = new ToolTip() { Content = validWave ?
-                $"Group: {_wiew[row, column].GroupIdx}\nWave: {_wiew[row, column].WaveIdx}\nLine: {_wiew[row, column].BreakLine}"
+                $"Group: {_view[row, column].GroupIdx}\nWave: {_view[row, column].WaveIdx}\nLine: {_view[row, column].BreakLine}"
                 : "No data"
             };
-            r.Fill = validWave ? _wiew[row, column].BreakColor : Brushes.Gray;
+            r.Fill = validWave ? _view[row, column].BreakColor : Brushes.Gray;
             r.Height = 7;
             r.Width = 7;
             r.StrokeThickness = 1;

--- a/VSRAD.Package/DebugVisualizer/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/WavemapCanvas.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Shapes;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace VSRAD.Package.DebugVisualizer
+{
+    class WavemapCanvas
+    {
+        private readonly Canvas _canvas;
+        private readonly Rectangle[][] _rectangles = { new Rectangle[200], new Rectangle[200] };
+
+        public WavemapCanvas(Canvas canvas)
+        {
+            _canvas = canvas;
+            for (int y = 0; y < 2; ++y)
+            {
+                for (int i = 0, x = 1; i < 200; ++i, x += 6)
+                {
+                    var r = new Rectangle();
+                    r.Fill = Brushes.Gray;
+                    r.Height = 7;
+                    r.Width = 7;
+                    r.StrokeThickness = 1;
+                    r.Stroke = Brushes.Black;
+                    Canvas.SetLeft(r, x);
+                    Canvas.SetTop(r, 7 * y);
+                    _rectangles[y][i] = r;
+                    _canvas.Children.Add(r);
+                }
+            }
+        }
+    }
+}

--- a/VSRAD.Package/DebugVisualizer/WavemapCanvas.cs
+++ b/VSRAD.Package/DebugVisualizer/WavemapCanvas.cs
@@ -26,24 +26,30 @@ namespace VSRAD.Package.DebugVisualizer
 
             _wiew = new WavemapView(_data, 6, 3, 12);
 
-            for (int y = 0; y < 2; ++y)
+            for (int i = 0; i < 200; ++i)
             {
-                for (int i = 0, x = 1; i < 200; ++i, x += 6)
+                for (int j = 0; j < 2; ++j)
                 {
-                    var wave = _wiew[y, i];
-                    var r = new Rectangle();
-                    r.ToolTip = new ToolTip() { Content = $"Group: {wave.GroupIdx}\nWave: {wave.WaveIdx}\nLine: {wave.BreakLine}" };
-                    r.Fill = wave.BreakColor;
-                    r.Height = 7;
-                    r.Width = 7;
-                    r.StrokeThickness = 1;
-                    r.Stroke = Brushes.Black;
-                    Canvas.SetLeft(r, x);
-                    Canvas.SetTop(r, 7 * y);
-                    _rectangles[y][i] = r;
+                    var r = GetWaveRectangleByCoordinates(j, i);
+                    _rectangles[j][i] = r;
                     _canvas.Children.Add(r);
                 }
             }
+        }
+
+        private Rectangle GetWaveRectangleByCoordinates(int row, int column)
+        {
+            var wave = _wiew[row, column];
+            var r = new Rectangle();
+            r.ToolTip = new ToolTip() { Content = $"Group: {wave.GroupIdx}\nWave: {wave.WaveIdx}\nLine: {wave.BreakLine}" };
+            r.Fill = wave.BreakColor;
+            r.Height = 7;
+            r.Width = 7;
+            r.StrokeThickness = 1;
+            r.Stroke = Brushes.Black;
+            Canvas.SetLeft(r, 1 + 6 * column);
+            Canvas.SetTop(r, 1 + 7 * row);
+            return r;
         }
     }
 }

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -21,7 +21,7 @@ namespace VSRAD.Package.Options
             new ReadOnlyCollection<string>(Watches.Where(w => w.IsAVGPR).Select(w => w.Name).Distinct().ToList());
 
         private uint _nGroups;
-        public uint NGroups { get => _nGroups; set => SetField(ref _nGroups, value); }
+        public uint NGroups { get => _nGroups; set => SetField(ref _nGroups, (uint)0); } // always 0 for now as it should be refactored (see ce37993)
 
         private uint _counter;
         public uint Counter { get => _counter; set => SetField(ref _counter, value); }

--- a/VSRAD.Package/Options/VisualizerOptions.cs
+++ b/VSRAD.Package/Options/VisualizerOptions.cs
@@ -46,6 +46,10 @@ namespace VSRAD.Package.Options
         private bool _showBreakArgsField;
         [DefaultValue(true)]
         public bool ShowBreakArgsField { get => _showBreakArgsField; set => SetField(ref _showBreakArgsField, value); }
+
+        private bool _showWavemapField;
+        [DefaultValue(true)]
+        public bool ShowWavemapField { get => _showWavemapField; set => SetField(ref _showWavemapField, value); }
     }
 
     public sealed class MagicNumberConverter : JsonConverter

--- a/VSRAD.Package/Options/VisualizerOptions.cs
+++ b/VSRAD.Package/Options/VisualizerOptions.cs
@@ -28,6 +28,9 @@ namespace VSRAD.Package.Options
         private uint _waveSize = 64;
         public uint WaveSize { get => _waveSize; set => SetField(ref _waveSize, Math.Max(value, 1)); }  // < 1 causes VS hang
 
+        private int _wavemapElementSize = 7;
+        public int WavemapElementSize { get => _wavemapElementSize; set => SetField(ref _wavemapElementSize, Math.Max(value, 7)); }
+
         private bool _checkMagicNumber = true;
         public bool CheckMagicNumber { get => _checkMagicNumber; set => SetField(ref _checkMagicNumber, value); }
 

--- a/VSRAD.Package/Server/BreakStateData.cs
+++ b/VSRAD.Package/Server/BreakStateData.cs
@@ -177,7 +177,7 @@ namespace VSRAD.Package.Server
                 return null;
 
             var requestedByteOffset = waveOffset * _waveDataSize * 4;
-            var requestedByteCount = fetchWholeFile ? 0 : waveCount * _waveDataSize * 4;
+            var requestedByteCount = waveCount * _waveDataSize * 4;
 
             var response = await channel.SendWithReplyAsync<DebugServer.IPC.Responses.ResultRangeFetched>(
                 new DebugServer.IPC.Commands.FetchResultRange

--- a/VSRAD.Package/Server/BreakStateData.cs
+++ b/VSRAD.Package/Server/BreakStateData.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
+using VSRAD.Package.DebugVisualizer.Wavemap;
 using VSRAD.Package.Options;
 
 namespace VSRAD.Package.Server
@@ -158,6 +159,8 @@ namespace VSRAD.Package.Server
             }
             return new SliceWatchView(_data, groupsInRow, GroupSize, GetGroupCount(GroupSize, nGroups), laneDataOffset, _laneDataSize);
         }
+
+        public WavemapView GetWavemapView(int waveSize) => new WavemapView(_data, waveSize, Watches.Count + 1, GroupSize);
 
         public async Task<string> ChangeGroupWithWarningsAsync(ICommunicationChannel channel, int groupIndex, int groupSize, int nGroups, bool fetchWholeFile = false)
         {

--- a/VSRAD.Package/Server/BreakStateData.cs
+++ b/VSRAD.Package/Server/BreakStateData.cs
@@ -160,7 +160,7 @@ namespace VSRAD.Package.Server
             return new SliceWatchView(_data, groupsInRow, GroupSize, GetGroupCount(GroupSize, nGroups), laneDataOffset, _laneDataSize);
         }
 
-        public WavemapView GetWavemapView(int waveSize) => new WavemapView(_data, waveSize, Watches.Count + 1, GroupSize);
+        public WavemapView GetWavemapView(int waveSize) => new WavemapView(_data, waveSize, Watches.Count + 1, GroupSize, _data.Length / GroupSize / _laneDataSize); // real group count
 
         public async Task<string> ChangeGroupWithWarningsAsync(ICommunicationChannel channel, int groupIndex, int groupSize, int nGroups, bool fetchWholeFile = false)
         {

--- a/VSRAD.Package/Server/BreakStateData.cs
+++ b/VSRAD.Package/Server/BreakStateData.cs
@@ -177,7 +177,7 @@ namespace VSRAD.Package.Server
                 return null;
 
             var requestedByteOffset = waveOffset * _waveDataSize * 4;
-            var requestedByteCount = waveCount * _waveDataSize * 4;
+            var requestedByteCount = fetchWholeFile ? 0 : waveCount * _waveDataSize * 4;
 
             var response = await channel.SendWithReplyAsync<DebugServer.IPC.Responses.ResultRangeFetched>(
                 new DebugServer.IPC.Commands.FetchResultRange

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -169,6 +169,12 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
                         </StackPanel>
+                        <StackPanel Orientation="Horizontal" Height="25">
+                            <TextBlock Text="Wavemap element size" VerticalAlignment="Center"/>
+                            <viz:NumberInput VerticalAlignment="Center" Width="50" Minimum="7" Maximum="100" Margin="5,0,0,0"
+                                            Value="{Binding Options.VisualizerOptions.WavemapElementSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                            <TextBlock Text="px" VerticalAlignment="Center" Margin="5,0,0,0"/>
+                        </StackPanel>
                     </StackPanel>
                 </Expander>
             </StackPanel>

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -174,6 +174,7 @@
     <Compile Include="DebugVisualizer\VisualizerTableHost.cs" />
     <Compile Include="DebugVisualizer\Watch.cs" />
     <Compile Include="BuildTools\BuildToolsServer.cs" />
+    <Compile Include="DebugVisualizer\WavemapCanvas.cs" />
     <Compile Include="Options\Actions.cs" />
     <Compile Include="Options\BuiltinActionFile.cs" />
     <Compile Include="DebugVisualizer\Wavemap\WavemapView.cs" />

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -176,6 +176,7 @@
     <Compile Include="BuildTools\BuildToolsServer.cs" />
     <Compile Include="Options\Actions.cs" />
     <Compile Include="Options\BuiltinActionFile.cs" />
+    <Compile Include="DebugVisualizer\Wavemap\WavemapView.cs" />
     <Compile Include="Options\DefaultOptionValues.cs" />
     <Compile Include="Options\MacroItem.cs" />
     <Compile Include="Options\SliceVisualizerOptions.cs" />

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -174,7 +174,7 @@
     <Compile Include="DebugVisualizer\VisualizerTableHost.cs" />
     <Compile Include="DebugVisualizer\Watch.cs" />
     <Compile Include="BuildTools\BuildToolsServer.cs" />
-    <Compile Include="DebugVisualizer\WavemapCanvas.cs" />
+    <Compile Include="DebugVisualizer\Wavemap\WavemapCanvas.cs" />
     <Compile Include="Options\Actions.cs" />
     <Compile Include="Options\BuiltinActionFile.cs" />
     <Compile Include="DebugVisualizer\Wavemap\WavemapView.cs" />

--- a/VSRAD.PackageTests/DebugVisualizer/ColumnSelectorTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/ColumnSelectorTests.cs
@@ -1,4 +1,4 @@
-﻿using VSRAD.Package.DebugVisualizer;
+using VSRAD.Package.DebugVisualizer;
 using Xunit;
 
 namespace VSRAD.PackageTests.DebugVisualizer

--- a/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
@@ -22,7 +22,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             for (uint i = 3, j = 313; i < 360; i += 18, j += 313)
                 _data[i] = j;
 
-            var wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3, groupSize: 12);
+            var wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3, groupSize: 12, groupCount: 10);
 
             uint expected = 313;
             for (int i = 0; i < 10; ++i)
@@ -43,7 +43,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
                 _data[i] = j;
 
             /* Red, Blue, Green, Yellow, Cyan */
-            var wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3, groupSize: 12);
+            var wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3, groupSize: 12, groupCount: 10);
 
             for (int i = 0; i < 10; ++i)
             {
@@ -57,7 +57,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             for (uint i = 3, j = 313; i < 360; i += 18, j += 313)
                 _data[i] = j;
 
-            wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3, groupSize: 12);
+            wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3, groupSize: 12, groupCount: 10);
 
             Assert.Equal(Brushes.Red, wavemapView[0, 0].BreakColor);
             Assert.Equal(Brushes.Blue, wavemapView[1, 0].BreakColor);
@@ -87,11 +87,11 @@ namespace VSRAD.PackageTests.DebugVisualizer
         [Fact]
         public void IsValidWaveTest()
         {
-            var wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3, groupSize: 12);
+            var wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3, groupSize: 12, groupCount: 10);
 
             for (int i = 0; i < 20; ++i)
                 for (int j = 0; j < 5; ++j)
-                    Assert.Equal(i < 10 && j < 2, wavemapView.IsValidWave(j, i));
+                    Assert.Equal(i < 10 && j < 2, wavemapView[j, i].IsVisible);
         }
     }
 }

--- a/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
@@ -1,4 +1,5 @@
-﻿using VSRAD.Package.DebugVisualizer.Wavemap;
+﻿using System.Xml.Serialization;
+using VSRAD.Package.DebugVisualizer.Wavemap;
 using Xunit;
 
 namespace VSRAD.PackageTests.DebugVisualizer
@@ -11,7 +12,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             777, 0, 15, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 100, 0, 100, 0, 0, 0,  // 1-st group, break on line 15, not-empty exec-mask
             777, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1,       // 2-nd group, empty exec-mask
             777, 0, 105, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100, 0, 100, 0, 0, 0, // 3-rd group, break on line 105, not-empty exec-mask
-            777, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1,       // 4-th group, empty exec-mask TODO: fix
+            777, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1,       // 4-th group, empty exec-mask
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,       // extra data
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,       // extra data
         };
@@ -32,6 +33,16 @@ namespace VSRAD.PackageTests.DebugVisualizer
             var executionMap = new bool[] { true, false, true, false };
             for (int i = 0; i < 4; ++i)
                 Assert.Equal(executionMap[i], wavemapView.GroupExecuted(i));
+        }
+
+        [Fact]
+        public void BreapointLineTest()
+        {
+            var wavemapView = new WavemapView(_data, groupSize: 11, laneDataSize: 2, groupCount: 4);
+
+            var breakpointMap = new int[] { 15, 1, 105, 0 };
+            for (int i = 0; i < 4; ++i)
+                Assert.Equal(breakpointMap[i], wavemapView.GetBreakpointLine(i));
         }
     }
 }

--- a/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
@@ -23,10 +23,17 @@ namespace VSRAD.PackageTests.DebugVisualizer
             for (uint i = 3, j = 313; i < 360; i += 18, j += 313)
                 _data[i] = j;
 
-            var wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3);
+            var wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3, groupSize: 12);
 
-            for (uint i = 0, expected = 313; i < 20; ++i, expected += 313)
-                Assert.Equal(expected, wavemapView.GetBreakpointLine((int)i));
+            uint expected = 313;
+            for (int i = 0; i < 10; ++i)
+            {
+                for (int j = 0; j < 2; ++j)
+                {
+                    Assert.Equal(expected, wavemapView[j, i].BreakLine);
+                    expected += 313;
+                }
+            }
         }
 
         [Fact]
@@ -37,25 +44,45 @@ namespace VSRAD.PackageTests.DebugVisualizer
                 _data[i] = j;
 
             /* Red, Blue, Green, Yellow, Cyan */
-            var wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3);
+            var wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3, groupSize: 12);
 
-            for (int i = 0; i < 20; ++i)
-                Assert.Equal(Color.Red, wavemapView.GetWaveColor(i));
+            for (int i = 0; i < 10; ++i)
+            {
+                for (int j = 0; j < 2; ++j)
+                {
+                    Assert.Equal(Color.Red, wavemapView[j, i].BreakColor);
+                }
+            }
 
             // now lets assume that all waves hitted unique breakpoint
             for (uint i = 3, j = 313; i < 360; i += 18, j += 313)
                 _data[i] = j;
 
-            wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3);
+            wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3, groupSize: 12);
 
-            for (int i = 0; i < 20; i += 5)
-            {
-                Assert.Equal(Color.Red, wavemapView.GetWaveColor(i));
-                Assert.Equal(Color.Blue, wavemapView.GetWaveColor(i+1));
-                Assert.Equal(Color.Green, wavemapView.GetWaveColor(i+2));
-                Assert.Equal(Color.Yellow, wavemapView.GetWaveColor(i+3));
-                Assert.Equal(Color.Cyan, wavemapView.GetWaveColor(i+4));
-            }
+            Assert.Equal(Color.Red, wavemapView[0, 0].BreakColor);
+            Assert.Equal(Color.Blue, wavemapView[1, 0].BreakColor);
+            Assert.Equal(Color.Green, wavemapView[0, 1].BreakColor);
+            Assert.Equal(Color.Yellow, wavemapView[1, 1].BreakColor);
+            Assert.Equal(Color.Cyan, wavemapView[0, 2].BreakColor);
+
+            Assert.Equal(Color.Red, wavemapView[1, 2].BreakColor);
+            Assert.Equal(Color.Blue, wavemapView[0, 3].BreakColor);
+            Assert.Equal(Color.Green, wavemapView[1, 3].BreakColor);
+            Assert.Equal(Color.Yellow, wavemapView[0, 4].BreakColor);
+            Assert.Equal(Color.Cyan, wavemapView[1, 4].BreakColor);
+
+            Assert.Equal(Color.Red, wavemapView[0, 5].BreakColor);
+            Assert.Equal(Color.Blue, wavemapView[1, 5].BreakColor);
+            Assert.Equal(Color.Green, wavemapView[0, 6].BreakColor);
+            Assert.Equal(Color.Yellow, wavemapView[1, 6].BreakColor);
+            Assert.Equal(Color.Cyan, wavemapView[0, 7].BreakColor);
+
+            Assert.Equal(Color.Red, wavemapView[1, 7].BreakColor);
+            Assert.Equal(Color.Blue, wavemapView[0, 8].BreakColor);
+            Assert.Equal(Color.Green, wavemapView[1, 8].BreakColor);
+            Assert.Equal(Color.Yellow, wavemapView[0, 9].BreakColor);
+            Assert.Equal(Color.Cyan, wavemapView[1, 9].BreakColor);
         }
     }
 }

--- a/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+﻿using System.Windows.Media;
 using VSRAD.Package.DebugVisualizer.Wavemap;
 using Xunit;
 
@@ -49,7 +49,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             {
                 for (int j = 0; j < 2; ++j)
                 {
-                    Assert.Equal(Color.Red, wavemapView[j, i].BreakColor);
+                    Assert.Equal(Brushes.Red, wavemapView[j, i].BreakColor);
                 }
             }
 
@@ -59,29 +59,29 @@ namespace VSRAD.PackageTests.DebugVisualizer
 
             wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3, groupSize: 12);
 
-            Assert.Equal(Color.Red, wavemapView[0, 0].BreakColor);
-            Assert.Equal(Color.Blue, wavemapView[1, 0].BreakColor);
-            Assert.Equal(Color.Green, wavemapView[0, 1].BreakColor);
-            Assert.Equal(Color.Yellow, wavemapView[1, 1].BreakColor);
-            Assert.Equal(Color.Cyan, wavemapView[0, 2].BreakColor);
+            Assert.Equal(Brushes.Red, wavemapView[0, 0].BreakColor);
+            Assert.Equal(Brushes.Blue, wavemapView[1, 0].BreakColor);
+            Assert.Equal(Brushes.Green, wavemapView[0, 1].BreakColor);
+            Assert.Equal(Brushes.Yellow, wavemapView[1, 1].BreakColor);
+            Assert.Equal(Brushes.Cyan, wavemapView[0, 2].BreakColor);
 
-            Assert.Equal(Color.Red, wavemapView[1, 2].BreakColor);
-            Assert.Equal(Color.Blue, wavemapView[0, 3].BreakColor);
-            Assert.Equal(Color.Green, wavemapView[1, 3].BreakColor);
-            Assert.Equal(Color.Yellow, wavemapView[0, 4].BreakColor);
-            Assert.Equal(Color.Cyan, wavemapView[1, 4].BreakColor);
+            Assert.Equal(Brushes.Red, wavemapView[1, 2].BreakColor);
+            Assert.Equal(Brushes.Blue, wavemapView[0, 3].BreakColor);
+            Assert.Equal(Brushes.Green, wavemapView[1, 3].BreakColor);
+            Assert.Equal(Brushes.Yellow, wavemapView[0, 4].BreakColor);
+            Assert.Equal(Brushes.Cyan, wavemapView[1, 4].BreakColor);
 
-            Assert.Equal(Color.Red, wavemapView[0, 5].BreakColor);
-            Assert.Equal(Color.Blue, wavemapView[1, 5].BreakColor);
-            Assert.Equal(Color.Green, wavemapView[0, 6].BreakColor);
-            Assert.Equal(Color.Yellow, wavemapView[1, 6].BreakColor);
-            Assert.Equal(Color.Cyan, wavemapView[0, 7].BreakColor);
+            Assert.Equal(Brushes.Red, wavemapView[0, 5].BreakColor);
+            Assert.Equal(Brushes.Blue, wavemapView[1, 5].BreakColor);
+            Assert.Equal(Brushes.Green, wavemapView[0, 6].BreakColor);
+            Assert.Equal(Brushes.Yellow, wavemapView[1, 6].BreakColor);
+            Assert.Equal(Brushes.Cyan, wavemapView[0, 7].BreakColor);
 
-            Assert.Equal(Color.Red, wavemapView[1, 7].BreakColor);
-            Assert.Equal(Color.Blue, wavemapView[0, 8].BreakColor);
-            Assert.Equal(Color.Green, wavemapView[1, 8].BreakColor);
-            Assert.Equal(Color.Yellow, wavemapView[0, 9].BreakColor);
-            Assert.Equal(Color.Cyan, wavemapView[1, 9].BreakColor);
+            Assert.Equal(Brushes.Red, wavemapView[1, 7].BreakColor);
+            Assert.Equal(Brushes.Blue, wavemapView[0, 8].BreakColor);
+            Assert.Equal(Brushes.Green, wavemapView[1, 8].BreakColor);
+            Assert.Equal(Brushes.Yellow, wavemapView[0, 9].BreakColor);
+            Assert.Equal(Brushes.Cyan, wavemapView[1, 9].BreakColor);
         }
     }
 }

--- a/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
@@ -83,5 +83,15 @@ namespace VSRAD.PackageTests.DebugVisualizer
             Assert.Equal(Brushes.Yellow, wavemapView[0, 9].BreakColor);
             Assert.Equal(Brushes.Cyan, wavemapView[1, 9].BreakColor);
         }
+
+        [Fact]
+        public void IsValidWaveTest()
+        {
+            var wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3, groupSize: 12);
+
+            for (int i = 0; i < 20; ++i)
+                for (int j = 0; j < 5; ++j)
+                    Assert.Equal(i < 10 && j < 2, wavemapView.IsValidWave(j, i));
+        }
     }
 }

--- a/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
@@ -20,7 +20,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
         [Fact]
         public void BreakLineTest()
         {
-            for (uint  i = 3, j = 313; i < 360; i += 18, j += 313)
+            for (uint i = 3, j = 313; i < 360; i += 18, j += 313)
                 _data[i] = j;
 
             var wavemapView = new WavemapView(_data, waveSize: 6, laneDataSize: 3);

--- a/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
@@ -1,0 +1,37 @@
+﻿using VSRAD.Package.DebugVisualizer.Wavemap;
+using Xunit;
+
+namespace VSRAD.PackageTests.DebugVisualizer
+{
+    public class WavemapTests
+    {
+        // 4 groups, 1 watch + system, group size 11
+        private readonly uint[] _data = new uint[]
+        {
+            777, 0, 15, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 100, 0, 100, 0, 0, 0,  // 1-st group, break on line 15, not-empty exec-mask
+            777, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1,       // 2-nd group, empty exec-mask
+            777, 0, 105, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100, 0, 100, 0, 0, 0, // 3-rd group, break on line 105, not-empty exec-mask
+            777, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1,       // 4-th group, empty exec-mask TODO: fix
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,       // extra data
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,       // extra data
+        };
+
+        [Fact]
+        public void IsActiveGroupTest()
+        {
+            var wavemapView = new WavemapView(_data, groupSize: 11, laneDataSize: 2, groupCount: 4);
+            for (int i = 0; i < 10; ++i)
+                Assert.Equal(i < 4, wavemapView.IsActiveGroup(i));
+        }
+
+        [Fact]
+        public void GroupExecutedTest()
+        {
+            var wavemapView = new WavemapView(_data, groupSize: 11, laneDataSize: 2, groupCount: 4);
+
+            var executionMap = new bool[] { true, false, true, false };
+            for (int i = 0; i < 4; ++i)
+                Assert.Equal(executionMap[i], wavemapView.GroupExecuted(i));
+        }
+    }
+}

--- a/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/WavemapTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Drawing;
-using System.Xml.Serialization;
 using VSRAD.Package.DebugVisualizer.Wavemap;
 using Xunit;
 

--- a/VSRAD.PackageTests/VSRAD.PackageTests.csproj
+++ b/VSRAD.PackageTests/VSRAD.PackageTests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="DebugVisualizer\ColumnStylingTests.cs" />
     <Compile Include="DebugVisualizer\GroupIndexSelectorTests.cs" />
     <Compile Include="DebugVisualizer\ComputedColumnStylingTests.cs" />
+    <Compile Include="DebugVisualizer\WavemapTests.cs" />
     <Compile Include="MockCommunicationChannel.cs" />
     <Compile Include="ProjectSystem\ActionLoggerTests.cs" />
     <Compile Include="ProjectSystem\Macros\MacroEvaluatorTests.cs" />


### PR DESCRIPTION
Added a new feature: `Wavemap`. It is available above the visualizer table, can be hidden just as `Columns`, `App Args` and `Break Args`.

`Wavemap` is a canvas that displays rectangles of different colors. Each rectangle corresponds to one wave. The color indicates the break line of its wave, so you can visually see which waves stepped on which breakpoints. When you hover your mouse over the rectangle the following info will appear in popup:

```
Group: X
Wave: X
Line: X
```

That is the info about what wave of what group is currently under the mouse and which breakline it has.

The breakline info is stored in the first lane of system watch (after a magic num) in every wave.

The wavemap is always shaped as `numGroups x wavesPerGroup` for convenience, so every column corresponds to one group executed.

You can change the size of rectangles in `Visualizer Appearance` tab.