### PR TITLE
Minor UI fixes and code cleanup

### DIFF
--- a/VSRAD.Package/BuildTools/Errors/LineMapper.cs
+++ b/VSRAD.Package/BuildTools/Errors/LineMapper.cs
@@ -1,52 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 namespace VSRAD.Package.BuildTools.Errors
 {
-    public struct LineMarker : IEquatable<LineMarker>
-    {
-        public int PpLine { get; }
-        public int SourceLine { get; }
-        public string SourceFile { get; }
-
-        public LineMarker(int ppLine, int sourceLine, string sourceFile)
-        {
-            PpLine = ppLine;
-            SourceLine = sourceLine;
-            SourceFile = sourceFile;
-        }
-
-        public bool Equals(LineMarker m) => PpLine == m.PpLine && SourceLine == m.SourceLine && SourceFile == m.SourceFile;
-        public override bool Equals(object o) => o is LineMarker m && Equals(m);
-        public override int GetHashCode() => (PpLine, SourceLine, SourceFile).GetHashCode();
-        public static bool operator ==(LineMarker left, LineMarker right) => left.Equals(right);
-        public static bool operator !=(LineMarker left, LineMarker right) => !(left == right);
-    }
-
     public static class LineMapper
     {
-        private static readonly Regex LineMarkerRegex = new Regex(@"^\s*(//)?#\s+(?<line>\d+)\s+\""(?<file>.*)\""", RegexOptions.Compiled);
-
-        public static List<LineMarker> MapLines(string preprocessed)
-        {
-            var lines = preprocessed.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
-            var result = new List<LineMarker>();
-            for (int i = 1; i <= lines.Length; i++)
-            {
-                var line = lines[i - 1];
-                var match = LineMarkerRegex.Match(line);
-
-                if (match.Success)
-                    result.Add(new LineMarker(
-                        //  +1 for next line after marker
-                        ppLine: i + 1,
-                        sourceLine: int.Parse(match.Groups["line"].Value),
-                        sourceFile: match.Groups["file"].Value));
-            }
-            return result;
-        }
-
         public static string MapSourceToHost(string remotePath, IEnumerable<string> projectPaths)
         {
             var remotePathArray = remotePath.Split(new[] { @"\", @"/" }, StringSplitOptions.None);

--- a/VSRAD.Package/DebugVisualizer/NumberInput.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/NumberInput.xaml.cs
@@ -44,9 +44,9 @@ namespace VSRAD.Package.DebugVisualizer
 
         public uint Step { get => (uint)GetValue(StepProperty); set => SetValue(StepProperty, value); }
 
-        public uint Minimum { get => (uint)GetValue(MinimumProperty); set => SetValue(MinimumProperty, value); }
+        public uint Minimum { get => (uint)GetValue(MinimumProperty); set { SetValue(MinimumProperty, value); Value = Value; } }
 
-        public uint Maximum { get => (uint)GetValue(MaximumProperty); set => SetValue(MaximumProperty, value); }
+        public uint Maximum { get => (uint)GetValue(MaximumProperty); set { SetValue(MaximumProperty, value); Value = Value; } }
 
         private string _rawValue = "0";
         public string RawValue

--- a/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
@@ -97,8 +97,7 @@ namespace VSRAD.Package.DebugVisualizer
             GroupFetched(this, new GroupFetchedEventArgs(warning));
 
             var status = new StringBuilder();
-            status.AppendFormat("{0} groups, last run at {1}, total: {2}ms, execute: {3}ms",
-                e.DataGroupCount, _breakState.ExecutedAt.ToString("HH:mm:ss"), _breakState.TotalElapsedMilliseconds, _breakState.ExecElapsedMilliseconds);
+            status.AppendFormat("{0} groups, last run at {1}", e.DataGroupCount, _breakState.ExecutedAt.ToString("HH:mm:ss"));
             if (_breakState.DispatchParameters?.StatusString is string statusStr && statusStr.Length != 0)
             {
                 status.Append(", status: ");

--- a/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
@@ -47,11 +47,11 @@
                                Width="60" Height="24" />
             <StackPanel Orientation="Horizontal">
                 <Label Content="Group #:" Height="26" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
-                <local:NumberInput Value="{Binding GroupIndex.X, UpdateSourceTrigger=PropertyChanged}"
+                <local:NumberInput Value="{Binding GroupIndex.X, UpdateSourceTrigger=PropertyChanged}" Maximum="{Binding GroupIndex.MaximumX, Mode=TwoWay}"
                                    Width="38" Height="24" Margin="6,0,0,0" Style="{StaticResource NDRangeInput}"/>
-                <local:NumberInput Value="{Binding GroupIndex.Y, UpdateSourceTrigger=PropertyChanged}"
+                <local:NumberInput Value="{Binding GroupIndex.Y, UpdateSourceTrigger=PropertyChanged}" Maximum="{Binding GroupIndex.MaximumY, Mode=TwoWay}"
                                    Width="38" Height="24" Margin="6,0,0,0" Style="{StaticResource NDRange3DInput}"/>
-                <local:NumberInput Value="{Binding GroupIndex.Z, UpdateSourceTrigger=PropertyChanged}"
+                <local:NumberInput Value="{Binding GroupIndex.Z, UpdateSourceTrigger=PropertyChanged}" Maximum="{Binding GroupIndex.MaximumZ, Mode=TwoWay}"
                                    Width="38" Height="24" Margin="6,0,0,0" Style="{StaticResource NDRange3DInput}"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal">

--- a/VSRAD.Package/Options/Actions.cs
+++ b/VSRAD.Package/Options/Actions.cs
@@ -307,13 +307,13 @@ namespace VSRAD.Package.Options
     public sealed class ReadDebugDataStep : DefaultNotifyPropertyChanged, IActionStep
     {
         private BuiltinActionFile _outputFile;
-        public BuiltinActionFile OutputFile { get => _outputFile; set => SetField(ref _outputFile, value); }
+        public BuiltinActionFile OutputFile { get => _outputFile; set => SetField(ref _outputFile, value, ignoreNull: true); }
 
         private BuiltinActionFile _watchesFile;
-        public BuiltinActionFile WatchesFile { get => _watchesFile; set => SetField(ref _watchesFile, value); }
+        public BuiltinActionFile WatchesFile { get => _watchesFile; set => SetField(ref _watchesFile, value, ignoreNull: true); }
 
-        private BuiltinActionFile _statusFile;
-        public BuiltinActionFile StatusFile { get => _statusFile; set => SetField(ref _statusFile, value); }
+        private BuiltinActionFile _dispatchParamsFile;
+        public BuiltinActionFile DispatchParamsFile { get => _dispatchParamsFile; set => SetField(ref _dispatchParamsFile, value, ignoreNull: true); }
 
         private bool _binaryOutput = true;
         public bool BinaryOutput { get => _binaryOutput; set => SetField(ref _binaryOutput, value); }
@@ -323,11 +323,11 @@ namespace VSRAD.Package.Options
 
         public ReadDebugDataStep() : this(new BuiltinActionFile(), new BuiltinActionFile(), new BuiltinActionFile(), binaryOutput: true, outputOffset: 0) { }
 
-        public ReadDebugDataStep(BuiltinActionFile outputFile, BuiltinActionFile watchesFile, BuiltinActionFile statusFile, bool binaryOutput, int outputOffset)
+        public ReadDebugDataStep(BuiltinActionFile outputFile, BuiltinActionFile watchesFile, BuiltinActionFile dispatchParamsFile, bool binaryOutput, int outputOffset)
         {
             OutputFile = outputFile;
             WatchesFile = watchesFile;
-            StatusFile = statusFile;
+            DispatchParamsFile = dispatchParamsFile;
             BinaryOutput = binaryOutput;
             OutputOffset = outputOffset;
         }
@@ -344,19 +344,19 @@ namespace VSRAD.Package.Options
             if (!watchesResult.TryGetResult(out var watchesFile, out error))
                 return EvaluationError(sourceAction, "Read Debug Data", error.Message);
 
-            var statusResult = await StatusFile.EvaluateAsync(evaluator);
-            if (!statusResult.TryGetResult(out var statusFile, out error))
+            var dispatchParamsResult = await DispatchParamsFile.EvaluateAsync(evaluator);
+            if (!dispatchParamsResult.TryGetResult(out var dispatchParamsFile, out error))
                 return EvaluationError(sourceAction, "Read Debug Data", error.Message);
 
             if (profile.General.RunActionsLocally)
             {
                 outputFile.Location = StepEnvironment.Local;
                 watchesFile.Location = StepEnvironment.Local;
-                statusFile.Location = StepEnvironment.Local;
+                dispatchParamsFile.Location = StepEnvironment.Local;
             }
 
             return new ReadDebugDataStep(outputOffset: OutputOffset, binaryOutput: BinaryOutput,
-                outputFile: outputFile, watchesFile: watchesFile, statusFile: statusFile);
+                outputFile: outputFile, watchesFile: watchesFile, dispatchParamsFile: dispatchParamsFile);
         }
 
         public override string ToString()
@@ -374,7 +374,7 @@ namespace VSRAD.Package.Options
             obj is ReadDebugDataStep step &&
             OutputFile.Equals(step.OutputFile) &&
             WatchesFile.Equals(step.WatchesFile) &&
-            StatusFile.Equals(step.StatusFile) &&
+            DispatchParamsFile.Equals(step.DispatchParamsFile) &&
             BinaryOutput == step.BinaryOutput &&
             OutputOffset == step.OutputOffset;
     }

--- a/VSRAD.Package/Options/ProfileOptions.cs
+++ b/VSRAD.Package/Options/ProfileOptions.cs
@@ -7,27 +7,6 @@ using VSRAD.Package.Utils;
 
 namespace VSRAD.Package.Options
 {
-    // TODO: remove (obsolete)
-    [AttributeUsage(AttributeTargets.Property)]
-    public sealed class MacroAttribute : Attribute
-    {
-        public string MacroName { get; }
-
-        public MacroAttribute(string macroName) => MacroName = macroName;
-    }
-
-    // TODO: remove (obsolete)
-    [AttributeUsage(AttributeTargets.Property)]
-    public sealed class BinaryChoiceAttribute : Attribute
-    {
-        public (string True, string False) Choice { get; }
-
-        public BinaryChoiceAttribute(string trueString, string falseString)
-        {
-            Choice = (trueString, falseString);
-        }
-    }
-
     public sealed class ProfileOptions : ICloneable
     {
         public GeneralProfileOptions General { get; } = new GeneralProfileOptions();

--- a/VSRAD.Package/Options/ProjectOptions.cs
+++ b/VSRAD.Package/Options/ProjectOptions.cs
@@ -67,6 +67,7 @@ namespace VSRAD.Package.Options
         {
             ((Dictionary<string, ProfileOptions>)Profiles)[ActiveProfile] = newProfile;
             RaisePropertyChanged(nameof(Profiles));
+            RaisePropertyChanged(nameof(ActiveProfile));
         }
         #endregion
 

--- a/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
+++ b/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
@@ -2,7 +2,6 @@
 using Microsoft.VisualStudio.Text.Tagging;
 using System;
 using System.ComponentModel.Composition;
-using System.Linq;
 using VSRAD.Deborgar;
 using VSRAD.Package.ProjectSystem.EditorExtensions;
 using VSRAD.Package.ProjectSystem.Macros;
@@ -31,10 +30,12 @@ namespace VSRAD.Package.ProjectSystem
             _actionLauncher = actionLauncher;
             _codeEditor = codeEditor;
 
-            _breakLineTagger = (BreakLineGlyphTaggerProvider)_project.UnconfiguredProject.Services.ExportProvider
-                .GetExports<IViewTaggerProvider, IAppliesToMetadataView>()
-                .Where(e => e.Metadata.AppliesTo == Constants.RadOrVisualCProjectCapability)
-                .First(e => e.Value.GetType() == typeof(BreakLineGlyphTaggerProvider)).Value;
+            // Cannot import BreakLineGlyphTaggerProvider directly because there are
+            // multiple IViewTaggerProvider exports and we don't want to instantiate each one
+            _breakLineTagger = (BreakLineGlyphTaggerProvider)
+                _project.GetExportByMetadataAndType<IViewTaggerProvider, IAppliesToMetadataView>(
+                        m => m.AppliesTo == Constants.RadOrVisualCProjectCapability,
+                        e => e.GetType() == typeof(BreakLineGlyphTaggerProvider));
         }
 
         public IEngineIntegration RegisterEngine()

--- a/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphFactory.cs
+++ b/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphFactory.cs
@@ -23,20 +23,21 @@ namespace VSRAD.Package.ProjectSystem.EditorExtensions
 
     public sealed class BreakLineGlyphFactory : IGlyphFactory
     {
+        private static BitmapImage _glyph;
+        private static BitmapImage Glyph
+        {
+            get
+            {
+                if (_glyph == null)
+                    _glyph = new BitmapImage(new Uri(Constants.CurrentStatementIconResourcePackUri));
+                return _glyph;
+            }
+        }
+
         public UIElement GenerateGlyph(IWpfTextViewLine line, IGlyphTag tag)
         {
-            if (tag is BreakLineGlyphTag breakLineTag)
-            {
-                var img = new BitmapImage(new Uri(Constants.CurrentStatementIconResourcePackUri));
-                return new Image
-                {
-                    Source = img,
-                    Width = 11,
-                    Height = 11,
-                    Margin = new Thickness(1, 2.5, 0, 0),
-                    ToolTip = breakLineTag.ToolTip
-                };
-            }
+            if (tag is BreakLineGlyphTag breakLine)
+                return new Image { Source = Glyph, Width = 11, Height = 11, Margin = new Thickness(1, 2.5, 0, 0), ToolTip = breakLine.ToolTip };
             return null;
         }
     }

--- a/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphTagger.cs
+++ b/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphTagger.cs
@@ -24,14 +24,14 @@ namespace VSRAD.Package.ProjectSystem.EditorExtensions
     [AppliesTo(Constants.RadOrVisualCProjectCapability)]
     [ContentType("any")]
     [TagType(typeof(BreakLineGlyphTag))]
-    public sealed class BreakLineGlyphTaggerProvider : IViewTaggerProvider
+    public class BreakLineGlyphTaggerProvider : IViewTaggerProvider
     {
         // Tagger provider can be instantiated before UnconfiguredProject,
         // so we can't use ImportingConstructor to access DebuggerIntegration's
         // ExecutionCompleted event directly.
         internal event EventHandler<ExecutionCompletedEventArgs> DebugExecutionCompleted;
 
-        internal void OnExecutionCompleted(ExecutionCompletedEventArgs e) =>
+        public virtual void OnExecutionCompleted(ExecutionCompletedEventArgs e) =>
             DebugExecutionCompleted?.Invoke(this, e);
 
         public ITagger<T> CreateTagger<T>(ITextView textView, ITextBuffer buffer) where T : ITag

--- a/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphTagger.cs
+++ b/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphTagger.cs
@@ -26,30 +26,18 @@ namespace VSRAD.Package.ProjectSystem.EditorExtensions
     [TagType(typeof(BreakLineGlyphTag))]
     public sealed class BreakLineGlyphTaggerProvider : IViewTaggerProvider
     {
-        /// Tagger provider can be instantiated either before or after UnconfiguredProject,
-        /// so we can't use ImportingConstructor _and_ we can't rely on the tagger being available
-        /// when IProject is loaded. This hack shouldn't cause issues as long as there's never more
-        /// than one active instance of IProject, which is guaranteed by SolutionManager.
-        private static DebuggerIntegration _debuggerIntegration;
+        // Tagger provider can be instantiated before UnconfiguredProject,
+        // so we can't use ImportingConstructor to access DebuggerIntegration's
+        // ExecutionCompleted event directly.
+        internal event EventHandler<ExecutionCompletedEventArgs> DebugExecutionCompleted;
 
-        public static void Initialize(IProject project)
-        {
-            _debuggerIntegration = project.UnconfiguredProject.Services.ExportProvider.GetExportedValue<DebuggerIntegration>();
-
-            void OnProjectUnloaded()
-            {
-                _debuggerIntegration = null;
-                project.Unloaded -= OnProjectUnloaded;
-            }
-            project.Unloaded += OnProjectUnloaded;
-        }
+        internal void OnExecutionCompleted(ExecutionCompletedEventArgs e) =>
+            DebugExecutionCompleted?.Invoke(this, e);
 
         public ITagger<T> CreateTagger<T>(ITextView textView, ITextBuffer buffer) where T : ITag
         {
-            if (_debuggerIntegration != null
-                && textView.TextBuffer == buffer
-                && buffer.Properties.TryGetProperty(typeof(ITextDocument), out ITextDocument document))
-                return buffer.Properties.GetOrCreateSingletonProperty(() => new BreakLineGlyphTagger(buffer, document, _debuggerIntegration) as ITagger<T>);
+            if (buffer != null && buffer.Properties.TryGetProperty(typeof(ITextDocument), out ITextDocument document))
+                return buffer.Properties.GetOrCreateSingletonProperty(() => new BreakLineGlyphTagger(buffer, document, this) as ITagger<T>);
             return null;
         }
     }
@@ -63,11 +51,11 @@ namespace VSRAD.Package.ProjectSystem.EditorExtensions
 
         private readonly List<TagSpan<BreakLineGlyphTag>> _tagSpans = new List<TagSpan<BreakLineGlyphTag>>();
 
-        public BreakLineGlyphTagger(ITextBuffer buffer, ITextDocument document, DebuggerIntegration debuggerIntegration)
+        public BreakLineGlyphTagger(ITextBuffer buffer, ITextDocument document, BreakLineGlyphTaggerProvider provider)
         {
             _buffer = buffer;
             _document = document;
-            debuggerIntegration.ExecutionCompleted += DebugExecutionCompleted;
+            provider.DebugExecutionCompleted += DebugExecutionCompleted;
         }
 
         private void DebugExecutionCompleted(object sender, ExecutionCompletedEventArgs e)

--- a/VSRAD.Package/ProjectSystem/ErrorListManager.cs
+++ b/VSRAD.Package/ProjectSystem/ErrorListManager.cs
@@ -48,7 +48,7 @@ namespace VSRAD.Package.ProjectSystem
             _errorListProvider.Tasks.Clear();
 
             var errors = new List<ErrorTask>();
-            var messages = await _buildErrorProcessor.ExtractMessagesAsync(outputs, null);
+            var messages = await _buildErrorProcessor.ExtractMessagesAsync(outputs);
             foreach (var message in messages)
             {
                 var document = string.IsNullOrEmpty(message.SourceFile) // make unclickable error otherwise it will refer to the project root

--- a/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
@@ -281,10 +281,10 @@
                                                            CurrentProfile="{Binding DataContext.CurrentProfile, ElementName=Root}"
                                                            Header="Watches" Grid.Row="1" Grid.ColumnSpan="3" />
 
-                            <local:BuiltinActionFileEditor DataContext="{Binding StatusFile}"
+                            <local:BuiltinActionFileEditor DataContext="{Binding DispatchParamsFile}"
                                                            MacroEditor="{Binding DataContext.MacroEditor, ElementName=Root}"
                                                            CurrentProfile="{Binding DataContext.CurrentProfile, ElementName=Root}"
-                                                           Header="Status" Grid.Row="2" Grid.ColumnSpan="3" />
+                                                           Header="Dispatch Params" Grid.Row="2" Grid.ColumnSpan="3" />
 
                             <Label Content="Outuput Type: " VerticalContentAlignment="Center" Padding="4,0" Height="22" Grid.Row="3" Grid.Column="0"/>
                             <ComboBox Height="22" Width="160" HorizontalAlignment="Left" Grid.Row="3" Grid.Column="1"

--- a/VSRAD.Package/ProjectSystem/Profiles/LegacyProfileImporter.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/LegacyProfileImporter.cs
@@ -91,9 +91,9 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             readDebugData.WatchesFile.CheckTimestamp = true;
             readDebugData.WatchesFile.Path = (string)conf["ValidWatchesFilePath"];
 
-            readDebugData.StatusFile.Location = StepEnvironment.Remote;
-            readDebugData.StatusFile.CheckTimestamp = true;
-            readDebugData.StatusFile.Path = (string)conf["StatusStringFilePath"];
+            readDebugData.DispatchParamsFile.Location = StepEnvironment.Remote;
+            readDebugData.DispatchParamsFile.CheckTimestamp = true;
+            readDebugData.DispatchParamsFile.Path = (string)conf["StatusStringFilePath"];
 
             action.Steps.Add(readDebugData);
             return action;

--- a/VSRAD.Package/ProjectSystem/Profiles/LegacyProfileOptionsMigrator.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/LegacyProfileOptionsMigrator.cs
@@ -49,10 +49,10 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             var steps = conf["Steps"].ToObject<List<IActionStep>>(serializer);
             var outputFile = conf["OutputFile"].ToObject<BuiltinActionFile>();
             var watchesFile = conf["WatchesFile"].ToObject<BuiltinActionFile>();
-            var statusFile = conf["StatusFile"].ToObject<BuiltinActionFile>();
+            var dispatchParamsFile = conf["StatusFile"].ToObject<BuiltinActionFile>();
             var binaryOutput = (bool)conf["BinaryOutput"];
             var outputOffset = (int)conf["OutputOffset"];
-            var readDebugData = new ReadDebugDataStep(outputFile, watchesFile, statusFile, binaryOutput, outputOffset);
+            var readDebugData = new ReadDebugDataStep(outputFile, watchesFile, dispatchParamsFile, binaryOutput, outputOffset);
             steps.Add(readDebugData);
             return steps;
         }

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml.cs
@@ -57,13 +57,18 @@ namespace VSRAD.Package.ProjectSystem.Profiles
                 _context.RemoveSelectedProfile();
         }
 
-        private void ApplyChanges(object sender, RoutedEventArgs e) =>
-            _context.SaveChanges();
+        private void ApplyChanges(object sender, RoutedEventArgs e)
+        {
+            if (_context.SaveChanges() is Error err)
+                Errors.Show(err);
+        }
 
         private void ApplyChangesAndClose(object sender, RoutedEventArgs e)
         {
-            _context.SaveChanges();
-            Close(sender, e);
+            if (_context.SaveChanges() is Error err)
+                Errors.Show(err);
+            else
+                Close(sender, e);
         }
 
         private void Close(object sender, RoutedEventArgs e)

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml.cs
@@ -113,7 +113,9 @@ namespace VSRAD.Package.ProjectSystem.Profiles
         {
             var dialog = new ProfileNameWindow(dialogLabel, okButton: "OK", cancelButton: "Cancel", initialName, existingNames)
             {
-                Title = dialogTitle
+                Title = dialogTitle,
+                Owner = Application.Current.MainWindow,
+                ShowInTaskbar = false
             };
             dialog.ShowDialog();
             return dialog.DialogResult == true ? dialog.EnteredName : null;

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindowContext.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindowContext.cs
@@ -252,10 +252,13 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             }
         }
 
-        public void ExportProfiles(string file)
+        public Error? ExportProfiles(string file)
         {
-            SaveChanges();
+            if (SaveChanges() is Error e)
+                return e;
+
             ProfileTransferManager.Export((IDictionary<string, ProfileOptions>)_project.Options.Profiles, file);
+            return null;
         }
 
         private void AddProfile(string title, string message, ProfileOptions profile)
@@ -271,7 +274,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             }
         }
 
-        public void SaveChanges()
+        public Error? SaveChanges()
         {
             var profiles = new Dictionary<string, ProfileOptions>();
             for (int i = 0; i < DirtyProfiles.Count; ++i) // not using an enumerator because we may remove elements
@@ -282,6 +285,8 @@ namespace VSRAD.Package.ProjectSystem.Profiles
                 {
                     name = _askProfileName(title: "Rename", message: ProfileNameWindow.NameConflictMessage(name),
                         existingNames: ProfileNames, initialName: name);
+                    if (string.IsNullOrEmpty(name))
+                        return new Error("Profile options were not saved.");
                     currProfile.General.ProfileName = name;
                 }
                 if (profiles.TryGetValue(name, out var replacedProfile))
@@ -296,6 +301,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
                 SelectedProfile = DirtyProfiles[0];
             var activeProfile = SelectedProfile?.General?.ProfileName ?? "";
             _project.Options.SetProfiles(profiles, activeProfile);
+            return null;
         }
 
         private void OpenMacroEditor(object sender)

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindowContext.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindowContext.cs
@@ -283,17 +283,21 @@ namespace VSRAD.Package.ProjectSystem.Profiles
                 var name = currProfile.General.ProfileName;
                 if (profiles.ContainsKey(name))
                 {
-                    name = _askProfileName(title: "Rename", message: ProfileNameWindow.NameConflictMessage(name),
+                    var newName = _askProfileName(title: "Rename",
+                        message: ProfileNameWindow.NameConflictMessage(name),
                         existingNames: ProfileNames, initialName: name);
-                    if (string.IsNullOrEmpty(name))
+                    if (string.IsNullOrEmpty(newName))
                         return new Error("Profile options were not saved.");
-                    currProfile.General.ProfileName = name;
-                }
-                if (profiles.TryGetValue(name, out var replacedProfile))
-                {
-                    if (SelectedProfile.General.ProfileName == name)
-                        SelectedProfile = currProfile;
-                    DirtyProfiles.Remove(replacedProfile);
+                    currProfile.General.ProfileName = newName;
+                    if (newName == name)
+                    {
+                        var replacedProfile = DirtyProfiles.First(p => p.General.ProfileName == name);
+                        DirtyProfiles.Remove(replacedProfile);
+                        i--; // the index is shifted by 1 after removing the profile
+                        if (SelectedProfile == replacedProfile)
+                            SelectedProfile = currProfile;
+                    }
+                    name = newName;
                 }
                 profiles[name] = (ProfileOptions)currProfile.Clone();
             }

--- a/VSRAD.Package/ProjectSystem/Project.cs
+++ b/VSRAD.Package/ProjectSystem/Project.cs
@@ -6,9 +6,9 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.IO;
+using System.Linq;
 using VSRAD.Package.BuildTools;
 using VSRAD.Package.Options;
-using VSRAD.Package.ProjectSystem.EditorExtensions;
 
 namespace VSRAD.Package.ProjectSystem
 {
@@ -25,6 +25,7 @@ namespace VSRAD.Package.ProjectSystem
 
         void RunWhenLoaded(Action<ProjectOptions> callback);
         IProjectProperties GetProjectProperties();
+        TExport GetExportByMetadataAndType<TExport, TMetadata>(Predicate<TMetadata> metadataFilter, Predicate<TExport> exportFilter) where TExport : class;
         void SaveOptions();
     }
 
@@ -93,6 +94,13 @@ namespace VSRAD.Package.ProjectSystem
         {
             var configuredProject = UnconfiguredProject.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
             return configuredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
+        }
+
+        public TExport GetExportByMetadataAndType<TExport, TMetadata>(Predicate<TMetadata> metadataFilter, Predicate<TExport> exportFilter) where TExport : class
+        {
+            return UnconfiguredProject.Services.ExportProvider.GetExports<TExport, TMetadata>()
+                .Where(e => metadataFilter(e.Metadata))
+                .FirstOrDefault(e => exportFilter(e.Value))?.Value;
         }
     }
 }

--- a/VSRAD.Package/ProjectSystem/Project.cs
+++ b/VSRAD.Package/ProjectSystem/Project.cs
@@ -77,8 +77,6 @@ namespace VSRAD.Package.ProjectSystem
             UnconfiguredProject.Services.ExportProvider.GetExportedValue<BreakpointIntegration>();
             UnconfiguredProject.Services.ExportProvider.GetExportedValue<BuildToolsServer>();
 
-            BreakLineGlyphTaggerProvider.Initialize(this);
-
             _loaded = true;
             foreach (var callback in _onLoadCallbacks)
                 callback(Options);

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -187,7 +187,7 @@ namespace VSRAD.Package.Server
         private async Task<(StepResult, BreakState)> DoReadDebugDataAsync(ReadDebugDataStep step)
         {
             var watches = _environment.Watches;
-            string statusString = null;
+            string dispatchParamsString = null;
 
             if (!string.IsNullOrEmpty(step.WatchesFile.Path))
             {
@@ -200,14 +200,14 @@ namespace VSRAD.Package.Server
 
                 watches = Array.AsReadOnly(watchArray);
             }
-            if (!string.IsNullOrEmpty(step.StatusFile.Path))
+            if (!string.IsNullOrEmpty(step.DispatchParamsFile.Path))
             {
-                var result = await ReadDebugDataFileAsync("Status string", step.StatusFile.Path, step.StatusFile.IsRemote(), step.StatusFile.CheckTimestamp);
+                var result = await ReadDebugDataFileAsync("Dispatch parameters", step.DispatchParamsFile.Path, step.DispatchParamsFile.IsRemote(), step.DispatchParamsFile.CheckTimestamp);
                 if (!result.TryGetResult(out var data, out var error))
                     return (new StepResult(false, error.Message, ""), null);
 
-                statusString = Encoding.UTF8.GetString(data);
-                statusString = Regex.Replace(statusString, @"[^\r]\n", "\r\n");
+                dispatchParamsString = Encoding.UTF8.GetString(data);
+                dispatchParamsString = Regex.Replace(dispatchParamsString, @"[^\r]\n", "\r\n");
             }
             {
                 var path = step.OutputFile.Path;
@@ -243,7 +243,7 @@ namespace VSRAD.Package.Server
 
                 var data = new BreakStateData(watches, outputFile, localOutputData);
 
-                var dispatchParamsResult = BreakStateDispatchParameters.Parse(statusString);
+                var dispatchParamsResult = BreakStateDispatchParameters.Parse(dispatchParamsString);
                 if (!dispatchParamsResult.TryGetResult(out var dispatchParams, out var error))
                     return (new StepResult(false, error.Message, ""), null);
 
@@ -315,7 +315,7 @@ namespace VSRAD.Package.Server
                 }
                 else if (step is ReadDebugDataStep readDebugData)
                 {
-                    var files = new[] { readDebugData.WatchesFile, readDebugData.StatusFile, readDebugData.OutputFile };
+                    var files = new[] { readDebugData.WatchesFile, readDebugData.DispatchParamsFile, readDebugData.OutputFile };
                     foreach (var file in files)
                     {
                         if (!file.CheckTimestamp || string.IsNullOrEmpty(file.Path))

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -6,16 +6,12 @@ namespace VSRAD.Package.Server
     {
         public BreakStateData Data { get; }
         public BreakStateDispatchParameters DispatchParameters { get; }
-        public long TotalElapsedMilliseconds { get; }
-        public long ExecElapsedMilliseconds { get; } = 0; // TODO: is this obsolete?
-        public int ExitCode { get; } = 0; // TODO: is this obsolete?
         public DateTime ExecutedAt { get; } = DateTime.Now;
 
-        public BreakState(BreakStateData breakStateData, BreakStateDispatchParameters dispatchParameters, long totalElapsedMilliseconds = 0)
+        public BreakState(BreakStateData breakStateData, BreakStateDispatchParameters dispatchParameters)
         {
             Data = breakStateData;
             DispatchParameters = dispatchParameters;
-            TotalElapsedMilliseconds = totalElapsedMilliseconds;
         }
     }
 }

--- a/VSRAD.Package/Server/BreakStateDispatchParameters.cs
+++ b/VSRAD.Package/Server/BreakStateDispatchParameters.cs
@@ -5,8 +5,8 @@ namespace VSRAD.Package.Server
 {
     public sealed class BreakStateDispatchParameters
     {
-        private static readonly Regex _statusRegex = new Regex(@"grid size \((?<gd_x>\d+), (?<gd_y>\d+), (?<gd_z>\d+)\)\s+group size \((?<gp_x>\d+), (?<gp_y>\d+), (?<gp_z>\d+)\)\s+wave size (?<wv>\d+)(\s+comment (?<comment>.*))?", RegexOptions.Compiled);
-        private const string _exampleStatusContents = @"
+        private static readonly Regex _paramsRegex = new Regex(@"grid size \((?<gd_x>\d+), (?<gd_y>\d+), (?<gd_z>\d+)\)\s+group size \((?<gp_x>\d+), (?<gp_y>\d+), (?<gp_z>\d+)\)\s+wave size (?<wv>\d+)(\s+comment (?<comment>.*))?", RegexOptions.Compiled);
+        private const string _exampleParamsContent = @"
 grid size (2048, 1, 1)
 group size (512, 1, 1)
 wave size 64
@@ -31,15 +31,15 @@ comment optional comment";
             StatusString = statusString;
         }
 
-        public static Result<BreakStateDispatchParameters> Parse(string statusFileContents)
+        public static Result<BreakStateDispatchParameters> Parse(string contents)
         {
-            if (statusFileContents == null)
+            if (contents == null)
                 return (BreakStateDispatchParameters)null;
 
-            var match = _statusRegex.Match(statusFileContents);
+            var match = _paramsRegex.Match(contents);
 
             if (!match.Success)
-                return new Error("Could not read dispatch parameters from the status file. The following is an example of the expected status file contents:\r\n" + _exampleStatusContents);
+                return new Error("Could not read the dispatch parameters file. The following is an example of the expected file contents:\r\n" + _exampleParamsContent);
 
             var gridX = uint.Parse(match.Groups["gd_x"].Value);
             var gridY = uint.Parse(match.Groups["gd_y"].Value);
@@ -52,24 +52,24 @@ comment optional comment";
             var statusString = match.Groups["comment"].Value;
 
             if (gridX == 0)
-                return new Error("Could not set dispatch parameters from the status file. GridX cannot be zero.");
+                return new Error("Could not read the dispatch parameters file. GridX cannot be zero.");
             if (groupX == 0)
-                return new Error("Could not set dispatch parameters from the status file. GroupX cannot be zero.");
+                return new Error("Could not read the dispatch parameters file. GroupX cannot be zero.");
 
             if (waveSize == 0)
-                return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be zero.");
+                return new Error("Could not read the dispatch parameters file. WaveSize cannot be zero.");
             if (waveSize > groupX)
-                return new Error("Could not set dispatch parameters from the status file. WaveSize cannot be bigger than GroupX.");
+                return new Error("Could not read the dispatch parameters file. WaveSize cannot be bigger than GroupX.");
 
             if (ndRange3D && (groupY == 0 || groupZ == 0))
-                return new Error("Could not set dispatch parameters from the status file. If GridY and GridZ are set, GroupY and GroupZ cannot be zero.");
+                return new Error("Could not read the dispatch parameters file. If GridY and GridZ are set, GroupY and GroupZ cannot be zero.");
 
             if (groupX > gridX)
-                return new Error("Could not set dispatch parameters from the status file. GroupX cannot be bigger than GridX.");
+                return new Error("Could not read the dispatch parameters file. GroupX cannot be bigger than GridX.");
             if (ndRange3D && groupY > gridY)
-                return new Error("Could not set dispatch parameters from the status file. GroupY cannot be bigger than GridY.");
+                return new Error("Could not read the dispatch parameters file. GroupY cannot be bigger than GridY.");
             if (ndRange3D && groupZ > gridZ)
-                return new Error("Could not set dispatch parameters from the status file. GroupZ cannot be bigger than GridZ.");
+                return new Error("Could not read the dispatch parameters file. GroupZ cannot be bigger than GridZ.");
 
             var dimX = gridX / groupX;
             var dimY = ndRange3D ? gridY / groupY : 0;

--- a/VSRAD.Package/Server/CommunicationChannel.cs
+++ b/VSRAD.Package/Server/CommunicationChannel.cs
@@ -27,8 +27,6 @@ namespace VSRAD.Package.Server
 
         Task<T> SendWithReplyAsync<T>(ICommand command) where T : IResponse;
 
-        Task<IResponse[]> SendBundleAsync(List<ICommand> commands);
-
         Task<IReadOnlyDictionary<string, string>> GetRemoteEnvironmentAsync();
 
         void ForceDisconnect();
@@ -150,15 +148,6 @@ namespace VSRAD.Package.Server
             {
                 _mutex.Release();
             }
-        }
-
-        public async Task<IResponse[]> SendBundleAsync(List<ICommand> commands)
-        {
-            // TODO: send in a single packet (opt)
-            var responses = new IResponse[commands.Count];
-            for (int i = 0; i < commands.Count; ++i)
-                responses[i] = await SendWithReplyAsync<IResponse>(commands[i]);
-            return responses;
         }
 
         public async Task<IReadOnlyDictionary<string, string>> GetRemoteEnvironmentAsync()

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
@@ -77,7 +77,7 @@ namespace VSRAD.Package.ToolWindows
         {
             new ProjectSystem.Profiles.ProfileOptionsWindow(_integration)
             {
-                Owner = Window.GetWindow(Parent),
+                Owner = Application.Current.MainWindow,
                 ShowInTaskbar = false
             }.ShowDialog();
         }

--- a/VSRAD.Package/Utils/NotifyPropertyChanged.cs
+++ b/VSRAD.Package/Utils/NotifyPropertyChanged.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace VSRAD.Package.Utils
@@ -12,9 +9,11 @@ namespace VSRAD.Package.Utils
         public event PropertyChangedEventHandler PropertyChanged;
 
         /* https://stackoverflow.com/a/1316417 */
-        protected bool SetField<T>(ref T field, T value, [CallerMemberName] string propertyName = null, bool raiseIfEqual = false)
+        protected bool SetField<T>(ref T field, T value, [CallerMemberName] string propertyName = null, bool raiseIfEqual = false, bool ignoreNull = false)
         {
             if (!raiseIfEqual && EqualityComparer<T>.Default.Equals(field, value))
+                return false;
+            if (ignoreNull && value == null)
                 return false;
 
             field = value;

--- a/VSRAD.Package/VSRAD.Package.tt
+++ b/VSRAD.Package/VSRAD.Package.tt
@@ -24,7 +24,7 @@
         </Strings>
       </Menu>
       <!-- Tools -> RAD Debug -> Actions -->
-      <Menu guid="guidCmdSetActionsMenu" id="ActionsMenuId" priority="0x700" type="Menu">
+      <Menu guid="guidCmdSetActionsMenu" id="ActionsMenuId" priority="10" type="Menu">
         <Parent guid="guidCmdSetToolsMenu" id="ToolsMenuGroup"/>
         <Strings>
           <ButtonText>Actions</ButtonText>
@@ -59,6 +59,36 @@
     </Menus>
 
     <Buttons>
+      <!-- Tool window commands -->
+      <Button guid="guidCmdSetToolWindow" id="ToolWindowVisualizerCommandId" priority="1" type="Button">
+        <Parent guid="guidCmdSetToolsMenu" id="ToolsMenuGroup" />
+        <Icon guid="guidImages" id="visualizerIcon" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Open Visualizer</ButtonText>
+        </Strings>
+      </Button>
+      <!--
+      <Button guid="guidCmdSetToolWindow" id="ToolWindowSliceVisualizerCommandId" priority="2" type="Button">
+        <Parent guid="guidCmdSetToolsMenu" id="ToolsMenuGroup" />
+        <Icon guid="guidImages" id="visualizerIcon" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Open Slice Visualizer</ButtonText>
+        </Strings>
+      </Button>
+      -->
+      <Button guid="guidCmdSetToolWindow" id="ToolWindowOptionsCommandId" priority="3" type="Button">
+        <Parent guid="guidCmdSetToolsMenu" id="ToolsMenuGroup" />
+        <Icon guid="guidImages" id="optionsIcon" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Options</ButtonText>
+        </Strings>
+      </Button>
       <!-- Tools menu -->
       <Button guid="guidCmdSetActionsMenu" id="ActionCommandId" priority="4" type="Button">
         <Parent guid="guidCmdSetActionsMenu" id="ActionsMenuGroup" />
@@ -107,36 +137,6 @@
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
           <ButtonText>Debug</ButtonText>
-        </Strings>
-      </Button>
-      <!-- Tool window commands -->
-      <Button guid="guidCmdSetToolWindow" id="ToolWindowVisualizerCommandId" priority="1" type="Button">
-        <Parent guid="guidCmdSetToolsMenu" id="ToolsMenuGroup" />
-        <Icon guid="guidImages" id="visualizerIcon" />
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <Strings>
-          <ButtonText>Open Visualizer</ButtonText>
-        </Strings>
-      </Button>
-      <!--
-      <Button guid="guidCmdSetToolWindow" id="ToolWindowSliceVisualizerCommandId" priority="2" type="Button">
-        <Parent guid="guidCmdSetToolsMenu" id="ToolsMenuGroup" />
-        <Icon guid="guidImages" id="visualizerIcon" />
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <Strings>
-          <ButtonText>Open Slice Visualizer</ButtonText>
-        </Strings>
-      </Button>
-      -->
-      <Button guid="guidCmdSetToolWindow" id="ToolWindowOptionsCommandId" priority="3" type="Button">
-        <Parent guid="guidCmdSetToolsMenu" id="ToolsMenuGroup" />
-        <Icon guid="guidImages" id="optionsIcon" />
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <Strings>
-          <ButtonText>Options</ButtonText>
         </Strings>
       </Button>
       <!-- Editor context menu -->
@@ -238,7 +238,7 @@
     </Groups>
 
     <Combos>
-       <Combo guid="guidCmdSetProfileDropdown" id="ProfileTargetMachineDropdownId" priority="10" type="DynamicCombo" defaultWidth="120" idCommandList="ProfileTargetMachineDropdownListId">
+       <Combo guid="guidCmdSetProfileDropdown" id="ProfileTargetMachineDropdownId" priority="100" type="DynamicCombo" defaultWidth="120" idCommandList="ProfileTargetMachineDropdownListId">
         <Parent guid="guidCmdSetToolsMenu" id="ToolsMenuGroup" />
         <CommandFlag>IconAndText</CommandFlag>
         <CommandFlag>CommandWellOnly</CommandFlag>

--- a/VSRAD.PackageTests/BuildTools/Errors/LineMapperTests.cs
+++ b/VSRAD.PackageTests/BuildTools/Errors/LineMapperTests.cs
@@ -1,56 +1,10 @@
-using System.Linq;
-using VSRAD.Package.BuildTools.Errors;
 using Xunit;
-using static VSRAD.Package.BuildTools.BuildErrorProcessor;
 using static VSRAD.Package.BuildTools.Errors.LineMapper;
-using static VSRAD.Package.BuildTools.Errors.Parser;
 
 namespace VSRAD.PackageTests.BuildTools.Errors
 {
     public class LineMapperTests
     {
-        public const string ErrString = @"code.c:14:8: error: use of undeclared identifier 'ia'
-return ia;
-       ^
-test.c:17:10: error: invalid suffix 'uigyuigyuiguyi' on integer constant
- return 0uigyuigyuiguyi;
-         ^
-2 errors generated.
-";
-
-        public const string PpString = @"# 1 ""test.c""
-    //# 1 ""<built-in>""
-# 1 ""<command-line>""
-# 31 ""<command-line>""
-    # 1     ""/usr/include/stdc-predef.h"" 1 3 4
-//# 32      ""<command-line>"" 2
-#       1 ""test.c""
-
-
-int main(int argc, char** argv)
-        {
-  # 1 ""code.c"" 1
-            int i = 3 + 3;
-            return ia;
-# 5 ""test.c"" 2
-
-            return 0uigyuigyuiguyi;
-
-        }
-";
-
-
-        public const string Preprocessed = @"int main() {
-    int a = 1 + 1;
-    int b = 2 + 2;
-  # 16 ""source.c""
-    int c = 3 + 3;
-    int d = 4 + 4;
-   //# 55 ""source1.c""
-    int f = 0xDEAD;
-}
-";
-
         public static readonly string[] ProjectPaths = new[] {
             @"code/EVA00/main.c",
             @"code/EVA00/sensors_controller.c",
@@ -67,43 +21,6 @@ int main(int argc, char** argv)
         };
 
         public const string RemotePath = @"MAIN_MODULE\EVA00\pilot_controller.c";
-
-        [Fact]
-        public void PreprocessMapLinesTest()
-        {
-            var lineMapping = MapLines(Preprocessed);
-            Assert.Equal(new LineMarker[] {
-                new LineMarker(ppLine: 5, sourceLine: 16, sourceFile: "source.c"),
-                new LineMarker(ppLine: 8, sourceLine: 55, sourceFile: "source1.c")
-            }, lineMapping);
-        }
-
-        [Fact]
-        public void ParseErrorsWithPreprocessedTest()
-        {
-            var messages = ParseStderr(new string[] { ErrString });
-            UpdateErrorLocations(messages, PpString, new string[] { "source.c", "code.c" });
-            Assert.Equal(2, messages.First().Line);
-            Assert.Equal("code.c", messages.First().SourceFile);
-            Assert.Equal(6, messages.Last().Line);
-            Assert.Equal("source.c", messages.Last().SourceFile);
-        }
-
-        [Fact]
-        public void EmptyLineTest()
-        {
-            var messages = ParseStderr(new string[] { @"
-*E,fatal: undefined reference to 'printf' (<stdin>:3)
-*W,undefined: 1 undefined references found
-*E,syntax error (<stdin>:12): at symbol 'printf'
-    parse error: syntax error, unexpected T_PAAMAYIM_NEKUDOTAYIM
-    did you really mean to use the scope resolution op here?
-*E,fatal (auth.c:35): Uncaught error: Undefined variable: user
-" }).ToArray();
-            UpdateErrorLocations(messages, PpString, new string[] { "source.c", "code.c" });
-            Assert.Equal(0, messages[1].Line);
-
-        }
 
         [Fact]
         public void HostSourcePathMappingTest()

--- a/VSRAD.PackageTests/MockCommunicationChannel.cs
+++ b/VSRAD.PackageTests/MockCommunicationChannel.cs
@@ -50,9 +50,6 @@ namespace VSRAD.PackageTests
                     HandleCommand(c, withReply: false);
                     return Task.CompletedTask;
                 });
-            _mock
-                .Setup((c) => c.SendBundleAsync(It.IsAny<List<ICommand>>()))
-                .Returns<List<ICommand>>((c) => Task.FromResult(HandleBundle(c)));
         }
 
         public void ThenRespond<TCommand, TResponse>(TResponse response, Action<TCommand> processCallback)
@@ -95,16 +92,6 @@ namespace VSRAD.PackageTests
                 _nonReplyInteractions.Dequeue()?.Invoke(command);
                 return null;
             }
-        }
-
-        private IResponse[] HandleBundle(List<ICommand> bundle)
-        {
-            if (_bundledInteractions.Count == 0)
-                throw new Xunit.Sdk.XunitException($"The test method has sent a request bundle when none was expected.");
-
-            var (responses, callback) = _bundledInteractions.Dequeue();
-            callback?.Invoke(bundle);
-            return responses;
         }
     }
 }

--- a/VSRAD.PackageTests/ProjectSystem/Profiles/LegacyProfileImporterTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Profiles/LegacyProfileImporterTests.cs
@@ -88,9 +88,9 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             Assert.Equal("valid_watches", readDebugData.WatchesFile.Path);
             Assert.True(readDebugData.WatchesFile.CheckTimestamp);
 
-            Assert.Equal(StepEnvironment.Remote, readDebugData.StatusFile.Location);
-            Assert.Equal("status", readDebugData.StatusFile.Path);
-            Assert.True(readDebugData.StatusFile.CheckTimestamp);
+            Assert.Equal(StepEnvironment.Remote, readDebugData.DispatchParamsFile.Location);
+            Assert.Equal("status", readDebugData.DispatchParamsFile.Path);
+            Assert.True(readDebugData.DispatchParamsFile.CheckTimestamp);
         }
 
         [Fact]

--- a/VSRAD.PackageTests/ProjectSystem/Profiles/LegacyProfileOptionsMigratorTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Profiles/LegacyProfileOptionsMigratorTests.cs
@@ -33,9 +33,9 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             Assert.Equal(StepEnvironment.Remote, step2.WatchesFile.Location);
             Assert.Equal("watches-file", step2.WatchesFile.Path);
             Assert.False(step2.WatchesFile.CheckTimestamp);
-            Assert.Equal(StepEnvironment.Local, step2.StatusFile.Location);
-            Assert.Equal("status-file", step2.StatusFile.Path);
-            Assert.True(step2.StatusFile.CheckTimestamp);
+            Assert.Equal(StepEnvironment.Local, step2.DispatchParamsFile.Location);
+            Assert.Equal("status-file", step2.DispatchParamsFile.Path);
+            Assert.True(step2.DispatchParamsFile.CheckTimestamp);
 
             Assert.Equal("Debug (Old)", converted.Profiles["Default"].MenuCommands.DebugAction);
         }

--- a/VSRAD.PackageTests/ProjectSystem/Profiles/ProfileOptionsWindowContextTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Profiles/ProfileOptionsWindowContextTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
+using VSRAD.Package;
 using VSRAD.Package.Options;
 using VSRAD.Package.ProjectSystem;
 using VSRAD.Package.ProjectSystem.Macros;
@@ -177,7 +178,7 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             nameResolver.Setup(n => n("Rename", "Profile kana already exists. Enter a new name or leave it as is to overwrite the profile:", It.IsAny<IEnumerable<string>>(), "kana"))
                 .Returns("asa-renamed").Verifiable();
 
-            context.SaveChanges();
+            Assert.Null(context.SaveChanges()); // no error
             nameResolver.Verify();
 
             Assert.Equal(2, project.Options.Profiles.Count);
@@ -205,7 +206,7 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
 
             nameResolver.Setup(n => n("Rename", It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), "kana")).Returns("kana");
 
-            context.SaveChanges();
+            Assert.Null(context.SaveChanges()); // no error
 
             // Selected profile is transparently switched to the replacement
             Assert.Equal(asa, context.SelectedProfile);
@@ -214,6 +215,27 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             Assert.Equal(1, project.Options.Profiles.Count);
             Assert.True(project.Options.Profiles.TryGetValue("kana", out var renamed));
             Assert.Equal("asa-edited", renamed.General.RemoteMachine);
+        }
+
+        [Fact]
+        public void SaveChangesNameConflictResolutionCancelledTest()
+        {
+            var project = CreateTestProject();
+            var nameResolver = new Mock<ProfileOptionsWindowContext.AskProfileNameDelegate>(MockBehavior.Strict);
+            var context = new ProfileOptionsWindowContext(project, null, nameResolver.Object);
+
+            context.SelectedProfile = GetDirtyProfile(context, "kana");
+            var asa = GetDirtyProfile(context, "asa");
+            asa.General.ProfileName = "kana";
+
+            nameResolver.Setup(n => n("Rename", It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), "kana")).Returns((string)null);
+
+            Assert.Equal("Profile options were not saved.", ((Error)context.SaveChanges()).Message);
+
+            // Profiles are unchanged
+            Assert.Equal(2, project.Options.Profiles.Count);
+            Assert.True(project.Options.Profiles.ContainsKey("kana"));
+            Assert.True(project.Options.Profiles.ContainsKey("asa"));
         }
 
         [Fact]

--- a/VSRAD.PackageTests/ProjectSystem/Profiles/ProfileOptionsWindowContextTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Profiles/ProfileOptionsWindowContextTests.cs
@@ -196,6 +196,10 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
         public void SaveChangesNameConflictIgnoredTest()
         {
             var project = CreateTestProject();
+            // Add a third profile at the end
+            project.Options.SetProfiles(project.Options.Profiles.Append(new KeyValuePair<string, ProfileOptions>("miz", new ProfileOptions())).ToDictionary(p => p.Key, p => p.Value),
+                project.Options.ActiveProfile);
+
             var nameResolver = new Mock<ProfileOptionsWindowContext.AskProfileNameDelegate>(MockBehavior.Strict);
             var context = new ProfileOptionsWindowContext(project, null, nameResolver.Object);
 
@@ -210,11 +214,13 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
 
             // Selected profile is transparently switched to the replacement
             Assert.Equal(asa, context.SelectedProfile);
-            Assert.Single(context.DirtyProfiles, asa);
+            Assert.Equal(2, context.DirtyProfiles.Count);
+            Assert.Equal(asa, context.DirtyProfiles[0]);
 
-            Assert.Equal(1, project.Options.Profiles.Count);
+            Assert.Equal(2, project.Options.Profiles.Count);
             Assert.True(project.Options.Profiles.TryGetValue("kana", out var renamed));
             Assert.Equal("asa-edited", renamed.General.RemoteMachine);
+            Assert.True(project.Options.Profiles.ContainsKey("miz"));
         }
 
         [Fact]

--- a/VSRAD.PackageTests/Server/ActionMacroEvaluationTests.cs
+++ b/VSRAD.PackageTests/Server/ActionMacroEvaluationTests.cs
@@ -203,7 +203,7 @@ namespace VSRAD.PackageTests.Server
             a.Steps.Add(new ReadDebugDataStep(
                 outputFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "remote-output", CheckTimestamp = true },
                 watchesFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "remote-watches", CheckTimestamp = false },
-                statusFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "remote-status", CheckTimestamp = false },
+                dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "remote-status", CheckTimestamp = false },
                 binaryOutput: true, outputOffset: 0));
 
             profile.General.RunActionsLocally = false;
@@ -231,7 +231,7 @@ namespace VSRAD.PackageTests.Server
             {
                 var readDebugData = (ReadDebugDataStep)result.Steps[5];
                 Assert.Equal(StepEnvironment.Remote, readDebugData.OutputFile.Location);
-                Assert.Equal(StepEnvironment.Remote, readDebugData.StatusFile.Location);
+                Assert.Equal(StepEnvironment.Remote, readDebugData.DispatchParamsFile.Location);
                 Assert.Equal(StepEnvironment.Remote, readDebugData.WatchesFile.Location);
             }
 
@@ -260,7 +260,7 @@ namespace VSRAD.PackageTests.Server
             {
                 var readDebugData = (ReadDebugDataStep)result.Steps[5];
                 Assert.Equal(StepEnvironment.Local, readDebugData.OutputFile.Location);
-                Assert.Equal(StepEnvironment.Local, readDebugData.StatusFile.Location);
+                Assert.Equal(StepEnvironment.Local, readDebugData.DispatchParamsFile.Location);
                 Assert.Equal(StepEnvironment.Local, readDebugData.WatchesFile.Location);
             }
         }

--- a/VSRAD.PackageTests/Server/ActionRunnerTests.cs
+++ b/VSRAD.PackageTests/Server/ActionRunnerTests.cs
@@ -362,7 +362,7 @@ namespace VSRAD.PackageTests.Server
                 new ReadDebugDataStep(
                     outputFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "output", CheckTimestamp = true },
                     watchesFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "watches", CheckTimestamp = false },
-                    statusFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "status", CheckTimestamp = false },
+                    dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "status", CheckTimestamp = false },
                     binaryOutput: true, outputOffset: 0)
             };
 
@@ -407,7 +407,7 @@ comment 115200") }, (FetchResultRange statusFetch) =>
                 new ReadDebugDataStep(
                     outputFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "remote/output", CheckTimestamp = true },
                     watchesFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "remote/watches", CheckTimestamp = true },
-                    statusFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "remote/status", CheckTimestamp = true },
+                    dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "remote/status", CheckTimestamp = true },
                     binaryOutput: true, outputOffset: 0)
             };
 
@@ -441,10 +441,10 @@ comment 115200") }, (FetchResultRange statusFetch) =>
         {
             var outputFile = Path.GetTempFileName();
             var watchesFile = Path.GetTempFileName();
-            var statusFile = Path.GetTempFileName();
+            var dispatchParamsFile = Path.GetTempFileName();
 
             File.WriteAllText(watchesFile, "jill\r\njulianne");
-            File.WriteAllText(statusFile, @"
+            File.WriteAllText(dispatchParamsFile, @"
 grid size (64, 0, 0)
 group size (64, 0, 0)
 wave size 64");
@@ -464,7 +464,7 @@ wave size 64");
                 new ReadDebugDataStep(
                     outputFile: new BuiltinActionFile { Location = StepEnvironment.Local, Path = outputFile, CheckTimestamp = false },
                     watchesFile: new BuiltinActionFile { Location = StepEnvironment.Local, Path = watchesFile, CheckTimestamp = false },
-                    statusFile: new BuiltinActionFile { Location = StepEnvironment.Local, Path = statusFile, CheckTimestamp = false },
+                    dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Local, Path = dispatchParamsFile, CheckTimestamp = false },
                     binaryOutput: true, outputOffset: 0)
             };
             var runner = new ActionRunner(null, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), ""));
@@ -495,7 +495,7 @@ wave size 64");
                 new ReadDebugDataStep(
                     outputFile: new BuiltinActionFile { Location = StepEnvironment.Local, Path = fileName, CheckTimestamp = true },
                     watchesFile: new BuiltinActionFile(),
-                    statusFile: new BuiltinActionFile(),
+                    dispatchParamsFile: new BuiltinActionFile(),
                     binaryOutput: true, outputOffset: 0)
             };
 
@@ -549,7 +549,7 @@ wave size 64");
             {
                 new ReadDebugDataStep(
                     outputFile: new BuiltinActionFile { Location = StepEnvironment.Local, Path = outputFile, CheckTimestamp = false },
-                    watchesFile: new BuiltinActionFile(), statusFile: new BuiltinActionFile(), binaryOutput: false, outputOffset: 1)
+                    watchesFile: new BuiltinActionFile(), dispatchParamsFile: new BuiltinActionFile(), binaryOutput: false, outputOffset: 1)
             };
             var runner = new ActionRunner(null, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), "", watches: new ReadOnlyCollection<string>(new[] { "const" })));
             var result = await runner.RunAsync("Debug", steps);
@@ -574,9 +574,9 @@ wave size 64");
             readDebugData.OutputFile.Location = StepEnvironment.Remote;
             readDebugData.OutputFile.CheckTimestamp = true;
             readDebugData.OutputFile.Path = "/home/parker/audio/master";
-            readDebugData.StatusFile.Location = StepEnvironment.Remote;
-            readDebugData.StatusFile.CheckTimestamp = false;
-            readDebugData.StatusFile.Path = "/home/parker/audio/copy";
+            readDebugData.DispatchParamsFile.Location = StepEnvironment.Remote;
+            readDebugData.DispatchParamsFile.CheckTimestamp = false;
+            readDebugData.DispatchParamsFile.Path = "/home/parker/audio/copy";
             //readDebugData.WatchesFile.Location = StepEnvironment.Local;
             //readDebugData.WatchesFile.CheckTimestamp = true;
             //readDebugData.WatchesFile.Path = "non-existent-local-path";

--- a/VSRAD.PackageTests/Server/BreakStateDispatchParametersTests.cs
+++ b/VSRAD.PackageTests/Server/BreakStateDispatchParametersTests.cs
@@ -38,7 +38,7 @@ group size (512, 0, 0)
 wave size 64
 comment -");
             Assert.False(paramsResult.TryGetResult(out _, out var error));
-            Assert.Equal("Could not set dispatch parameters from the status file. If GridY and GridZ are set, GroupY and GroupZ cannot be zero.", error.Message);
+            Assert.Equal("Could not read the dispatch parameters file. If GridY and GridZ are set, GroupY and GroupZ cannot be zero.", error.Message);
         }
 
         [Fact]
@@ -49,35 +49,35 @@ grid size (0, 0, 0)
 group size (0, 0, 0)
 wave size 64
 comment -").TryGetResult(out _, out var error));
-            Assert.Equal("Could not set dispatch parameters from the status file. GridX cannot be zero.", error.Message);
+            Assert.Equal("Could not read the dispatch parameters file. GridX cannot be zero.", error.Message);
 
             Assert.False(BreakStateDispatchParameters.Parse(@"
 grid size (64, 0, 0)
 group size (0, 0, 0)
 wave size 64
 comment -").TryGetResult(out _, out error));
-            Assert.Equal("Could not set dispatch parameters from the status file. GroupX cannot be zero.", error.Message);
+            Assert.Equal("Could not read the dispatch parameters file. GroupX cannot be zero.", error.Message);
 
             Assert.False(BreakStateDispatchParameters.Parse(@"
 grid size (128, 0, 0)
 group size (512, 0, 0)
 wave size 64
 comment -").TryGetResult(out _, out error));
-            Assert.Equal("Could not set dispatch parameters from the status file. GroupX cannot be bigger than GridX.", error.Message);
+            Assert.Equal("Could not read the dispatch parameters file. GroupX cannot be bigger than GridX.", error.Message);
 
             Assert.False(BreakStateDispatchParameters.Parse(@"
 grid size (512, 128, 1)
 group size (512, 512, 1)
 wave size 64
 comment -").TryGetResult(out _, out error));
-            Assert.Equal("Could not set dispatch parameters from the status file. GroupY cannot be bigger than GridY.", error.Message);
+            Assert.Equal("Could not read the dispatch parameters file. GroupY cannot be bigger than GridY.", error.Message);
 
             Assert.False(BreakStateDispatchParameters.Parse(@"
 grid size (512, 512, 1)
 group size (512, 512, 128)
 wave size 64
 comment -").TryGetResult(out _, out error));
-            Assert.Equal("Could not set dispatch parameters from the status file. GroupZ cannot be bigger than GridZ.", error.Message);
+            Assert.Equal("Could not read the dispatch parameters file. GroupZ cannot be bigger than GridZ.", error.Message);
         }
 
         [Fact]
@@ -88,14 +88,14 @@ grid size (128, 0, 0)
 group size (32, 0, 0)
 wave size 0
 comment -").TryGetResult(out _, out var error));
-            Assert.Equal("Could not set dispatch parameters from the status file. WaveSize cannot be zero.", error.Message);
+            Assert.Equal("Could not read the dispatch parameters file. WaveSize cannot be zero.", error.Message);
 
             Assert.False(BreakStateDispatchParameters.Parse(@"
 grid size (128, 0, 0)
 group size (32, 0, 0)
 wave size 64
 comment -").TryGetResult(out _, out error));
-            Assert.Equal("Could not set dispatch parameters from the status file. WaveSize cannot be bigger than GroupX.", error.Message);
+            Assert.Equal("Could not read the dispatch parameters file. WaveSize cannot be bigger than GroupX.", error.Message);
         }
 
         [Fact]
@@ -134,7 +134,7 @@ local size (512, 0, 0)
 warp size 32");
             Assert.False(result.TryGetResult(out _, out var error));
             Assert.Equal(
-@"Could not read dispatch parameters from the status file. The following is an example of the expected status file contents:
+@"Could not read the dispatch parameters file. The following is an example of the expected file contents:
 
 grid size (2048, 1, 1)
 group size (512, 1, 1)


### PR DESCRIPTION
* Renamed `Status File` to `Dispatch Parameters File`
* Fixed a crash when attempting to save profiles with conflicting names and pressing "Cancel" in the name conflict resolution dialog
* Removed preprocessor line mapping. This code was broken for a long time (see #138, #21) and can be reimplemented as a separate script
* Fixed current statement markers not showing up in Release builds