### PR TITLE
Add target hosts editor

### DIFF
--- a/VSRAD.Package/Commands/ProfileDropdownCommand.cs
+++ b/VSRAD.Package/Commands/ProfileDropdownCommand.cs
@@ -65,17 +65,17 @@ namespace VSRAD.Package.Commands
 
         private void ListTargetMachines(IntPtr variantOut)
         {
-            if (_project.Options.RecentlyUsedHosts.Count == 0)
+            if (_project.Options.TargetHosts.Count == 0)
             {
                 foreach (var profile in _project.Options.Profiles)
-                    _project.Options.RecentlyUsedHosts.Add(profile.Value.General.Connection.ToString());
+                    _project.Options.TargetHosts.Add(profile.Value.General.Connection.ToString());
             }
 
             // Add the current host to the list in case the user switches to a different profile
             // (if the profile is not changed this is a no-op because the current host is already at the top of the list)
-            _project.Options.RecentlyUsedHosts.Add(_project.Options.Profile.General.Connection.ToString());
+            _project.Options.TargetHosts.Add(_project.Options.Profile.General.Connection.ToString());
 
-            var displayItems = _project.Options.RecentlyUsedHosts.Prepend("Local").Append("Edit...").ToArray();
+            var displayItems = _project.Options.TargetHosts.Prepend("Local").Append("Edit...").ToArray();
             Marshal.GetNativeVariantForObject(displayItems, variantOut);
         }
 
@@ -98,7 +98,7 @@ namespace VSRAD.Package.Commands
                 if (!RecentlyUsedHostsEditor.TryParseHost(selected, out var formattedHost, out var hostname, out var port))
                     return;
 
-                _project.Options.RecentlyUsedHosts.Add(formattedHost);
+                _project.Options.TargetHosts.Add(formattedHost);
 
                 updatedProfile.General.RemoteMachine = hostname;
                 updatedProfile.General.Port = port;

--- a/VSRAD.Package/Commands/ProfileDropdownCommand.cs
+++ b/VSRAD.Package/Commands/ProfileDropdownCommand.cs
@@ -65,23 +65,23 @@ namespace VSRAD.Package.Commands
 
         private void ListTargetMachines(IntPtr variantOut)
         {
-            if (_project.Options.TargetHosts.Count == 0)
-            {
-                foreach (var profile in _project.Options.Profiles)
-                    _project.Options.TargetHosts.Add(profile.Value.General.Connection.ToString());
-            }
-
-            // Add the current host to the list in case the user switches to a different profile
-            // (if the profile is not changed this is a no-op because the current host is already at the top of the list)
-            _project.Options.TargetHosts.Add(_project.Options.Profile.General.Connection.ToString());
-
             var displayItems = _project.Options.TargetHosts.Prepend("Local").Append("Edit...").ToArray();
             Marshal.GetNativeVariantForObject(displayItems, variantOut);
         }
 
         private void GetCurrentTargetMachine(IntPtr variantOut)
         {
-            var currentHost = _project.Options.Profile.General.RunActionsLocally ? "Local" : _project.Options.Profile.General.Connection.ToString();
+            string currentHost;
+            if (_project.Options.Profile.General.RunActionsLocally)
+            {
+                currentHost = "Local";
+            }
+            else
+            {
+                currentHost = _project.Options.Profile.General.Connection.ToString();
+                // Display current host at the top of the list
+                _project.Options.TargetHosts.Add(currentHost);
+            }
             Marshal.GetNativeVariantForObject(currentHost, variantOut);
         }
 

--- a/VSRAD.Package/Options/ProjectOptions.cs
+++ b/VSRAD.Package/Options/ProjectOptions.cs
@@ -28,9 +28,9 @@ namespace VSRAD.Package.Options
         public DebugVisualizer.ColumnStylingOptions VisualizerColumnStyling { get; } =
             new DebugVisualizer.ColumnStylingOptions();
 
-        private MruCollection<string> _recentlyUsedHosts = new MruCollection<string>(10);
         [JsonConverter(typeof(MruCollection<string>.Converter))]
-        public MruCollection<string> RecentlyUsedHosts { get => _recentlyUsedHosts; set { if (value != null) _recentlyUsedHosts = value; } }
+        public MruCollection<string> RecentlyUsedHosts { get; } =
+            new MruCollection<string>();
 
         public ProjectOptions() { }
 

--- a/VSRAD.Package/Options/ProjectOptions.cs
+++ b/VSRAD.Package/Options/ProjectOptions.cs
@@ -29,7 +29,7 @@ namespace VSRAD.Package.Options
             new DebugVisualizer.ColumnStylingOptions();
 
         [JsonConverter(typeof(MruCollection<string>.Converter))]
-        public MruCollection<string> RecentlyUsedHosts { get; } =
+        public MruCollection<string> TargetHosts { get; } =
             new MruCollection<string>();
 
         public ProjectOptions() { }

--- a/VSRAD.Package/ProjectSystem/Profiles/RecentlyUsedHostsEditor.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/RecentlyUsedHostsEditor.xaml
@@ -1,0 +1,54 @@
+﻿<Window x:Class="VSRAD.Package.ProjectSystem.Profiles.RecentlyUsedHostsEditor"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+        Title="Target Hosts Editor" Height="450" Width="300" MinHeight="150" MinWidth="200"
+        WindowStartupLocation="CenterScreen"
+        x:Name="Root" mc:Ignorable="d"
+        Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+        Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}">
+    <Window.Resources>
+        <ResourceDictionary Source="../../ToolWindows/ControlStyle.xaml"/>
+    </Window.Resources>
+    <DockPanel Margin="4">
+        <StackPanel Margin="4" Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Bottom">
+            <Button Content="OK" Click="HandleOK" Width="61" Height="22" />
+            <Button Content="Cancel" IsCancel="True" Click="HandleCancel" Width="61" Height="22" Margin="4,0,0,0" />
+        </StackPanel>
+        <DataGrid x:Name="HostGrid" ItemsSource="{Binding Hosts, ElementName=Root}" Margin="4" GridLinesVisibility="None" Focusable="True"
+                  RowEditEnding="ValidateHostAfterEdit" PreviewKeyDown="HandleDeleteKey"
+                  AutoGenerateColumns="False" CanUserAddRows="False" CanUserReorderColumns="False" CanUserSortColumns="False" CanUserResizeRows="False" CanUserDeleteRows="False"
+                  HeadersVisibility="Column" HorizontalScrollBarVisibility="Disabled" RowHeight="24">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Host" Binding="{Binding Host, UpdateSourceTrigger=PropertyChanged}" Width="*">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="VerticalAlignment" Value="Center" />
+                            <Setter Property="Padding" Value="6,0" />
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                    <DataGridTextColumn.EditingElementStyle>
+                        <Style TargetType="{x:Type TextBox}">
+                            <Setter Property="VerticalContentAlignment" Value="Center" />
+                            <Setter Property="Padding" Value="3,0" />
+                            <Setter Property="Height" Value="22" />
+                        </Style>
+                    </DataGridTextColumn.EditingElementStyle>
+                </DataGridTextColumn>
+                <DataGridTemplateColumn Width="36" MinWidth="36" MaxWidth="36">
+                    <DataGridTemplateColumn.Header>
+                        <Button Grid.Column="1" Content="➕" ToolTip="Add host" Width="22" Height="22" HorizontalAlignment="Center" Click="AddHost" />
+                    </DataGridTemplateColumn.Header>
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Button Content="❌" ToolTip="Delete host" Width="22" Height="22" HorizontalAlignment="Center"
+                                    Command="{Binding DeleteHostCommand, ElementName=Root}" CommandParameter="{Binding}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+    </DockPanel>
+</Window>

--- a/VSRAD.Package/ProjectSystem/Profiles/RecentlyUsedHostsEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/RecentlyUsedHostsEditor.xaml.cs
@@ -44,7 +44,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
         public RecentlyUsedHostsEditor(IProject project)
         {
             _project = project;
-            Hosts = new ObservableCollection<HostItem>(project.Options.RecentlyUsedHosts.Select(h => new HostItem { Host = h }));
+            Hosts = new ObservableCollection<HostItem>(project.Options.TargetHosts.Select(h => new HostItem { Host = h }));
             DeleteHostCommand = new WpfDelegateCommand(DeleteHost);
 
             InitializeComponent();
@@ -75,8 +75,8 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 
         private void SaveChanges()
         {
-            _project.Options.RecentlyUsedHosts.Clear();
-            _project.Options.RecentlyUsedHosts.AddRange(Hosts.Select(h => h.Host));
+            _project.Options.TargetHosts.Clear();
+            _project.Options.TargetHosts.AddRange(Hosts.Select(h => h.Host));
             _project.SaveOptions();
         }
 
@@ -134,12 +134,12 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 
         private bool HasChanges()
         {
-            if (Hosts.Count != _project.Options.RecentlyUsedHosts.Count)
+            if (Hosts.Count != _project.Options.TargetHosts.Count)
                 return true;
 
             for (int i = 0; i < Hosts.Count; ++i)
             {
-                if (Hosts[i].Host != _project.Options.RecentlyUsedHosts[i])
+                if (Hosts[i].Host != _project.Options.TargetHosts[i])
                     return true;
             }
 

--- a/VSRAD.Package/ProjectSystem/Profiles/RecentlyUsedHostsEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/RecentlyUsedHostsEditor.xaml.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using VSRAD.Package.Utils;
+
+namespace VSRAD.Package.ProjectSystem.Profiles
+{
+    public sealed partial class RecentlyUsedHostsEditor : Window
+    {
+        public class HostItem : DefaultNotifyPropertyChanged
+        {
+            private string _host = "";
+            public string Host { get => _host; set => SetField(ref _host, value); }
+        }
+
+        public static bool TryParseHost(string input, out string formatted, out string hostname, out ushort port)
+        {
+            formatted = "";
+            hostname = "";
+            port = 0;
+
+            var hostnamePort = input.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+            if (hostnamePort.Length == 0)
+                return false;
+
+            hostname = hostnamePort[0];
+            if (hostnamePort.Length < 2 || !ushort.TryParse(hostnamePort[1], out port))
+                port = 9339;
+
+            formatted = $"{hostname}:{port}";
+            return true;
+        }
+
+        public ObservableCollection<HostItem> Hosts { get; }
+        public ICommand DeleteHostCommand { get; }
+
+        private readonly IProject _project;
+        private bool _promptUnsavedOnClose = true;
+
+        public RecentlyUsedHostsEditor(IProject project)
+        {
+            _project = project;
+            Hosts = new ObservableCollection<HostItem>(project.Options.RecentlyUsedHosts.Select(h => new HostItem { Host = h }));
+            DeleteHostCommand = new WpfDelegateCommand(DeleteHost);
+
+            InitializeComponent();
+        }
+
+        private void AddHost(object sender, RoutedEventArgs e)
+        {
+            var item = new HostItem();
+            Hosts.Add(item);
+
+            // Finish editing the current host before moving the focus away from it
+            HostGrid.CommitEdit();
+
+            HostGrid.SelectedItem = item;
+            HostGrid.CurrentCell = new DataGridCellInfo(item, HostGrid.Columns[0]);
+#pragma warning disable VSTHRD001 // Using BeginInvoke to focus on the added host item _after_ it's been added to the DataGrid
+            Dispatcher.BeginInvoke((Action)(() => HostGrid.BeginEdit()), System.Windows.Threading.DispatcherPriority.Background);
+#pragma warning restore VSTHRD001
+        }
+
+        private void DeleteHost(object param)
+        {
+            var item = (HostItem)param;
+            var prompt = MessageBox.Show($"Are you sure you want to delete {item.Host}?", "Confirm host deletion", MessageBoxButton.YesNo);
+            if (prompt == MessageBoxResult.Yes)
+                Hosts.Remove(item);
+        }
+
+        private void SaveChanges()
+        {
+            _project.Options.RecentlyUsedHosts.Clear();
+            _project.Options.RecentlyUsedHosts.AddRange(Hosts.Select(h => h.Host));
+            _project.SaveOptions();
+        }
+
+        private void ValidateHostAfterEdit(object sender, DataGridRowEditEndingEventArgs e)
+        {
+            var item = (HostItem)e.Row.DataContext;
+            if (TryParseHost(item.Host, out var formattedHost, out _, out _))
+                item.Host = formattedHost;
+            else
+#pragma warning disable VSTHRD001 // Using BeginInvoke to delete item after all post-edit events fire
+                Dispatcher.BeginInvoke((Action)(() => Hosts.Remove(item)), System.Windows.Threading.DispatcherPriority.Background);
+#pragma warning restore VSTHRD001
+        }
+
+        private void HandleDeleteKey(object sender, KeyEventArgs e)
+        {
+            IEditableCollectionView itemsView = HostGrid.Items;
+            if (e.Key == Key.Delete && !itemsView.IsAddingNew && !itemsView.IsEditingItem && HostGrid.CurrentItem is HostItem item)
+            {
+                DeleteHost(item);
+                e.Handled = true;
+            }
+        }
+
+        private void HandleOK(object sender, RoutedEventArgs e)
+        {
+            _promptUnsavedOnClose = false;
+            SaveChanges();
+            Close();
+        }
+
+        private void HandleCancel(object sender, RoutedEventArgs e)
+        {
+            _promptUnsavedOnClose = false;
+            Close();
+        }
+
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            if (_promptUnsavedOnClose && HasChanges())
+            {
+                var result = MessageBox.Show($"Save changes to hosts?", "Target Hosts Editor", MessageBoxButton.YesNoCancel);
+                if (result == MessageBoxResult.Yes)
+                {
+                    SaveChanges();
+                }
+                else if (result == MessageBoxResult.Cancel)
+                {
+                    e.Cancel = true;
+                    return;
+                }
+            }
+            base.OnClosing(e);
+        }
+
+        private bool HasChanges()
+        {
+            if (Hosts.Count != _project.Options.RecentlyUsedHosts.Count)
+                return true;
+
+            for (int i = 0; i < Hosts.Count; ++i)
+            {
+                if (Hosts[i].Host != _project.Options.RecentlyUsedHosts[i])
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/VSRAD.Package/Utils/MruCollection.cs
+++ b/VSRAD.Package/Utils/MruCollection.cs
@@ -5,10 +5,13 @@ using System.Collections.Generic;
 
 namespace VSRAD.Package.Utils
 {
-    public sealed class MruCollection<T> : IReadOnlyCollection<T>
+    public sealed class MruCollection<T> : IReadOnlyCollection<T>, ICollection<T>
     {
         public int Count => _list.Count;
         public int MaxCount { get; }
+        public bool IsReadOnly => false;
+
+        public T this[int index] { get => _list[index]; }
 
         private readonly List<T> _list;
 
@@ -38,6 +41,16 @@ namespace VSRAD.Package.Utils
         public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_list).GetEnumerator();
+
+        public void AddRange(IEnumerable<T> collection) => _list.AddRange(collection);
+
+        public void Clear() => _list.Clear();
+
+        public bool Contains(T item) => _list.Contains(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => _list.CopyTo(array, arrayIndex);
+
+        public bool Remove(T item) => _list.Remove(item);
 
         public sealed class Converter : JsonConverter
         {

--- a/VSRAD.Package/Utils/MruCollection.cs
+++ b/VSRAD.Package/Utils/MruCollection.cs
@@ -8,34 +8,19 @@ namespace VSRAD.Package.Utils
     public sealed class MruCollection<T> : IReadOnlyCollection<T>, ICollection<T>
     {
         public int Count => _list.Count;
-        public int MaxCount { get; }
         public bool IsReadOnly => false;
 
         public T this[int index] { get => _list[index]; }
 
-        private readonly List<T> _list;
-
-        public MruCollection(int maxCount)
-        {
-            MaxCount = maxCount;
-            _list = new List<T>(maxCount);
-        }
+        private readonly List<T> _list = new List<T>();
 
         public void Add(T item)
         {
+            // Put the item at the start of the list
             if (_list.Contains(item))
-            {
-                /* Put the item at the start of the list */
                 _list.Remove(item);
-                _list.Insert(0, item);
-            }
-            else
-            {
-                if (_list.Count == MaxCount)
-                    _list.RemoveAt(MaxCount - 1);
 
-                _list.Insert(0, item);
-            }
+            _list.Insert(0, item);
         }
 
         public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
@@ -59,9 +44,7 @@ namespace VSRAD.Package.Utils
             public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
             {
                 var items = serializer.Deserialize<List<T>>(reader);
-                items.Reverse();
-                foreach (var item in items)
-                    ((MruCollection<T>)existingValue).Add(item);
+                ((MruCollection<T>)existingValue).AddRange(items);
                 return existingValue;
             }
 

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -213,6 +213,9 @@
     <Compile Include="ProjectSystem\Profiles\LegacyProfileImporter.cs" />
     <Compile Include="ProjectSystem\Profiles\LegacyProfileOptionsMigrator.cs" />
     <Compile Include="ProjectSystem\Profiles\ProfileOptionsWindowContext.cs" />
+    <Compile Include="ProjectSystem\Profiles\RecentlyUsedHostsEditor.xaml.cs">
+      <DependentUpon>RecentlyUsedHostsEditor.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ProjectSystem\ProjectItemPasteProcessor.cs" />
     <Compile Include="ProjectSystem\SolutionManager.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
@@ -446,6 +449,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="ProjectSystem\Profiles\ProfileOptionsWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="ProjectSystem\Profiles\RecentlyUsedHostsEditor.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>


### PR DESCRIPTION
* Clicking _Edit..._ at the bottom of the target hosts dropdown opens the editor window, where hosts can be added, edited or removed.
* Changes can be discarded by pressing _Cancel_ or closing the editor window and choosing _No_ in the _Save changes?_ dialog.
* The maximum number of hosts in the dropdown is no longer limited.