### PR TITLE
Minor visualizer fixes

### DIFF
--- a/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
@@ -45,15 +45,16 @@ namespace VSRAD.Package.DebugVisualizer
             var wfrontSize = Math.Min(options.WaveSize, GroupSize);
             for (int wfrontOffset = 0; wfrontOffset < GroupSize; wfrontOffset += (int)wfrontSize)
             {
+                var lastLaneId = Math.Min(wfrontOffset + wfrontSize, GroupSize) - 1; // handle incomplete groups (group size % wave size != 0)
                 if (options.CheckMagicNumber && system[wfrontOffset] != options.MagicNumber)
                 {
-                    for (int laneId = 0; laneId < wfrontSize; ++laneId)
+                    for (int laneId = 0; wfrontOffset + laneId <= lastLaneId; ++laneId)
                         _columnState[wfrontOffset + laneId] |= ColumnStates.Inactive;
                 }
-                else if (options.MaskLanes)
+                else if (options.MaskLanes && wfrontSize <= 64 && wfrontOffset + 9 <= lastLaneId)
                 {
                     var execMask = new BitArray(new[] { (int)system[wfrontOffset + 8], (int)system[wfrontOffset + 9] });
-                    for (int laneId = 0; laneId < wfrontSize; ++laneId)
+                    for (int laneId = 0; wfrontOffset + laneId <= lastLaneId; ++laneId)
                         if (!execMask[laneId])
                             _columnState[wfrontOffset + laneId] |= ColumnStates.Inactive;
                 }

--- a/VSRAD.Package/DebugVisualizer/ContextMenus/SubgroupContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/SubgroupContextMenu.cs
@@ -30,8 +30,7 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
             if (hit.RowIndex != -1 || hit.ColumnIndex < 0)
                 return false;
             _clickedColumnIndex = hit.ColumnIndex;
-            _menu.MenuItems[12].Enabled = hit.ColumnIndex >= VisualizerTable.DataColumnOffset;
-            _menu.MenuItems[16].Enabled = hit.ColumnIndex >= VisualizerTable.DataColumnOffset;
+            _menu.MenuItems.Cast<MenuItem>().First(m => m.Text == "Hide This").Enabled = hit.ColumnIndex >= VisualizerTable.DataColumnOffset;
             _menu.Show(_table, new Point(e.X, e.Y));
             return true;
         }
@@ -41,7 +40,7 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
             var keepFirst = CreatePartialSubgroupMenu(minSubgroupSize: 1, maxSubgroupSize: 512, displayLast: false);
             var keepLast = CreatePartialSubgroupMenu(minSubgroupSize: 1, maxSubgroupSize: 512, displayLast: true);
 
-            var showAll = new MenuItem("All Columns", (s, e) => SetColumnSelector($"0-{_getGroupSize() - 1}"));
+            var showAll = new MenuItem("Show All Columns", (s, e) => SetColumnSelector($"0-{_getGroupSize() - 1}"));
 
             var fgColor = new MenuItem("Font Color", new[]
             {
@@ -58,7 +57,7 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
                 new MenuItem("None", (s, e) => SetBackgroundColor(DataHighlightColor.None))
             });
 
-            var fitWidth = new MenuItem("Fit Width", (s, e) =>
+            var fitWidth = new MenuItem("Autofit Width", (s, e) =>
                 _state.FitWidth(_clickedColumnIndex));
 
             var hideThis = new MenuItem("Hide This", HideColumns);

--- a/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
+++ b/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
@@ -108,6 +108,25 @@ namespace VSRAD.Package.DebugVisualizer
             Update();
         }
 
+        public void GoToGroup(uint groupIdx)
+        {
+            if (_projectOptions.VisualizerOptions.NDRange3D)
+            {
+                _updateOptions = false;
+                X = groupIdx % DimX;
+                groupIdx /= DimX;
+                Y = groupIdx % DimY;
+                groupIdx /= DimY;
+                Z = groupIdx;
+                _updateOptions = true;
+                Update();
+            }
+            else
+            {
+                X = groupIdx;
+            }
+        }
+
         public void Update()
         {
             var index = _projectOptions.VisualizerOptions.NDRange3D ? (X + Y * DimX + Z * DimX * DimY) : X;

--- a/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
+++ b/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
@@ -64,25 +64,24 @@ namespace VSRAD.Package.DebugVisualizer
         public GroupIndexSelector(Options.ProjectOptions options)
         {
             _projectOptions = options;
-            _projectOptions.VisualizerOptions.PropertyChanged += (sender, args) =>
-            {
-                if (args.PropertyName == nameof(Options.VisualizerOptions.NDRange3D))
-                {
-                    RaisePropertyChanged(nameof(MaximumX));
-                    Update();
-                }
-            };
+            _projectOptions.VisualizerOptions.PropertyChanged += OptionsChanged;
+            _projectOptions.DebuggerOptions.PropertyChanged += OptionsChanged;
+        }
 
-            _projectOptions.DebuggerOptions.PropertyChanged += (sender, args) =>
+        private void OptionsChanged(object sender, PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
             {
-                switch (args.PropertyName)
-                {
-                    case nameof(Options.DebuggerOptions.GroupSize):
-                    case nameof(Options.DebuggerOptions.NGroups):
-                        if (_updateOptions) Update();
-                        break;
-                }
-            };
+                case nameof(Options.VisualizerOptions.NDRange3D):
+                    RaisePropertyChanged(nameof(MaximumX));
+                    if (_updateOptions) Update();
+                    break;
+                case nameof(Options.VisualizerOptions.WaveSize):
+                case nameof(Options.DebuggerOptions.GroupSize):
+                case nameof(Options.DebuggerOptions.NGroups):
+                    if (_updateOptions) Update();
+                    break;
+            }
         }
 
         public void UpdateOnBreak(BreakState breakState)

--- a/VSRAD.Package/DebugVisualizer/SelectionController.cs
+++ b/VSRAD.Package/DebugVisualizer/SelectionController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Windows.Forms;
 using System.Windows.Input;
 
@@ -26,6 +27,30 @@ namespace VSRAD.Package.DebugVisualizer
                 return GetSelectedRows();
             else
                 return new[] { _table.Rows[clickedRowIndex] };
+        }
+
+        public bool SelectAllColumnsInRange(int fromIndex, int toIndex)
+        {
+            toIndex = Math.Min(toIndex, _table.Columns.Count - 1);
+
+            bool anySelected = false;
+
+            _table.ClearSelection();
+            for (int i = fromIndex; i <= toIndex; ++i)
+            {
+                if (_table.Columns[i].Visible)
+                {
+                    if (!anySelected)
+                        _table.FirstDisplayedScrollingColumnIndex = i;
+
+                    anySelected = true;
+                    foreach (DataGridViewRow row in _table.Rows)
+                        if (row.Index >= 0 && row.Index != _table.RowCount - 1)
+                            row.Cells[i].Selected = true;
+                }
+            }
+
+            return anySelected;
         }
 
         // We want to select a column when the column header is clicked, and a row when the row header is clicked.

--- a/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
@@ -42,21 +42,8 @@ namespace VSRAD.Package.DebugVisualizer
         private int _canvasHeight = 10;
         public int CanvasHeight { get => _canvasHeight; set => SetField(ref _canvasHeight, value); }
 
-        private int _currentWaveGroupIndex = 0;
-        public int CurrentWaveGroupIndex { get => _currentWaveGroupIndex; set => SetField(ref _currentWaveGroupIndex, value); }
-
-        private int _currentWaveIndex = 0;
-        public int CurrentWaveIndex { get => _currentWaveIndex; set => SetField(ref _currentWaveIndex, value); }
-
-        private int _currentWaveBreakLine = 0;
-        public int CurrentWaveBreakLine { get => _currentWaveBreakLine; set => SetField(ref _currentWaveBreakLine, value); }
-
-        private bool _currentWavePartialMask = false;
-        public bool CurrentWavePartialMask { get => _currentWavePartialMask; set => SetField(ref _currentWavePartialMask, value); }
-
-        private bool _currentWaveBreakNotRiched = false;
-        public bool CurrentWaveBreakNotRiched { get => _currentWaveBreakNotRiched; set => SetField(ref _currentWaveBreakNotRiched, value); }
-
+        private Wavemap.WaveInfo _currentWaveInfo;
+        public Wavemap.WaveInfo CurrentWaveInfo { get => _currentWaveInfo; set => SetField(ref _currentWaveInfo, value); }
 
         private bool _groupIndexEditable = true;
         public bool GroupIndexEditable { get => _groupIndexEditable; set => SetField(ref _groupIndexEditable, value); }

--- a/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
@@ -42,9 +42,6 @@ namespace VSRAD.Package.DebugVisualizer
         private int _canvasHeight = 10;
         public int CanvasHeight { get => _canvasHeight; set => SetField(ref _canvasHeight, value); }
 
-        private string _currentWaveInfo = "";
-        public string CurrentWaveInfo { get => _currentWaveInfo; set => SetField(ref _currentWaveInfo, value); }
-
         private int _currentWaveGroupIndex = 0;
         public int CurrentWaveGroupIndex { get => _currentWaveGroupIndex; set => SetField(ref _currentWaveGroupIndex, value); }
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
@@ -45,6 +45,22 @@ namespace VSRAD.Package.DebugVisualizer
         private string _currentWaveInfo = "";
         public string CurrentWaveInfo { get => _currentWaveInfo; set => SetField(ref _currentWaveInfo, value); }
 
+        private int _currentWaveGroupIndex = 0;
+        public int CurrentWaveGroupIndex { get => _currentWaveGroupIndex; set => SetField(ref _currentWaveGroupIndex, value); }
+
+        private int _currentWaveIndex = 0;
+        public int CurrentWaveIndex { get => _currentWaveIndex; set => SetField(ref _currentWaveIndex, value); }
+
+        private int _currentWaveBreakLine = 0;
+        public int CurrentWaveBreakLine { get => _currentWaveBreakLine; set => SetField(ref _currentWaveBreakLine, value); }
+
+        private bool _currentWavePartialMask = false;
+        public bool CurrentWavePartialMask { get => _currentWavePartialMask; set => SetField(ref _currentWavePartialMask, value); }
+
+        private bool _currentWaveBreakNotRiched = false;
+        public bool CurrentWaveBreakNotRiched { get => _currentWaveBreakNotRiched; set => SetField(ref _currentWaveBreakNotRiched, value); }
+
+
         private bool _groupIndexEditable = true;
         public bool GroupIndexEditable { get => _groupIndexEditable; set => SetField(ref _groupIndexEditable, value); }
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
@@ -42,12 +42,6 @@ namespace VSRAD.Package.DebugVisualizer
         private int _canvasHeight = 10;
         public int CanvasHeight { get => _canvasHeight; set => SetField(ref _canvasHeight, value); }
 
-        private int _wavemapXOffset = 0;
-        public int WavemapXOffset { get => _wavemapXOffset; set => SetField(ref _wavemapXOffset, value); }
-
-        private int _wavemapYOffset = 0;
-        public int WavemapYOffset { get => _wavemapYOffset; set => SetField(ref _wavemapYOffset, value); }
-
         private string _currentWaveInfo = "";
         public string CurrentWaveInfo { get => _currentWaveInfo; set => SetField(ref _currentWaveInfo, value); }
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerContext.cs
@@ -77,7 +77,7 @@ namespace VSRAD.Package.DebugVisualizer
             if (_breakState == null)
                 return;
 
-            e.DataGroupCount = (uint)_breakState.Data.GetGroupCount((int)e.GroupSize, (int)Options.DebuggerOptions.NGroups);
+            e.DataGroupCount = (uint)_breakState.Data.GetGroupCount((int)e.GroupSize, (int)Options.VisualizerOptions.WaveSize, (int)Options.DebuggerOptions.NGroups);
             WatchesValid = e.IsValid = e.GroupIndex < e.DataGroupCount;
             if (!WatchesValid)
                 return;
@@ -95,7 +95,7 @@ namespace VSRAD.Package.DebugVisualizer
             GroupIndexEditable = false;
 
             var warning = await _breakState.Data.ChangeGroupWithWarningsAsync(_channel, (int)e.GroupIndex, (int)e.GroupSize,
-                (int)Options.DebuggerOptions.NGroups, fetchArgs.FetchWholeFile);
+                (int)Options.VisualizerOptions.WaveSize, (int)Options.DebuggerOptions.NGroups, fetchArgs.FetchWholeFile);
 
             GroupFetched(this, new GroupFetchedEventArgs(warning));
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -91,12 +91,6 @@ namespace VSRAD.Package.DebugVisualizer
                     else
                         GrayOutWatches();
                     break;
-                case nameof(VisualizerContext.WavemapXOffset):
-                    _wavemap.XOffset = _context.WavemapXOffset;
-                    break;
-                case nameof(VisualizerContext.WavemapYOffset):
-                    _wavemap.YOffset = _context.WavemapYOffset;
-                    break;
             }
         }
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -23,6 +23,7 @@ namespace VSRAD.Package.DebugVisualizer
             InitializeComponent();
 
             _wavemap = new WavemapImage(HeaderHost.WavemapImage, _context);
+            _wavemap.NavigationRequested += NavigateToWave;
             HeaderHost.WavemapSelector.Setup(_context, _wavemap);
 
             integration.AddWatch += AddWatch;
@@ -48,6 +49,13 @@ namespace VSRAD.Package.DebugVisualizer
             _table.SetScalingMode(_context.Options.VisualizerAppearance.ScalingMode);
             TableHost.Setup(_table);
             RestoreSavedState();
+        }
+
+        private void NavigateToWave(object sender, WavemapImage.NagivationEventArgs e)
+        {
+            _context.GroupIndex.GoToGroup(e.GroupIdx);
+            if (e.WaveIdx is uint waveIdx)
+                _table.GoToWave(waveIdx, _context.Options.VisualizerOptions.WaveSize);
         }
 
         private void SetupDataFetch(object sender, GroupFetchingEventArgs e)

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Windows.Controls;
 using VSRAD.Package.DebugVisualizer.Wavemap;
-using VSRAD.Package.Options;
 using VSRAD.Package.ProjectSystem;
 using VSRAD.Package.Server;
 using VSRAD.Package.Utils;
@@ -18,8 +17,6 @@ namespace VSRAD.Package.DebugVisualizer
         {
             _context = integration.GetVisualizerContext();
             _context.PropertyChanged += ContextPropertyChanged;
-            _context.Options.DebuggerOptions.PropertyChanged += DebuggerOptionChanged;
-            _context.Options.VisualizerOptions.PropertyChanged += HandleWavemapElementSize;
             _context.GroupFetched += GroupFetched;
             _context.GroupFetching += SetupDataFetch;
             DataContext = _context;
@@ -53,23 +50,9 @@ namespace VSRAD.Package.DebugVisualizer
             RestoreSavedState();
         }
 
-        private void HandleWavemapElementSize(object sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(VisualizerOptions.WavemapElementSize))
-            {
-                _wavemap.ElementSize = _context.Options.VisualizerOptions.WavemapElementSize;
-            }
-        }
-
         private void SetupDataFetch(object sender, GroupFetchingEventArgs e)
         {
-            e.FetchWholeFile |= _context.Options.VisualizerOptions.ShowWavemapField;
-        }
-
-        private void DebuggerOptionChanged(object sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(VisualizerContext.Options.DebuggerOptions.GroupSize))
-                RefreshDataStyling();
+            e.FetchWholeFile |= _context.Options.VisualizerOptions.ShowWavemap;
         }
 
         public void WindowFocusChanged(bool hasFocus) =>
@@ -102,7 +85,7 @@ namespace VSRAD.Package.DebugVisualizer
             _table.ApplyWatchStyling();
             RefreshDataStyling();
 
-            _wavemap.SetData(_context.BreakData.GetWavemapView((int)_context.Options.VisualizerOptions.WaveSize));
+            _wavemap.View = _context.BreakData.GetWavemapView((int)_context.Options.VisualizerOptions.WaveSize);
 
             foreach (System.Windows.Forms.DataGridViewRow row in _table.Rows)
                 SetRowContentsFromBreakState(row);
@@ -137,6 +120,7 @@ namespace VSRAD.Package.DebugVisualizer
                 case nameof(Options.VisualizerAppearance.ScalingMode):
                     _table.SetScalingMode(_context.Options.VisualizerAppearance.ScalingMode);
                     break;
+                case nameof(Options.DebuggerOptions.GroupSize):
                 case nameof(Options.VisualizerOptions.MaskLanes):
                 case nameof(Options.VisualizerOptions.LaneGrouping):
                 case nameof(Options.VisualizerOptions.CheckMagicNumber):
@@ -145,6 +129,10 @@ namespace VSRAD.Package.DebugVisualizer
                 case nameof(Options.VisualizerAppearance.HiddenColumnSeparatorWidth):
                 case nameof(Options.VisualizerAppearance.DarkenAlternatingRowsBy):
                     RefreshDataStyling();
+                    break;
+                case nameof(Options.VisualizerOptions.WaveSize):
+                    RefreshDataStyling();
+                    _wavemap.View = _context.BreakData.GetWavemapView((int)_context.Options.VisualizerOptions.WaveSize);
                     break;
                 case nameof(Options.VisualizerOptions.MagicNumber):
                     if (_context.Options.VisualizerOptions.CheckMagicNumber)

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -77,9 +77,7 @@ namespace VSRAD.Package.DebugVisualizer
             switch (e.PropertyName)
             {
                 case nameof(VisualizerContext.WatchesValid):
-                    if (_context.WatchesValid)
-                        RefreshDataStyling();
-                    else
+                    if (!_context.WatchesValid)
                         GrayOutWatches();
                     break;
             }

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -93,7 +93,7 @@ namespace VSRAD.Package.DebugVisualizer
             _table.ApplyWatchStyling();
             RefreshDataStyling();
 
-            _wavemap.View = _context.BreakData.GetWavemapView((int)_context.Options.VisualizerOptions.WaveSize);
+            _wavemap.View = _context.BreakData.GetWavemapView();
 
             foreach (System.Windows.Forms.DataGridViewRow row in _table.Rows)
                 SetRowContentsFromBreakState(row);
@@ -140,7 +140,7 @@ namespace VSRAD.Package.DebugVisualizer
                     break;
                 case nameof(Options.VisualizerOptions.WaveSize):
                     RefreshDataStyling();
-                    _wavemap.View = _context.BreakData.GetWavemapView((int)_context.Options.VisualizerOptions.WaveSize);
+                    _wavemap.View = _context.BreakData.GetWavemapView();
                     break;
                 case nameof(Options.VisualizerOptions.MagicNumber):
                     if (_context.Options.VisualizerOptions.CheckMagicNumber)

--- a/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
@@ -16,7 +16,8 @@
             <MenuItem Header="Columns" IsChecked="{Binding Options.VisualizerOptions.ShowColumnsField, Mode=TwoWay}" IsCheckable="True"/>
             <MenuItem Header="App args" IsChecked="{Binding Options.VisualizerOptions.ShowAppArgsField, Mode=TwoWay}" IsCheckable="True"/>
             <MenuItem Header="Break args" IsChecked="{Binding Options.VisualizerOptions.ShowBreakArgsField, Mode=TwoWay}" IsCheckable="True"/>
-            <MenuItem Header="Wavemap" IsChecked="{Binding Options.VisualizerOptions.ShowWavemapField, Mode=TwoWay}" IsCheckable="True"/>
+            <MenuItem Header="Wave size" IsChecked="{Binding Options.VisualizerOptions.ShowWaveSizeField, Mode=TwoWay}" IsCheckable="True"/>
+            <MenuItem Header="Wavemap" IsChecked="{Binding Options.VisualizerOptions.ShowWavemap, Mode=TwoWay}" IsCheckable="True"/>
         </ContextMenu>
     </UserControl.ContextMenu>
     <UserControl.Resources>
@@ -68,6 +69,11 @@
                 <Label Content="Group size:" Height="26" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
                 <local:NumberInput Value="{Binding Options.DebuggerOptions.GroupSize, UpdateSourceTrigger=PropertyChanged}"
                                    Minimum="1" Step="64" Width="38" Height="24"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Visibility="{Binding Options.VisualizerOptions.ShowWaveSizeField, Converter={StaticResource BoolToVisibility}}">
+                <Label Content="Wave size:" Height="26" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
+                <local:NumberInput Value="{Binding Options.VisualizerOptions.WaveSize, UpdateSourceTrigger=PropertyChanged}"
+                                   Minimum="1" Step="32" Width="38" Height="24"/>
             </StackPanel>
             <!--
             <StackPanel Orientation="Horizontal">
@@ -125,7 +131,7 @@
                         <Style TargetType="RowDefinition">
                             <Setter Property="Height" Value="*" />
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding Options.VisualizerOptions.ShowWavemapField}" Value="False">
+                                <DataTrigger Binding="{Binding Options.VisualizerOptions.ShowWavemap}" Value="False">
                                     <Setter Property="Height" Value="0" />
                                 </DataTrigger>
                             </Style.Triggers>

--- a/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
@@ -162,7 +162,7 @@
                     <ColumnDefinition Width="85"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
-                <wavemap:WavemapOffsetInput WaveInfo="{Binding CurrentWaveInfo, UpdateSourceTrigger=PropertyChanged}"
+                <wavemap:WavemapOffsetInput
                                                HorizontalAlignment="Stretch" VerticalAlignment="Center" x:Name="WavemapSelector"
                                                Height="84" Grid.Column="0" Grid.Row="0" Margin="5,5,5,5"/>
                 <Border Grid.Column="1" Grid.Row="0" HorizontalAlignment="Stretch" BorderBrush="{x:Null}" Margin="4">

--- a/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
@@ -67,12 +67,12 @@
             </StackPanel>
             <StackPanel Orientation="Horizontal">
                 <Label Content="Group size:" Height="26" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
-                <local:NumberInput Value="{Binding Options.DebuggerOptions.GroupSize, UpdateSourceTrigger=PropertyChanged}"
+                <local:NumberInput IsEnabled="{Binding GroupIndexEditable}" Value="{Binding Options.DebuggerOptions.GroupSize, UpdateSourceTrigger=PropertyChanged}"
                                    Minimum="1" Step="64" Width="38" Height="24"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Visibility="{Binding Options.VisualizerOptions.ShowWaveSizeField, Converter={StaticResource BoolToVisibility}}">
                 <Label Content="Wave size:" Height="26" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
-                <local:NumberInput Value="{Binding Options.VisualizerOptions.WaveSize, UpdateSourceTrigger=PropertyChanged}"
+                <local:NumberInput IsEnabled="{Binding GroupIndexEditable}" Value="{Binding Options.VisualizerOptions.WaveSize, UpdateSourceTrigger=PropertyChanged}"
                                    Minimum="1" Step="32" Width="38" Height="24"/>
             </StackPanel>
             <!--

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
-using System.Windows.Media;
 using VSRAD.Package.Options;
 using VSRAD.Package.Utils;
 
@@ -17,7 +16,7 @@ namespace VSRAD.Package.DebugVisualizer
         public delegate uint GetGroupSize();
         public delegate ReadOnlyCollection<string> GetValidWatches();
 
-        private GetValidWatches _getValidWatches;
+        private readonly GetValidWatches _getValidWatches;
 
         public event ChangeWatchState WatchStateChanged;
 
@@ -95,6 +94,14 @@ namespace VSRAD.Package.DebugVisualizer
 
             _mouseMoveController = new MouseMove.MouseMoveController(this, _state);
             _selectionController = new SelectionController(this);
+        }
+
+        public void GoToWave(uint waveIdx, uint waveSize)
+        {
+            var firstCol = waveIdx * waveSize;
+            var lastCol = (waveIdx + 1) * waveSize - 1;
+            if (!_selectionController.SelectAllColumnsInRange((int)firstCol + DataColumnOffset, (int)lastCol + DataColumnOffset))
+                Errors.ShowWarning($"All columns of the target wave ({firstCol}-{lastCol}) are hidden.");
         }
 
         public void SetScalingMode(ScalingMode mode) => _state.ScalingMode = mode;

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapImage.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapImage.cs
@@ -149,14 +149,7 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
         private void ShowWaveInfo(object sender, System.Windows.Input.MouseEventArgs e)
         {
             if (GetWaveAtMousePos(e.GetPosition(_img)) is WaveInfo wave && wave.IsVisible)
-            {
-                //_context.CurrentWaveInfo = $"G: {wave.GroupIdx}\nW: {wave.WaveIdx}\nL: {wave.BreakLine}";
-                _context.CurrentWaveGroupIndex = (int)wave.GroupIdx;
-                _context.CurrentWaveIndex = (int)wave.WaveIdx;
-                _context.CurrentWaveBreakLine = (int)wave.BreakLine;
-                _context.CurrentWavePartialMask = wave.PartialMask;
-                _context.CurrentWaveBreakNotRiched = wave.BreakNotRiched;
-            }
+                _context.CurrentWaveInfo = wave;
         }
 
         private void ShowWaveMenu(object sender, System.Windows.Input.MouseButtonEventArgs e)

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapImage.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapImage.cs
@@ -149,7 +149,14 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
         private void ShowWaveInfo(object sender, System.Windows.Input.MouseEventArgs e)
         {
             if (GetWaveAtMousePos(e.GetPosition(_img)) is WaveInfo wave && wave.IsVisible)
-                _context.CurrentWaveInfo = $"G: {wave.GroupIdx}\nW: {wave.WaveIdx}\nL: {wave.BreakLine}";
+            {
+                //_context.CurrentWaveInfo = $"G: {wave.GroupIdx}\nW: {wave.WaveIdx}\nL: {wave.BreakLine}";
+                _context.CurrentWaveGroupIndex = (int)wave.GroupIdx;
+                _context.CurrentWaveIndex = (int)wave.WaveIdx;
+                _context.CurrentWaveBreakLine = (int)wave.BreakLine;
+                _context.CurrentWavePartialMask = wave.PartialMask;
+                _context.CurrentWaveBreakNotRiched = wave.BreakNotRiched;
+            }
         }
 
         private void ShowWaveMenu(object sender, System.Windows.Input.MouseButtonEventArgs e)

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapImage.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapImage.cs
@@ -93,27 +93,6 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
             }
         }
 
-        private int _xOffset = 0;
-        public int XOffset
-        {
-            get => _xOffset;
-            set
-            {
-                _xOffset = value;
-                SetData(_view);
-            }
-        }
-
-        private int _yOffset = 0;
-        public int YOffset
-        {
-            get => _yOffset;
-            set
-            {
-                _yOffset = value;
-                SetData(_view);
-            }
-        }
 
 
         private int _gridSizeX;

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapImage.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapImage.cs
@@ -186,7 +186,8 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
 
         public void SetData(WavemapView view)
         {
-            if (view == null || view.WavesPerGroup == 0)
+            var imageContainer = (FrameworkElement)_img.Parent;
+            if (view == null || view.WavesPerGroup == 0 || imageContainer.ActualHeight == 0)
             {
                 _img.Source = null;
                 return;
@@ -196,7 +197,7 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
             view.CheckLanes = _context.Options.VisualizerOptions.MaskLanes;
             view.CheckMagicNumber = _context.Options.VisualizerOptions.CheckMagicNumber;
 
-            GridSizeX = (int)((FrameworkElement)_img.Parent).ActualWidth / _rSize;
+            GridSizeX = (int)imageContainer.ActualWidth / _rSize;
             GridSizeY = view.WavesPerGroup;
 
             _view = view;

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapImage.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapImage.cs
@@ -148,14 +148,23 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
             }
         }
 
-
         public WavemapImage(Image image, VisualizerContext context)
         {
             _img = image;
             _context = context;
             _rSize = _context.Options.VisualizerOptions.WavemapElementSize;
 
+            _context.Options.VisualizerOptions.PropertyChanged += UpdateWavemapImage;
+
             ((FrameworkElement)_img.Parent).SizeChanged += RecomputeGridSize;
+        }
+
+        private void UpdateWavemapImage(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(Options.VisualizerOptions.MaskLanes) ||
+                e.PropertyName == nameof(Options.VisualizerOptions.CheckMagicNumber) ||
+                e.PropertyName == nameof(Options.VisualizerOptions.MagicNumber))
+                SetData(_view);
         }
 
         private void RecomputeGridSize(object sender, SizeChangedEventArgs e)
@@ -182,6 +191,10 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
                 _img.Source = null;
                 return;
             }
+
+            view.MagicNumber = (uint)_context.Options.VisualizerOptions.MagicNumber;
+            view.CheckLanes = _context.Options.VisualizerOptions.MaskLanes;
+            view.CheckMagicNumber = _context.Options.VisualizerOptions.CheckMagicNumber;
 
             GridSizeX = (int)((FrameworkElement)_img.Parent).ActualWidth / _rSize;
             GridSizeY = view.WavesPerGroup;

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml
@@ -36,7 +36,7 @@
                     </TextBlock>
                 </RepeatButton>
             </StackPanel>
-            <TextBlock Text="{Binding RawValue}" VerticalAlignment="Center" Margin="0,6,0,0" Height="24" Grid.Row="0"
+            <TextBlock Text="{Binding OffsetLabel}" VerticalAlignment="Center" Margin="0,6,0,0" Height="24" Grid.Row="0"
                    Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
         </DockPanel>
         <TextBlock Grid.Row="1" VerticalAlignment="Top" HorizontalAlignment="Left" Text="{Binding WaveInfo}"

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml
@@ -39,7 +39,7 @@
             <TextBlock Text="{Binding OffsetLabel}" VerticalAlignment="Center" Margin="0,6,0,0" Height="24" Grid.Row="0"
                    Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
         </DockPanel>
-        <TextBlock Grid.Row="1" VerticalAlignment="Top" HorizontalAlignment="Left" Text="{Binding WaveInfo}"
+        <TextBlock Grid.Row="1" VerticalAlignment="Top" HorizontalAlignment="Left" x:Name="WaveInfoTextBlock"
                    ToolTip="G: Group index under cursor&#x0a;W: Wave index under cursor&#x0a;L: Break line of wave under cursor"
                    Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
     </Grid>

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml.cs
@@ -7,16 +7,6 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
 {
     public sealed partial class WavemapOffsetInput : UserControl, INotifyPropertyChanged
     {
-        public static readonly DependencyProperty WaveInfoProperty =
-            DependencyProperty.Register(nameof(WaveInfo), typeof(string), typeof(WavemapOffsetInput),
-                new FrameworkPropertyMetadata("", FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
-
-        public string WaveInfo
-        {
-            get => (string)GetValue(WaveInfoProperty);
-            set => SetValue(WaveInfoProperty, value);
-        }
-
         private VisualizerContext _context;
         private WavemapImage _image;
 
@@ -65,13 +55,21 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
                 e.PropertyName == nameof(VisualizerContext.CurrentWaveBreakNotRiched))
             {
                 var waveInfo = $"G: {_context.CurrentWaveGroupIndex}\nW: {_context.CurrentWaveIndex}";
-                if (_context.CurrentWavePartialMask) waveInfo += " (E)";
+                if (_context.CurrentWavePartialMask && !_context.CurrentWaveBreakNotRiched) waveInfo += " (E)";
                 waveInfo += "\n";
                 waveInfo += _context.CurrentWaveBreakNotRiched
                     ? "no brk"
-                    : $"{_context.CurrentWaveBreakLine}";
+                    : $"L: {_context.CurrentWaveBreakLine}";
 
-                WaveInfo = waveInfo;
+                var tooltip = $"Group: {_context.CurrentWaveGroupIndex}\nWave: {_context.CurrentWaveIndex}";
+                if (_context.CurrentWavePartialMask && !_context.CurrentWaveBreakNotRiched) tooltip += " (partial mask)";
+                tooltip += "\n";
+                tooltip += _context.CurrentWaveBreakNotRiched
+                    ? "Brk point not reached"
+                    : $"Line: {_context.CurrentWaveBreakLine}";
+
+                WaveInfoTextBlock.Text = waveInfo;
+                WaveInfoTextBlock.ToolTip = tooltip;
             }
         }
 

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml.cs
@@ -63,7 +63,16 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
                 e.PropertyName == nameof(VisualizerContext.CurrentWaveIndex) ||
                 e.PropertyName == nameof(VisualizerContext.CurrentWavePartialMask) ||
                 e.PropertyName == nameof(VisualizerContext.CurrentWaveBreakNotRiched))
-                WaveInfo = $"G: {_context.CurrentWaveGroupIndex}\nW: {_context.CurrentWaveIndex}\nL: {_context.CurrentWaveBreakLine}";
+            {
+                var waveInfo = $"G: {_context.CurrentWaveGroupIndex}\nW: {_context.CurrentWaveIndex}";
+                if (_context.CurrentWavePartialMask) waveInfo += " (E)";
+                waveInfo += "\n";
+                waveInfo += _context.CurrentWaveBreakNotRiched
+                    ? "no brk"
+                    : $"{_context.CurrentWaveBreakLine}";
+
+                WaveInfo = waveInfo;
+            }
         }
 
         private void UpdateControls(object sender, EventArgs e)

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml.cs
@@ -72,7 +72,8 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
 
         private void UpdateControls(object sender, EventArgs e)
         {
-            var groupCount = _context.BreakData?.GetGroupCount((int)_context.Options.DebuggerOptions.GroupSize, (int)_context.Options.DebuggerOptions.NGroups) ?? 0;
+            var groupCount = _context.BreakData?.GetGroupCount((int)_context.Options.DebuggerOptions.GroupSize,
+                (int)_context.Options.VisualizerOptions.WaveSize, (int)_context.Options.DebuggerOptions.NGroups) ?? 0;
             if (groupCount > 0 && _image.GridSizeX > 0)
             {
                 DecButton.IsEnabled = _image.FirstGroup != 0;

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml.cs
@@ -48,27 +48,24 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
 
         private void UpdateTooltipAndWaveInfo(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(VisualizerContext.CurrentWaveBreakLine) ||
-                e.PropertyName == nameof(VisualizerContext.CurrentWaveGroupIndex) ||
-                e.PropertyName == nameof(VisualizerContext.CurrentWaveIndex) ||
-                e.PropertyName == nameof(VisualizerContext.CurrentWavePartialMask) ||
-                e.PropertyName == nameof(VisualizerContext.CurrentWaveBreakNotRiched))
+            if (e.PropertyName == nameof(VisualizerContext.CurrentWaveInfo))
             {
-                var waveInfo = $"G: {_context.CurrentWaveGroupIndex}\nW: {_context.CurrentWaveIndex}";
-                if (_context.CurrentWavePartialMask && !_context.CurrentWaveBreakNotRiched) waveInfo += " (E)";
-                waveInfo += "\n";
-                waveInfo += _context.CurrentWaveBreakNotRiched
+                var waveInfo = _context.CurrentWaveInfo;
+                var waveInfoText = $"G: {waveInfo.GroupIdx}\nW: {waveInfo.WaveIdx}";
+                if (waveInfo.PartialMask && !waveInfo.BreakNotReached) waveInfoText += " (E)";
+                waveInfoText += "\n";
+                waveInfoText += waveInfo.BreakNotReached
                     ? "no brk"
-                    : $"L: {_context.CurrentWaveBreakLine}";
+                    : $"L: {waveInfo.BreakLine}";
 
-                var tooltip = $"Group: {_context.CurrentWaveGroupIndex}\nWave: {_context.CurrentWaveIndex}";
-                if (_context.CurrentWavePartialMask && !_context.CurrentWaveBreakNotRiched) tooltip += " (partial mask)";
+                var tooltip = $"Group: {waveInfo.GroupIdx}\nWave: {waveInfo.WaveIdx}";
+                if (waveInfo.PartialMask && !waveInfo.BreakNotReached) tooltip += " (partial mask)";
                 tooltip += "\n";
-                tooltip += _context.CurrentWaveBreakNotRiched
+                tooltip += waveInfo.BreakNotReached
                     ? "Brk point not reached"
-                    : $"Line: {_context.CurrentWaveBreakLine}";
+                    : $"Line: {waveInfo.BreakLine}";
 
-                WaveInfoTextBlock.Text = waveInfo;
+                WaveInfoTextBlock.Text = waveInfoText;
                 WaveInfoTextBlock.ToolTip = tooltip;
             }
         }

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml.cs
@@ -51,8 +51,19 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
         public void Setup(VisualizerContext context, WavemapImage image)
         {
             _context = context;
+            _context.PropertyChanged += UpdateTooltipAndWaveInfo;
             _image = image;
             _image.Updated += UpdateControls;
+        }
+
+        private void UpdateTooltipAndWaveInfo(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(VisualizerContext.CurrentWaveBreakLine) ||
+                e.PropertyName == nameof(VisualizerContext.CurrentWaveGroupIndex) ||
+                e.PropertyName == nameof(VisualizerContext.CurrentWaveIndex) ||
+                e.PropertyName == nameof(VisualizerContext.CurrentWavePartialMask) ||
+                e.PropertyName == nameof(VisualizerContext.CurrentWaveBreakNotRiched))
+                WaveInfo = $"G: {_context.CurrentWaveGroupIndex}\nW: {_context.CurrentWaveIndex}\nL: {_context.CurrentWaveBreakLine}";
         }
 
         private void UpdateControls(object sender, EventArgs e)

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapOffsetInput.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -50,13 +51,11 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
         public void Setup(VisualizerContext context, WavemapImage image)
         {
             _context = context;
-            _context.GroupFetched += (s, e) => UpdateControls();
-
             _image = image;
-            _image.PropertyChanged += (s, e) => UpdateControls();
+            _image.Updated += UpdateControls;
         }
 
-        private void UpdateControls()
+        private void UpdateControls(object sender, EventArgs e)
         {
             var groupCount = _context.BreakData?.GetGroupCount((int)_context.Options.DebuggerOptions.GroupSize, (int)_context.Options.DebuggerOptions.NGroups) ?? 0;
             if (groupCount > 0 && _image.GridSizeX > 0)

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -13,7 +13,7 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
         public uint WaveIdx;
         public bool IsVisible;
         public bool PartialMask;
-        public bool BreakNotRiched;
+        public bool BreakNotReached;
     }
 #pragma warning restore CA1815
 
@@ -115,7 +115,7 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
                     WaveIdx = 0,
                     IsVisible = false,
                     PartialMask = false,
-                    BreakNotRiched = false
+                    BreakNotReached = false
                 };
 
 
@@ -130,7 +130,7 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
                 WaveIdx = (uint)row,
                 IsVisible = true,
                 PartialMask = CheckLanes && HasInactiveLanes(flatIndex),
-                BreakNotRiched = CheckMagicNumber && !MagicNumberSet(flatIndex)
+                BreakNotReached = CheckMagicNumber && !MagicNumberSet(flatIndex)
             };
         }
 

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -9,8 +9,8 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
     {
         public Color BreakColor;
         public uint BreakLine;
-        public int GroupIdx;
-        public int WaveIdx;
+        public uint GroupIdx;
+        public uint WaveIdx;
         public bool IsVisible;
     }
 #pragma warning restore CA1815
@@ -122,8 +122,8 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
             {
                 BreakColor = GetBreakColor(flatIndex, breakLine),
                 BreakLine = breakLine,
-                GroupIdx = column,
-                WaveIdx = row,
+                GroupIdx = (uint)column,
+                WaveIdx = (uint)row,
                 IsVisible = true
             };
         }

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -75,25 +75,23 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
 
         private uint GetBreakpointLine(int waveIndex)
         {
-            var breakIndex = waveIndex * _waveSize * _laneDataSize + _laneDataSize; // break line is in the first lane of system watch
+            var breakIndex = waveIndex * _waveSize * _laneDataSize + _laneDataSize; // break line is in the lane #1 of system watch
             return _data[breakIndex];
         }
 
         private bool IsValidWave(int row, int column) =>
             GetWaveFlatIndex(row, column) * _waveSize * _laneDataSize + _laneDataSize < _data.Length && row < WavesPerGroup;
 
-        private bool HasIncativeLanes(int flatWaveIndex)
+        private bool HasInactiveLanes(int flatWaveIndex)
         {
-            var execMaskOffset = flatWaveIndex * _waveSize * _laneDataSize + (_laneDataSize * 8); // exec mask is in lanes #8 and #9 of system watch
-
+            var execMaskOffset = flatWaveIndex * _waveSize * _laneDataSize + (_laneDataSize * 8); // exec mask is in the lanes #8 and #9 of system watch
             return _data[execMaskOffset] != 0xfffffff && _data[execMaskOffset + _laneDataSize] != 0xffffffff;
         }
 
         private bool MagicNumberSet(int flatWaveIndex)
         {
-            var execMaskOffset = flatWaveIndex * _waveSize * _laneDataSize; // exec mask is in lane #0 of system watch
-
-            return _data[execMaskOffset] == MagicNumber;
+            var magicNumberOffset = flatWaveIndex * _waveSize * _laneDataSize; // magic number is in the lane #0 of system watch
+            return _data[magicNumberOffset] == MagicNumber;
         }
 
         private int GetWaveFlatIndex(int row, int column) => column * WavesPerGroup + row;
@@ -101,7 +99,7 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
         private Color GetBreakColor(int flatWaveIndex, uint breakLine)
         {
             if (CheckMagicNumber && !MagicNumberSet(flatWaveIndex)) return Color.Gray;
-            if (CheckLanes && HasIncativeLanes(flatWaveIndex)) return Color.LightGray;
+            if (CheckLanes && HasInactiveLanes(flatWaveIndex)) return Color.LightGray;
             return _colorManager.GetColorForBreakpoint(breakLine);
         }
 

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -68,7 +68,7 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
             _data = data;
             _waveSize = waveSize;
             _laneDataSize = laneDataSize;
-            WavesPerGroup = groupSize / waveSize;
+            WavesPerGroup = (groupSize + waveSize - 1) / waveSize;
             GroupCount = groupCount;
             _colorManager = new BreakpointColorManager();
         }
@@ -79,8 +79,7 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
             return _data[breakIndex];
         }
 
-        private bool IsValidWave(int row, int column) =>
-            GetWaveFlatIndex(row, column) * _waveSize * _laneDataSize + _laneDataSize < _data.Length && row < WavesPerGroup;
+        private bool IsValidWave(int row, int column) => row < WavesPerGroup && column < GroupCount;
 
         private bool HasInactiveLanes(int flatWaveIndex)
         {

--- a/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
+++ b/VSRAD.Package/DebugVisualizer/Wavemap/WavemapView.cs
@@ -12,6 +12,8 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
         public uint GroupIdx;
         public uint WaveIdx;
         public bool IsVisible;
+        public bool PartialMask;
+        public bool BreakNotRiched;
     }
 #pragma warning restore CA1815
 
@@ -111,7 +113,9 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
                     BreakLine = 0,
                     GroupIdx = 0,
                     WaveIdx = 0,
-                    IsVisible = false
+                    IsVisible = false,
+                    PartialMask = false,
+                    BreakNotRiched = false
                 };
 
 
@@ -124,7 +128,9 @@ namespace VSRAD.Package.DebugVisualizer.Wavemap
                 BreakLine = breakLine,
                 GroupIdx = (uint)column,
                 WaveIdx = (uint)row,
-                IsVisible = true
+                IsVisible = true,
+                PartialMask = CheckLanes && HasInactiveLanes(flatIndex),
+                BreakNotRiched = CheckMagicNumber && !MagicNumberSet(flatIndex)
             };
         }
 

--- a/VSRAD.Package/Options/VisualizerOptions.cs
+++ b/VSRAD.Package/Options/VisualizerOptions.cs
@@ -50,9 +50,13 @@ namespace VSRAD.Package.Options
         [DefaultValue(true)]
         public bool ShowBreakArgsField { get => _showBreakArgsField; set => SetField(ref _showBreakArgsField, value); }
 
-        private bool _showWavemapField;
+        private bool _showWaveSizeField;
+        [DefaultValue(false)]
+        public bool ShowWaveSizeField { get => _showWaveSizeField; set => SetField(ref _showWaveSizeField, value); }
+
+        private bool _showWavemap;
         [DefaultValue(true)]
-        public bool ShowWavemapField { get => _showWavemapField; set => SetField(ref _showWavemapField, value); }
+        public bool ShowWavemap { get => _showWavemap; set => SetField(ref _showWavemap, value); }
     }
 
     public sealed class MagicNumberConverter : JsonConverter

--- a/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
@@ -135,16 +135,13 @@
                                 <RowDefinition Height="26"/>
                             </Grid.RowDefinitions>
                             <Label Content="Direction:" VerticalContentAlignment="Center" Padding="4,0" Height="22" Grid.Row="0" Grid.Column="0"/>
-                            <ComboBox ItemsSource="{Binding Source={StaticResource FileCopyDirections}}" SelectedItem="{Binding Direction, Mode=TwoWay}"
-                                      Height="22" Width="160" HorizontalAlignment="Left" Grid.Row="0" Grid.Column="1"
-                                      Visibility="{Binding DataContext.CurrentProfile.General.RunActionsLocally, ElementName=Root, Converter={StaticResource VisibleWhenFalseConverter}}"/>
-                            <Border Grid.Row="0" Grid.Column="1" BorderBrush="{x:Null}" Height="22"
-                                    Visibility="{Binding DataContext.CurrentProfile.General.RunActionsLocally, ElementName=Root, Converter={StaticResource VisibleWhenTrueConverter}}">
-                                <TextBlock VerticalAlignment="Center" ToolTip="Overridden by General -> Run on Localhost">
-                                    <Run>LocalToLocal </Run>
-                                    <Run Text="{Binding Direction, StringFormat='({0})'}" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarTextInactiveKey}}"/>
-                                </TextBlock>
-                            </Border>
+                            <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Height="22">
+                                <ComboBox ItemsSource="{Binding Source={StaticResource FileCopyDirections}}" SelectedItem="{Binding Direction, Mode=TwoWay}"
+                                          Height="22" Width="160" HorizontalAlignment="Left"/>
+                                <TextBlock Margin="4,0" VerticalAlignment="Center" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarTextInactiveKey}}"
+                                           Visibility="{Binding DataContext.CurrentProfile.General.RunActionsLocally, ElementName=Root, Converter={StaticResource VisibleWhenTrueConverter}}"
+                                           Text="Forced to LocalToLocal" ToolTip="Overridden by General -> Run on Localhost"/>
+                            </StackPanel>
 
                             <Label Content="Source Path:" VerticalContentAlignment="Center" Padding="4,0" Height="22" Grid.Row="1" Grid.Column="0"/>
                             <TextBox Text="{Binding SourcePath, UpdateSourceTrigger=PropertyChanged}" VerticalContentAlignment="Center" Height="22" Grid.Row="1" Grid.Column="1"
@@ -192,16 +189,13 @@
                                 <RowDefinition Height="26"/>
                             </Grid.RowDefinitions>
                             <Label Content="Environment:" VerticalContentAlignment="Center" Padding="4,0" Height="22" Grid.Row="0" Grid.Column="0"/>
-                            <ComboBox ItemsSource="{Binding Source={StaticResource StepEnvironments}}" SelectedItem="{Binding Environment, Mode=TwoWay}"
-                                      Height="22" Width="160" HorizontalAlignment="Left" Grid.Row="0" Grid.Column="1"
-                                      Visibility="{Binding DataContext.CurrentProfile.General.RunActionsLocally, ElementName=Root, Converter={StaticResource VisibleWhenFalseConverter}}"/>
-                            <Border Grid.Row="0" Grid.Column="1" BorderBrush="{x:Null}" Height="22"
-                                    Visibility="{Binding DataContext.CurrentProfile.General.RunActionsLocally, ElementName=Root, Converter={StaticResource VisibleWhenTrueConverter}}">
-                                <TextBlock VerticalAlignment="Center" ToolTip="Overridden by General -> Run on Localhost">
-                                    <Run>Local </Run>
-                                    <Run Text="{Binding Environment, StringFormat='({0})'}" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarTextInactiveKey}}"/>
-                                </TextBlock>
-                            </Border>
+                            <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Height="22">
+                                <ComboBox ItemsSource="{Binding Source={StaticResource StepEnvironments}}" SelectedItem="{Binding Environment, Mode=TwoWay}"
+                                          Height="22" Width="160" HorizontalAlignment="Left"/>
+                                <TextBlock Margin="4,0" VerticalAlignment="Center" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarTextInactiveKey}}"
+                                           Visibility="{Binding DataContext.CurrentProfile.General.RunActionsLocally, ElementName=Root, Converter={StaticResource VisibleWhenTrueConverter}}"
+                                           Text="Forced to Local" ToolTip="Overridden by General -> Run on Localhost"/>
+                            </StackPanel>
 
                             <Label Content="Executable:" VerticalContentAlignment="Center" Padding="4,0" Height="22" Grid.Row="1" Grid.Column="0"/>
                             <TextBox Text="{Binding Executable, UpdateSourceTrigger=PropertyChanged}" VerticalContentAlignment="Center" Height="22" Grid.Row="1" Grid.Column="1" />

--- a/VSRAD.Package/ProjectSystem/Profiles/BuiltinActionFileEditor.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/BuiltinActionFileEditor.xaml
@@ -39,16 +39,13 @@
         </Grid.RowDefinitions>
         <Label Content="{Binding Header, ElementName=Root}" ContentStringFormat="{}{0} File Location"
                VerticalContentAlignment="Center" Padding="4,0" Height="22" Grid.Row="0" Grid.Column="0"/>
-        <ComboBox ItemsSource="{Binding Source={StaticResource LocationTypes}}" SelectedItem="{Binding Location, Mode=TwoWay}"
-                  Height="22" Width="160" HorizontalAlignment="Left" Grid.Row="0" Grid.Column="1"
-                  Visibility="{Binding CurrentProfile.General.RunActionsLocally, ElementName=Root, Converter={StaticResource VisibleWhenFalseConverter}}"/>
-        <Border Grid.Row="0" Grid.Column="1" BorderBrush="{x:Null}" Height="22"
-                Visibility="{Binding CurrentProfile.General.RunActionsLocally, ElementName=Root, Converter={StaticResource VisibleWhenTrueConverter}}">
-            <TextBlock VerticalAlignment="Center" ToolTip="Overridden by General -> Run on Localhost">
-                <Run>Local </Run>
-                <Run Text="{Binding Location, StringFormat='({0})'}" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarTextInactiveKey}}"/>
-            </TextBlock>
-        </Border>
+        <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Height="22">
+            <ComboBox ItemsSource="{Binding Source={StaticResource LocationTypes}}" SelectedItem="{Binding Location, Mode=TwoWay}"
+                      Height="22" Width="160" HorizontalAlignment="Left"/>
+            <TextBlock Margin="4,0" VerticalAlignment="Center" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarTextInactiveKey}}"
+                       Visibility="{Binding CurrentProfile.General.RunActionsLocally, ElementName=Root, Converter={StaticResource VisibleWhenTrueConverter}}"
+                       Text="Forced to Local" ToolTip="Overridden by General -> Run on Localhost"/>
+        </StackPanel>
 
         <Label Content="{Binding Header, ElementName=Root}" ContentStringFormat="{}{0} File Path"
                VerticalContentAlignment="Center" Padding="4,0" Height="22" Grid.Row="1" Grid.Column="0"/>

--- a/VSRAD.Package/Utils/MagicNumberConverter.cs
+++ b/VSRAD.Package/Utils/MagicNumberConverter.cs
@@ -13,14 +13,14 @@ namespace VSRAD.Package.Utils
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var magicNumber = value.ToString();
-            if (magicNumber.StartsWith("0x", StringComparison.Ordinal) && int.TryParse(
-                magicNumber.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int converted))
+            if (magicNumber.StartsWith("0x", StringComparison.Ordinal) && uint.TryParse(
+                magicNumber.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint converted))
             {
                 _enteredDecimal = false;
                 _enteredLeadingZero = false;
                 return converted;
             }
-            if (int.TryParse(magicNumber, out converted))
+            if (uint.TryParse(magicNumber, out converted))
             {
                 _enteredLeadingZero = magicNumber.StartsWith("0", StringComparison.Ordinal);
                 _enteredDecimal = true;
@@ -31,14 +31,14 @@ namespace VSRAD.Package.Utils
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is int magicNumber)
+            if (value is uint magicNumber)
             {
                 if (_enteredDecimal)
                     return magicNumber.ToString();
                 else if (_enteredLeadingZero)
-                    return $"0{magicNumber.ToString()}";
+                    return $"0{magicNumber}";
                 else
-                    return $"0x{magicNumber.ToString("x")}";
+                    return $"0x{magicNumber:x}";
             }
             return "";
         }

--- a/VSRAD.Package/VSRAD.Package.tt
+++ b/VSRAD.Package/VSRAD.Package.tt
@@ -240,11 +240,11 @@
     <Combos>
        <Combo guid="guidCmdSetProfileDropdown" id="ProfileTargetMachineDropdownId" priority="100" type="DynamicCombo" defaultWidth="120" idCommandList="ProfileTargetMachineDropdownListId">
         <Parent guid="guidCmdSetToolsMenu" id="ToolsMenuGroup" />
-        <CommandFlag>IconAndText</CommandFlag>
         <CommandFlag>CommandWellOnly</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
+          <ButtonText>Target Host</ButtonText>
           <ToolTipText>Enter the remote machine address and port (e.g. 127.0.0.1:9339)</ToolTipText>
         </Strings>
       </Combo>

--- a/VSRAD.PackageTests/ProjectSystem/Profiles/LegacyProfileImporterTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Profiles/LegacyProfileImporterTests.cs
@@ -25,7 +25,7 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
                 w3 => Assert.Equal(new Watch("v2", VariableType.Float, false), w3));
 
             Assert.Equal(15u, imported.DebuggerOptions.Counter);
-            Assert.Equal(6, imported.VisualizerOptions.MagicNumber);
+            Assert.Equal(6u, imported.VisualizerOptions.MagicNumber);
             Assert.Equal("0-1023", imported.VisualizerColumnStyling.VisibleColumns);
             Assert.Equal("h", imported.ActiveProfile);
         }

--- a/VSRAD.PackageTests/Server/ActionRunnerTests.cs
+++ b/VSRAD.PackageTests/Server/ActionRunnerTests.cs
@@ -480,6 +480,7 @@ wave size 64");
             Assert.Equal<uint>(64, result.BreakState.DispatchParameters.GroupSize);
             Assert.Equal<uint>(64, result.BreakState.DispatchParameters.WaveSize);
 
+            await result.BreakState.Data.ChangeGroupWithWarningsAsync(null, groupIndex: 0, groupSize: 64, waveSize: 64, nGroups: 0);
             var secondWatch = result.BreakState.Data.GetWatch("julianne");
             for (int i = 0; i < 64; ++i)
                 Assert.Equal(i, (int)secondWatch[i]);
@@ -556,6 +557,8 @@ wave size 64");
             var result = await runner.RunAsync("Debug", steps);
 
             Assert.True(result.Successful);
+
+            await result.BreakState.Data.ChangeGroupWithWarningsAsync(null, groupIndex: 0, groupSize: 4, waveSize: 4, nGroups: 0);
             var system = result.BreakState.Data.GetSystem();
             Assert.Equal(0x6173616b, (int)system[0]);
             Assert.Equal(0x69646f72, (int)system[1]);

--- a/VSRAD.Syntax/Package.vsct
+++ b/VSRAD.Syntax/Package.vsct
@@ -73,9 +73,9 @@
       <Combo guid="guidInstructionSetSelectorCmdSet" id="cmdidInstructionSetDropDownCombo" priority="0x001" type="DropDownCombo" defaultWidth="55" idCommandList="cmdidInstructionSetDropDownComboGetList">
         <Parent guid="guidInstructionSetSelectorCmdSet" id="instructionSetSelectorGroup"/>
         <Strings>
-          <MenuText>Instruction set: </MenuText>
-          <ButtonText></ButtonText>
-          <ToolTipText>Instruction set</ToolTipText>
+          <MenuText>Instruction Set: </MenuText>
+          <ButtonText>Instruction Set</ButtonText>
+          <ToolTipText>Instruction Set</ToolTipText>
           <CanonicalName>InstructionSetCombo</CanonicalName>
           <LocCanonicalName>InstructionSetCombo</LocCanonicalName>
           <CommandName>InstructionSetCombo</CommandName>
@@ -85,9 +85,9 @@
       <Combo guid="guidInstructionSetSelectorCmdSet" id="cmdidInstructionSetDropDownCombo" priority="0x1000" type="DropDownCombo" defaultWidth="55" idCommandList="cmdidInstructionSetDropDownComboGetList">
         <Parent guid="guidCmdSetToolsMenu" id="ToolsMenuGroup"/>
         <Strings>
-          <MenuText>Instruction set: </MenuText>
-          <ButtonText></ButtonText>
-          <ToolTipText>Instruction set</ToolTipText>
+          <MenuText>Instruction Set: </MenuText>
+          <ButtonText>Instruction Set</ButtonText>
+          <ToolTipText>Instruction Set</ToolTipText>
           <CanonicalName>InstructionSetCombo</CanonicalName>
           <LocCanonicalName>InstructionSetCombo</LocCanonicalName>
           <CommandName>InstructionSetCombo</CommandName>


### PR DESCRIPTION
* Waves with inactive lanes or non-matching magic number are grayed out in wavemap
* Wave size can be manually set in visualizer
* Visualizer context menu: _Hide This_ is disabled when displaying the menu for the _Name_ column, _Show All Columns_ is always enabled
* All items in the _RAD Debug_ toolbar have labels
* Setting group size to a value that's not divisible by wave size no longer causes a crash