### PR TITLE
Debug server capabilities check

### DIFF
--- a/VSRAD.DebugServer/Dispatcher.cs
+++ b/VSRAD.DebugServer/Dispatcher.cs
@@ -17,6 +17,7 @@ namespace VSRAD.DebugServer
             PutDirectoryCommand pd => new PutDirectoryHandler(pd).RunAsync(),
             ListFilesCommand lf => new ListFilesHandler(lf).RunAsync(),
             GetFilesCommand gf => new GetFilesHandler(gf).RunAsync(),
+            GetServerCapabilitiesCommand _ => new GetServerCapabilitiesHandler().RunAsync(),
             Deploy d => new DeployHandler(d, clientLog).RunAsync(),
             ListEnvironmentVariables lev => new ListEnvironmentVariablesHandler(lev).RunAsync(),
             _ => throw new ArgumentException($"Unknown command type {command.GetType()}"),

--- a/VSRAD.DebugServer/Handlers/GetServerCapabilitiesHandler.cs
+++ b/VSRAD.DebugServer/Handlers/GetServerCapabilitiesHandler.cs
@@ -1,0 +1,20 @@
+﻿using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using VSRAD.DebugServer.IPC;
+using VSRAD.DebugServer.IPC.Responses;
+
+namespace VSRAD.DebugServer.Handlers
+{
+    public sealed class GetServerCapabilitiesHandler : IHandler
+    {
+        public Task<IResponse> RunAsync()
+        {
+            var info = new CapabilityInfo(
+                version: typeof(CapabilityInfo).Assembly.GetName().Version.ToString(3),
+                platform: RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ServerPlatform.Windows : ServerPlatform.Linux,
+                capabilities: CapabilityInfo.LatestServerCapabilities
+            );
+            return Task.FromResult<IResponse>(new GetServerCapabilitiesResponse { Info = info });
+        }
+    }
+}

--- a/VSRAD.DebugServer/Handlers/ListFilesHandler.cs
+++ b/VSRAD.DebugServer/Handlers/ListFilesHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using VSRAD.DebugServer.IPC.Commands;
 using VSRAD.DebugServer.IPC.Responses;
 using VSRAD.DebugServer.SharedUtils;
@@ -17,8 +16,7 @@ namespace VSRAD.DebugServer.Handlers
 
         public Task<IResponse> RunAsync()
         {
-            var path = Path.Combine(_command.WorkDir, _command.Path);
-            var files = FileMetadata.GetMetadataForPath(path, _command.IncludeSubdirectories);
+            var files = FileMetadata.GetMetadataForPath(_command.Path, _command.IncludeSubdirectories);
             return Task.FromResult<IResponse>(new ListFilesResponse { Files = files.ToArray() });
         }
     }

--- a/VSRAD.DebugServer/Handlers/PutDirectoryHandler.cs
+++ b/VSRAD.DebugServer/Handlers/PutDirectoryHandler.cs
@@ -18,9 +18,7 @@ namespace VSRAD.DebugServer.Handlers
 
         public async Task<IResponse> RunAsync()
         {
-            var fullPath = Path.Combine(_command.WorkDir, _command.Path);
-
-            if (File.Exists(fullPath))
+            if (File.Exists(_command.Path))
                 return new PutDirectoryResponse { Status = PutDirectoryStatus.TargetPathIsFile };
 
             bool retryOnce = true;
@@ -28,7 +26,7 @@ namespace VSRAD.DebugServer.Handlers
             {
                 try
                 {
-                    PackedFile.UnpackFiles(fullPath, _command.Files, _command.PreserveTimestamps);
+                    PackedFile.UnpackFiles(_command.Path, _command.Files, _command.PreserveTimestamps);
                     return new PutDirectoryResponse { Status = PutDirectoryStatus.Successful };
                 }
                 catch (UnauthorizedAccessException)

--- a/VSRAD.DebugServer/IPC/Capabilities.cs
+++ b/VSRAD.DebugServer/IPC/Capabilities.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace VSRAD.DebugServer.IPC
+{
+#pragma warning disable CA1028 // Using byte for enum storage because it's used for binary serialization
+    public enum ServerCapability : byte
+    {
+        Base = 0
+    }
+
+    public enum ServerPlatform : byte
+    {
+        Windows = 0,
+        Linux = 1
+    }
+#pragma warning restore CA1028
+
+    public sealed class CapabilityInfo
+    {
+        public string Version { get; }
+        public ServerPlatform Platform { get; }
+        public HashSet<ServerCapability> Capabilities { get; }
+
+        public static readonly HashSet<ServerCapability> LatestServerCapabilities = new HashSet<ServerCapability>(new[]
+        {
+            ServerCapability.Base
+        });
+
+        public CapabilityInfo(string version, ServerPlatform platform, HashSet<ServerCapability> capabilities)
+        {
+            Version = version;
+            Platform = platform;
+            Capabilities = capabilities;
+        }
+
+        public bool IsUpToDate()
+        {
+            return Capabilities.SetEquals(LatestServerCapabilities);
+        }
+
+        public override string ToString() => string.Join(Environment.NewLine, new[]
+        {
+            $"Version = {Version}",
+            $"Platform = {Platform}",
+            $"Capabilities = {string.Join(", ", Capabilities)}"
+        });
+
+        public static CapabilityInfo Deserialize(IPCReader reader)
+        {
+            var version = reader.ReadString();
+            var platform = (ServerPlatform)reader.ReadByte();
+            var capabilityCount = reader.Read7BitEncodedInt();
+            var capabilities = new HashSet<ServerCapability>();
+            for (int i = 0; i < capabilityCount; ++i)
+                capabilities.Add((ServerCapability)reader.ReadByte());
+            return new CapabilityInfo(version, platform, capabilities);
+        }
+
+        public void Serialize(IPCWriter writer)
+        {
+            writer.Write(Version);
+            writer.Write((byte)Platform);
+            writer.Write7BitEncodedInt(Capabilities.Count);
+            foreach (var cap in Capabilities)
+                writer.Write((byte)cap);
+        }
+    }
+}

--- a/VSRAD.DebugServer/IPC/Commands.cs
+++ b/VSRAD.DebugServer/IPC/Commands.cs
@@ -228,8 +228,6 @@ namespace VSRAD.DebugServer.IPC.Commands
 
         public string Path { get; set; }
 
-        public string WorkDir { get; set; }
-
         public bool PreserveTimestamps { get; set; }
 
         public override string ToString() => string.Join(Environment.NewLine, new[]
@@ -237,7 +235,6 @@ namespace VSRAD.DebugServer.IPC.Commands
             "PutDirectoryCommand",
             $"Files = <{Files.Length} files>",
             $"Path = {Path}",
-            $"WorkDir = {WorkDir}",
             $"PreserveTimestamps = {PreserveTimestamps}"
         });
 
@@ -245,7 +242,6 @@ namespace VSRAD.DebugServer.IPC.Commands
         {
             Files = reader.ReadLengthPrefixedFileArray(),
             Path = reader.ReadString(),
-            WorkDir = reader.ReadString(),
             PreserveTimestamps = reader.ReadBoolean()
         };
 
@@ -253,7 +249,6 @@ namespace VSRAD.DebugServer.IPC.Commands
         {
             writer.WriteLengthPrefixedFileArray(Files);
             writer.Write(Path);
-            writer.Write(WorkDir);
             writer.Write(PreserveTimestamps);
         }
     }
@@ -262,28 +257,23 @@ namespace VSRAD.DebugServer.IPC.Commands
     {
         public string Path { get; set; }
 
-        public string WorkDir { get; set; }
-
         public bool IncludeSubdirectories { get; set; }
 
         public override string ToString() => string.Join(Environment.NewLine, new[] {
             "ListFilesCommand",
             $"Path = {Path}",
-            $"WorkDir = {WorkDir}",
             $"IncludeSubdirectories = {IncludeSubdirectories}"
         });
 
         public static ListFilesCommand Deserialize(IPCReader reader) => new ListFilesCommand
         {
             Path = reader.ReadString(),
-            WorkDir = reader.ReadString(),
             IncludeSubdirectories = reader.ReadBoolean()
         };
 
         public void Serialize(IPCWriter writer)
         {
             writer.Write(Path);
-            writer.Write(WorkDir);
             writer.Write(IncludeSubdirectories);
         }
     }
@@ -292,29 +282,29 @@ namespace VSRAD.DebugServer.IPC.Commands
     {
         public bool UseCompression { get; set; }
 
-        public string[] Paths { get; set; }
+        public string RootPath { get; set; }
 
-        public string[] RootPath { get; set; }
+        public string[] Paths { get; set; }
 
         public override string ToString() => string.Join(Environment.NewLine, new[] {
             "GetFilesCommand",
             $"UseCompression = {UseCompression}",
-            $"Paths = {string.Join(", ", Paths)}",
-            $"WorkDir = {string.Join(", ", RootPath)}"
+            $"RootPath = {RootPath}",
+            $"Paths = {string.Join(", ", Paths)}"
         });
 
         public static GetFilesCommand Deserialize(IPCReader reader) => new GetFilesCommand
         {
             UseCompression = reader.ReadBoolean(),
-            Paths = reader.ReadLengthPrefixedStringArray(),
-            RootPath = reader.ReadLengthPrefixedStringArray()
+            RootPath = reader.ReadString(),
+            Paths = reader.ReadLengthPrefixedStringArray()
         };
 
         public void Serialize(IPCWriter writer)
         {
             writer.Write(UseCompression);
+            writer.Write(RootPath);
             writer.WriteLengthPrefixedArray(Paths);
-            writer.WriteLengthPrefixedArray(RootPath);
         }
     }
 

--- a/VSRAD.DebugServer/IPC/Commands.cs
+++ b/VSRAD.DebugServer/IPC/Commands.cs
@@ -17,6 +17,7 @@ namespace VSRAD.DebugServer.IPC.Commands
         PutDirectory = 6,
         ListFiles = 7,
         GetFiles = 8,
+        GetServerCapabilities = 9,
 
         CompressedCommand = 0xFF
     }
@@ -46,6 +47,7 @@ namespace VSRAD.DebugServer.IPC.Commands
                 case CommandType.PutDirectory: return PutDirectoryCommand.Deserialize(reader);
                 case CommandType.ListFiles: return ListFilesCommand.Deserialize(reader);
                 case CommandType.GetFiles: return GetFilesCommand.Deserialize(reader);
+                case CommandType.GetServerCapabilities: return GetServerCapabilitiesCommand.Deserialize(reader);
 
                 case CommandType.CompressedCommand: return CompressedCommand.Deserialize(reader);
             }
@@ -66,6 +68,7 @@ namespace VSRAD.DebugServer.IPC.Commands
                 case PutDirectoryCommand _: type = CommandType.PutDirectory; break;
                 case ListFilesCommand _: type = CommandType.ListFiles; break;
                 case GetFilesCommand _: type = CommandType.GetFiles; break;
+                case GetServerCapabilitiesCommand _: type = CommandType.GetServerCapabilities; break;
 
                 case CompressedCommand _: type = CommandType.CompressedCommand; break;
                 default: throw new ArgumentException($"Unable to serialize {command.GetType()}");
@@ -313,6 +316,15 @@ namespace VSRAD.DebugServer.IPC.Commands
             writer.WriteLengthPrefixedArray(Paths);
             writer.WriteLengthPrefixedArray(RootPath);
         }
+    }
+
+    public sealed class GetServerCapabilitiesCommand : ICommand
+    {
+        public override string ToString() => "GetServerCapabilitiesCommand";
+
+        public static GetServerCapabilitiesCommand Deserialize(IPCReader _) => new GetServerCapabilitiesCommand();
+
+        public void Serialize(IPCWriter _) { }
     }
 
     public sealed class CompressedCommand : ICommand

--- a/VSRAD.DebugServer/IPC/Commands.cs
+++ b/VSRAD.DebugServer/IPC/Commands.cs
@@ -197,7 +197,7 @@ namespace VSRAD.DebugServer.IPC.Commands
 
         public string Path { get; set; }
 
-        public string WorkDir { get; set; }
+        public string WorkDir { get; set; } = "";
 
         public override string ToString() => string.Join(Environment.NewLine, new[]
         {

--- a/VSRAD.DebugServer/IPC/Responses.cs
+++ b/VSRAD.DebugServer/IPC/Responses.cs
@@ -17,6 +17,7 @@ namespace VSRAD.DebugServer.IPC.Responses
         PutDirectory = 5,
         ListFiles = 6,
         GetFiles = 7,
+        GetServerCapabilities = 8,
 
         CompressedResponse = 0xFF
     }
@@ -42,6 +43,7 @@ namespace VSRAD.DebugServer.IPC.Responses
                 case ResponseType.PutDirectory: return PutDirectoryResponse.Deserialize(reader);
                 case ResponseType.ListFiles: return ListFilesResponse.Deserialize(reader);
                 case ResponseType.GetFiles: return GetFilesResponse.Deserialize(reader);
+                case ResponseType.GetServerCapabilities: return GetServerCapabilitiesResponse.Deserialize(reader);
 
                 case ResponseType.CompressedResponse: return CompressedResponse.Deserialize(reader);
             }
@@ -61,6 +63,7 @@ namespace VSRAD.DebugServer.IPC.Responses
                 case PutDirectoryResponse _: type = ResponseType.PutDirectory; break;
                 case ListFilesResponse _: type = ResponseType.ListFiles; break;
                 case GetFilesResponse _: type = ResponseType.GetFiles; break;
+                case GetServerCapabilitiesResponse _: type = ResponseType.GetServerCapabilities; break;
 
                 case CompressedResponse _: type = ResponseType.CompressedResponse; break;
                 default: throw new ArgumentException($"Unable to serialize {response.GetType()}");
@@ -288,6 +291,24 @@ namespace VSRAD.DebugServer.IPC.Responses
 
         public void Serialize(IPCWriter writer) =>
             writer.WriteLengthPrefixedDict(Variables);
+    }
+
+    public sealed class GetServerCapabilitiesResponse : IResponse
+    {
+        public CapabilityInfo Info { get; set; }
+
+        public override string ToString() => string.Join(Environment.NewLine, new[]
+        {
+            "GetServerCapabilitiesResponse",
+            Info.ToString()
+        });
+
+        public static GetServerCapabilitiesResponse Deserialize(IPCReader reader) => new GetServerCapabilitiesResponse
+        {
+            Info = CapabilityInfo.Deserialize(reader)
+        };
+
+        public void Serialize(IPCWriter writer) => Info.Serialize(writer);
     }
 
     public sealed class CompressedResponse : IResponse

--- a/VSRAD.DebugServerTests/Handlers/GetFilesHandlerTest.cs
+++ b/VSRAD.DebugServerTests/Handlers/GetFilesHandlerTest.cs
@@ -29,7 +29,7 @@ namespace VSRAD.DebugServerTests.Handlers
             {
                 UseCompression = false,
                 Paths = new[] { "k/s", "h/b/w", "empty/" },
-                RootPath = new[] { tmpPath }
+                RootPath = tmpPath
             });
 
             Assert.Equal(GetFilesStatus.Successful, response.Status);
@@ -61,7 +61,7 @@ namespace VSRAD.DebugServerTests.Handlers
             {
                 UseCompression = true,
                 Paths = new[] { "test" },
-                RootPath = new[] { tmpPath }
+                RootPath = tmpPath
             });
             Assert.Equal(GetFilesStatus.FileNotFound, response.Status);
 
@@ -72,7 +72,7 @@ namespace VSRAD.DebugServerTests.Handlers
             {
                 UseCompression = true,
                 Paths = new[] { "test" },
-                RootPath = new[] { tmpPath }
+                RootPath = tmpPath
             });
             Assert.Equal(GetFilesStatus.FileNotFound, response.Status);
         }

--- a/VSRAD.DebugServerTests/Handlers/ListFilesHandlerTest.cs
+++ b/VSRAD.DebugServerTests/Handlers/ListFilesHandlerTest.cs
@@ -19,8 +19,7 @@ namespace VSRAD.DebugServerTests.Handlers
 
             var response = await Helper.DispatchCommandAsync<ListFilesCommand, ListFilesResponse>(new ListFilesCommand
             {
-                Path = Path.GetFileName(tmpPath),
-                WorkDir = Path.GetDirectoryName(tmpPath),
+                Path = tmpPath,
                 IncludeSubdirectories = true
             });
 
@@ -53,7 +52,6 @@ namespace VSRAD.DebugServerTests.Handlers
             var response = await Helper.DispatchCommandAsync<ListFilesCommand, ListFilesResponse>(new ListFilesCommand
             {
                 Path = tmpPath,
-                WorkDir = "",
                 IncludeSubdirectories = true
             });
 
@@ -93,7 +91,6 @@ namespace VSRAD.DebugServerTests.Handlers
             var response = await Helper.DispatchCommandAsync<ListFilesCommand, ListFilesResponse>(new ListFilesCommand
             {
                 Path = tmpPath + "\\",
-                WorkDir = "",
                 IncludeSubdirectories = false
             });
 
@@ -112,8 +109,7 @@ namespace VSRAD.DebugServerTests.Handlers
 
             var response = await Helper.DispatchCommandAsync<ListFilesCommand, ListFilesResponse>(new ListFilesCommand
             {
-                Path = Path.GetFileName(tmpPath),
-                WorkDir = Path.GetDirectoryName(tmpPath),
+                Path = tmpPath,
                 IncludeSubdirectories = true
             });
 

--- a/VSRAD.DebugServerTests/Handlers/PutDirectoryHandlerTest.cs
+++ b/VSRAD.DebugServerTests/Handlers/PutDirectoryHandlerTest.cs
@@ -26,8 +26,7 @@ namespace VSRAD.DebugServerTests.Handlers
             var response = await Helper.DispatchCommandAsync<PutDirectoryCommand, PutDirectoryResponse>(new PutDirectoryCommand
             {
                 Files = files,
-                Path = Path.GetFileName(tmpPath),
-                WorkDir = Path.GetDirectoryName(tmpPath),
+                Path = tmpPath,
                 PreserveTimestamps = true
             });
 
@@ -60,8 +59,7 @@ namespace VSRAD.DebugServerTests.Handlers
             var response = await Helper.DispatchCommandAsync<PutDirectoryCommand, PutDirectoryResponse>(new PutDirectoryCommand
             {
                 Files = Array.Empty<PackedFile>(),
-                Path = Path.GetFileName(tmpPath),
-                WorkDir = Path.GetDirectoryName(tmpPath)
+                Path = tmpPath
             });
 
             Assert.Equal(PutDirectoryStatus.TargetPathIsFile, response.Status);
@@ -83,8 +81,7 @@ namespace VSRAD.DebugServerTests.Handlers
             var response = await Helper.DispatchCommandAsync<PutDirectoryCommand, PutDirectoryResponse>(new PutDirectoryCommand
             {
                 Files = files,
-                Path = tmpPath,
-                WorkDir = ""
+                Path = tmpPath
             });
 
             Assert.Equal(PutDirectoryStatus.PermissionDenied, response.Status);

--- a/VSRAD.Package/Errors.cs
+++ b/VSRAD.Package/Errors.cs
@@ -26,6 +26,11 @@ namespace VSRAD.Package
         public static bool operator !=(Error left, Error right) => !(left == right);
     }
 
+    public class UserException : Exception
+    {
+        public UserException(string message) : base(message) { }
+    }
+
     public static class Errors
     {
         public static void Show(Error error) =>
@@ -45,7 +50,10 @@ namespace VSRAD.Package
             // Cancelled operations are usually triggered by the user or are accompanied by a more descriptive message.
             if (e is OperationCanceledException) return;
 
-            ShowCritical(e.Message + "\r\n\r\n" + e.StackTrace, title: "An unexpected error occurred in RAD Debugger");
+            if (typeof(UserException).IsAssignableFrom(e.GetType())) // Caused by user input/environment, intended to bubble up
+                ShowCritical(e.Message);
+            else // Caused by a bug: make diagnosing it easier by printing the stacktrace
+                ShowCritical(e.Message + "\r\n\r\n" + e.StackTrace, title: "An unexpected error occurred in RAD Debugger");
         }
 
         public static void RunAsyncWithErrorHandling(this JoinableTaskFactory taskFactory, Func<Task> method, Action exceptionCallbackOnMainThread = null) =>

--- a/VSRAD.Package/Options/ProfileOptions.cs
+++ b/VSRAD.Package/Options/ProfileOptions.cs
@@ -76,12 +76,12 @@ namespace VSRAD.Package.Options
         [JsonProperty(ItemConverterType = typeof(ActionStepJsonConverter))]
         public ObservableCollection<IActionStep> Steps { get; } = new ObservableCollection<IActionStep>();
 
-        public async Task<Result<ActionProfileOptions>> EvaluateAsync(IMacroEvaluator evaluator, ProfileOptions profile)
+        public async Task<Result<ActionProfileOptions>> EvaluateAsync(IMacroEvaluator evaluator, ActionEvaluationEnvironment env)
         {
             var evaluated = new ActionProfileOptions { Name = Name };
             foreach (var step in Steps)
             {
-                if ((await step.EvaluateAsync(evaluator, profile, Name)).TryGetResult(out var evaluatedStep, out var error))
+                if ((await step.EvaluateAsync(evaluator, env, Name)).TryGetResult(out var evaluatedStep, out var error))
                     evaluated.Steps.Add(evaluatedStep);
                 else
                     return error;
@@ -145,30 +145,5 @@ namespace VSRAD.Package.Options
         public override int GetHashCode() => (RemoteMachine, Port).GetHashCode();
         public static bool operator ==(ServerConnectionOptions left, ServerConnectionOptions right) => left.Equals(right);
         public static bool operator !=(ServerConnectionOptions left, ServerConnectionOptions right) => !(left == right);
-    }
-
-    public readonly struct ActionEnvironment : IEquatable<ActionEnvironment>
-    {
-        public string LocalWorkDir { get; }
-        public string RemoteWorkDir { get; }
-        public ReadOnlyCollection<string> Watches { get; }
-
-        public ActionEnvironment(string localWorkDir, string remoteWorkDir) :
-            this(localWorkDir, remoteWorkDir, new ReadOnlyCollection<string>(Array.Empty<string>()))
-        {
-        }
-
-        public ActionEnvironment(string localWorkDir, string remoteWorkDir, ReadOnlyCollection<string> watches)
-        {
-            LocalWorkDir = localWorkDir;
-            RemoteWorkDir = remoteWorkDir;
-            Watches = watches;
-        }
-
-        public bool Equals(ActionEnvironment o) => LocalWorkDir == o.LocalWorkDir && RemoteWorkDir == o.RemoteWorkDir;
-        public override bool Equals(object o) => o is ActionEnvironment env && Equals(env);
-        public override int GetHashCode() => (LocalWorkDir, RemoteWorkDir).GetHashCode();
-        public static bool operator ==(ActionEnvironment left, ActionEnvironment right) => left.Equals(right);
-        public static bool operator !=(ActionEnvironment left, ActionEnvironment right) => !(left == right);
     }
 }

--- a/VSRAD.Package/ProjectSystem/ActionLauncher.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLauncher.cs
@@ -112,15 +112,17 @@ namespace VSRAD.Package.ProjectSystem
                 var generalResult = await _project.Options.Profile.General.EvaluateAsync(evaluator);
                 if (!generalResult.TryGetResult(out var general, out var evalError))
                     return new ActionExecution(evalError);
-                var evalResult = await action.EvaluateAsync(evaluator, _project.Options.Profile);
-                if (!evalResult.TryGetResult(out action, out evalError))
+
+                var actionEvalEnv = new ActionEvaluationEnvironment(general.LocalWorkDir, general.RemoteWorkDir, general.RunActionsLocally,
+                    _channel.ServerCapabilities, _project.Options.Profile.Actions);
+                var actionEvalResult = await action.EvaluateAsync(evaluator, actionEvalEnv);
+                if (!actionEvalResult.TryGetResult(out action, out evalError))
                     return new ActionExecution(evalError);
 
                 await VSPackage.TaskFactory.SwitchToMainThreadAsync();
                 _projectSources.SaveProjectState();
 
-                var env = new ActionEnvironment(general.LocalWorkDir, general.RemoteWorkDir, transients.Watches);
-                var runner = new ActionRunner(_channel, _serviceProvider, env);
+                var runner = new ActionRunner(_channel, _serviceProvider, transients.Watches);
                 var runResult = await runner.RunAsync(action.Name, action.Steps, _project.Options.Profile.General.ContinueActionExecOnError).ConfigureAwait(false);
                 var actionError = await _actionLogger.LogActionWithWarningsAsync(runResult).ConfigureAwait(false);
                 return new ActionExecution(actionError, transients, runResult);

--- a/VSRAD.Package/ProjectSystem/ActionLauncher.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLauncher.cs
@@ -106,6 +106,9 @@ namespace VSRAD.Package.ProjectSystem
                 var remoteEnvironment = _project.Options.Profile.General.RunActionsLocally
                     ? null
                     : new AsyncLazy<IReadOnlyDictionary<string, string>>(_channel.GetRemoteEnvironmentAsync, VSPackage.TaskFactory);
+                var serverCapabilities = _project.Options.Profile.General.RunActionsLocally
+                    ? null
+                    : await _channel.GetServerCapabilityInfoAsync();
 
                 var evaluator = new MacroEvaluator(projectProperties, transients, remoteEnvironment, _project.Options.DebuggerOptions, _project.Options.Profile);
 
@@ -114,7 +117,7 @@ namespace VSRAD.Package.ProjectSystem
                     return new ActionExecution(evalError);
 
                 var actionEvalEnv = new ActionEvaluationEnvironment(general.LocalWorkDir, general.RemoteWorkDir, general.RunActionsLocally,
-                    _channel.ServerCapabilities, _project.Options.Profile.Actions);
+                    serverCapabilities, _project.Options.Profile.Actions);
                 var actionEvalResult = await action.EvaluateAsync(evaluator, actionEvalEnv);
                 if (!actionEvalResult.TryGetResult(out action, out evalError))
                     return new ActionExecution(evalError);

--- a/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
+++ b/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
@@ -119,7 +119,7 @@ namespace VSRAD.Package.ProjectSystem
             Assumes.Present(textManager);
 
             textManager.GetActiveView2(0, null, (uint)_VIEWFRAMETYPE.vftCodeWindow, out var activeView);
-            return activeView ?? throw new InvalidOperationException(NoFilesOpenError);
+            return activeView ?? throw new UserException(NoFilesOpenError);
         }
 
         private static IWpfTextView GetTextViewFromVsTextView(IVsTextView view)

--- a/VSRAD.Package/ProjectSystem/Macros/DirtyProfileMacroEditor.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/DirtyProfileMacroEditor.cs
@@ -35,7 +35,10 @@ namespace VSRAD.Package.ProjectSystem.Macros
             var transients = GetMacroTransients();
             var evaluator = new MacroEvaluator(ProjectProperties, transients, RemoteEnvironment, _project.Options.DebuggerOptions, _dirtyProfile);
 
-            return await step.EvaluateAsync(evaluator, _dirtyProfile, sourceAction);
+            var actionEvalEnv = new ActionEvaluationEnvironment("", "", _dirtyProfile.General.RunActionsLocally,
+                new DebugServer.IPC.CapabilityInfo(default, default, default), _dirtyProfile.Actions);
+
+            return await step.EvaluateAsync(evaluator, actionEvalEnv, sourceAction);
         }
 
         public async Task EditObjectPropertyAsync(object target, string propertyName)

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
@@ -102,8 +102,6 @@ namespace VSRAD.Package.ProjectSystem.Macros
         Task<Result<string>> EvaluateAsync(string src);
     }
 
-    public sealed class MacroEvaluationException : Exception { public MacroEvaluationException(string message) : base(message) { } }
-
     public sealed class MacroEvaluator : IMacroEvaluator
     {
         private static readonly Regex _macroRegex = new Regex(@"\$(ENVR?)?\(([^()]+)\)", RegexOptions.Compiled);

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -425,7 +425,7 @@ namespace VSRAD.Package.Server
             }
         }
 
-        private bool ReadLocalFile(string fullPath, out byte[] data, out string error, int byteOffset = 0)
+        private static bool ReadLocalFile(string fullPath, out byte[] data, out string error, int byteOffset = 0)
         {
             try
             {
@@ -488,7 +488,7 @@ namespace VSRAD.Package.Server
             }
         }
 
-        private DateTime GetLocalFileLastWriteTimeUtc(string path)
+        private static DateTime GetLocalFileLastWriteTimeUtc(string path)
         {
             try
             {
@@ -500,7 +500,7 @@ namespace VSRAD.Package.Server
             }
         }
 
-        private bool TryGetLocalMetadata(string localPath, bool includeSubdirectories, out IList<FileMetadata> metadata, out string error)
+        private static bool TryGetLocalMetadata(string localPath, bool includeSubdirectories, out IList<FileMetadata> metadata, out string error)
         {
             try
             {

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -76,7 +76,7 @@ namespace VSRAD.Package.Server
             // List all source files
             if (step.Direction == FileCopyDirection.RemoteToLocal)
             {
-                var command = new ListFilesCommand { Path = step.SourcePath };
+                var command = new ListFilesCommand { Path = step.SourcePath, IncludeSubdirectories = step.IncludeSubdirectories };
                 var response = await _channel.SendWithReplyAsync<ListFilesResponse>(command);
                 sourceFiles = response.Files;
             }
@@ -92,7 +92,7 @@ namespace VSRAD.Package.Server
             // List all target files
             if (step.Direction == FileCopyDirection.LocalToRemote)
             {
-                var command = new ListFilesCommand { Path = step.TargetPath };
+                var command = new ListFilesCommand { Path = step.TargetPath, IncludeSubdirectories = step.IncludeSubdirectories };
                 var response = await _channel.SendWithReplyAsync<ListFilesResponse>(command);
                 targetFiles = response.Files;
             }

--- a/VSRAD.Package/Server/BreakStateData.cs
+++ b/VSRAD.Package/Server/BreakStateData.cs
@@ -213,7 +213,7 @@ namespace VSRAD.Package.Server
             var response = await channel.SendWithReplyAsync<DebugServer.IPC.Responses.ResultRangeFetched>(
                 new DebugServer.IPC.Commands.FetchResultRange
                 {
-                    FilePath = _outputFile.Path,
+                    FilePath = new[] { _outputFile.Path },
                     BinaryOutput = _outputFile.BinaryOutput,
                     ByteOffset = requestedByteOffset,
                     ByteCount = requestedByteCount,

--- a/VSRAD.Package/Server/BreakStateOutputFile.cs
+++ b/VSRAD.Package/Server/BreakStateOutputFile.cs
@@ -6,13 +6,13 @@ namespace VSRAD.Package.Server
     public readonly struct BreakStateOutputFile
 #pragma warning restore CA1815 // Override equals and operator equals on value types
     {
-        public string[] Path { get; }
+        public string Path { get; }
         public bool BinaryOutput { get; }
         public int Offset { get; }
         public DateTime Timestamp { get; }
         public int DwordCount { get; }
 
-        public BreakStateOutputFile(string[] path, bool binaryOutput, int offset, DateTime timestamp, int dwordCount)
+        public BreakStateOutputFile(string path, bool binaryOutput, int offset, DateTime timestamp, int dwordCount)
         {
             Path = path;
             BinaryOutput = binaryOutput;

--- a/VSRAD.Package/Server/CommunicationChannel.cs
+++ b/VSRAD.Package/Server/CommunicationChannel.cs
@@ -23,11 +23,11 @@ namespace VSRAD.Package.Server
 
         ClientState ConnectionState { get; }
 
-        DebugServer.IPC.CapabilityInfo ServerCapabilities { get; }
-
         Task<T> SendWithReplyAsync<T>(ICommand command) where T : IResponse;
 
         Task<IReadOnlyDictionary<string, string>> GetRemoteEnvironmentAsync();
+
+        Task<DebugServer.IPC.CapabilityInfo> GetServerCapabilityInfoAsync();
 
         void ForceDisconnect();
     }
@@ -144,6 +144,13 @@ namespace VSRAD.Package.Server
                 _remoteEnvironment = environment.Variables;
             }
             return _remoteEnvironment;
+        }
+
+        public async Task<DebugServer.IPC.CapabilityInfo> GetServerCapabilityInfoAsync()
+        {
+            if (ConnectionState != ClientState.Connected)
+                await EstablishServerConnectionAsync();
+            return ServerCapabilities;
         }
 
         public void ForceDisconnect()

--- a/VSRAD.Package/Server/CommunicationChannel.cs
+++ b/VSRAD.Package/Server/CommunicationChannel.cs
@@ -32,14 +32,14 @@ namespace VSRAD.Package.Server
         void ForceDisconnect();
     }
 
-    public sealed class ConnectionRefusedException : System.IO.IOException
+    public sealed class ConnectionRefusedException : UserException
     {
         public ConnectionRefusedException(ServerConnectionOptions connection) :
-            base($"Unable to establish connection to a debug server at {connection}")
+            base($"Unable to establish connection to the debug server at host {connection}")
         { }
     }
 
-    public sealed class UnsupportedServerVersionException : System.IO.IOException
+    public sealed class UnsupportedServerVersionException : UserException
     {
         public UnsupportedServerVersionException(ServerConnectionOptions connection) :
             base($"The debug server on host {connection} is out of date and missing critical features. Please update it to the latest available version.")
@@ -127,7 +127,7 @@ namespace VSRAD.Package.Server
                 {
                     ForceDisconnect();
                     await _outputWindowWriter.PrintMessageAsync($"Could not reconnect to {ConnectionOptions}").ConfigureAwait(false);
-                    throw new Exception($"Connection to {ConnectionOptions} has been terminated: {e.Message}");
+                    throw;
                 }
             }
             finally

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -48,7 +48,7 @@
                                                 <ComboBox ItemsSource="{Binding ProfileNames}" SelectedItem="{Binding Options.ActiveProfile, Mode=TwoWay}"
                                                           Width="156" Height="24" Margin="4,0,0,4"/>
                                                 <Button Content="Edit" Style="{StaticResource ProfileButton}" Height="24" Padding="6,0" Margin="4,0,0,4"/>
-                                                <Label Content="{Binding ConnectionInfo}" Margin="4,0,0,4"/>
+                                                <Label Content="{Binding ConnectionInfo}" ToolTip="{Binding ServerInfo}" Margin="4,0,0,4"/>
                                                 <Button Content="{Binding DisconnectLabel}" Command="{Binding DisconnectCommand}" Height="24" Padding="6,0" Margin="4,0,0,4"
                                                         Visibility="{Binding DisconnectButtonVisible, Mode=OneWay}"/>
                                             </WrapPanel>

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
@@ -36,13 +36,13 @@ namespace VSRAD.Package.ToolWindows
 
             public ICommand DisconnectCommand { get; }
 
-            private readonly ICommunicationChannel _channel;
+            private readonly CommunicationChannel _channel;
 
             public Context(ProjectOptions options, ICommunicationChannel channel)
             {
                 Options = options;
                 Options.PropertyChanged += OptionsChanged;
-                _channel = channel;
+                _channel = (CommunicationChannel)channel;
                 _channel.ConnectionStateChanged += ConnectionStateChanged;
                 DisconnectCommand = new WpfDelegateCommand((_) => _channel.ForceDisconnect(), isEnabled: _channel.ConnectionState == ClientState.Connected);
             }

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
@@ -22,6 +22,9 @@ namespace VSRAD.Package.ToolWindows
             public string ConnectionInfo =>
                 Options.Profile?.General?.RunActionsLocally == true ? "Local" : _channel.ConnectionOptions.ToString();
 
+            public string ServerInfo =>
+                _channel.ServerCapabilities?.ToString() ?? "";
+
             public Visibility DisconnectButtonVisible =>
                 Options.Profile?.General?.RunActionsLocally == true ? Visibility.Hidden : Visibility.Visible;
 
@@ -56,6 +59,7 @@ namespace VSRAD.Package.ToolWindows
             private void ConnectionStateChanged()
             {
                 RaisePropertyChanged(nameof(ConnectionInfo));
+                RaisePropertyChanged(nameof(ServerInfo));
                 RaisePropertyChanged(nameof(DisconnectLabel));
                 RaisePropertyChanged(nameof(DisconnectButtonVisible));
                 ((WpfDelegateCommand)DisconnectCommand).IsEnabled = _channel.ConnectionState == ClientState.Connected;

--- a/VSRAD.Package/Utils/StringExtensions.cs
+++ b/VSRAD.Package/Utils/StringExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace VSRAD.Package.Utils
+{
+    public static class StringExtensions
+    {
+        public static bool StartsWith(this string str, char c)
+        {
+            return str.Length > 0 && str[0] == c;
+        }
+
+        public static bool EndsWith(this string str, char c)
+        {
+            return str.Length > 0 && str[str.Length - 1] == c;
+        }
+    }
+}

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -253,6 +253,7 @@
     <Compile Include="Utils\CollectionExtensions.cs" />
     <Compile Include="Utils\MruCollection.cs" />
     <Compile Include="Utils\OleCommandText.cs" />
+    <Compile Include="Utils\StringExtensions.cs" />
     <Compile Include="Utils\VsEditor.cs" />
     <Compile Include="Utils\VsStatusBarWriter.cs" />
     <Compile Include="Utils\WpfConverters.cs" />

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -106,6 +106,9 @@
     <Compile Include="..\VSRAD.BuildTools\IPCBuildResult.cs">
       <Link>BuildTools\IPCBuildResult.cs</Link>
     </Compile>
+    <Compile Include="..\VSRAD.DebugServer\IPC\Capabilities.cs">
+      <Link>Server\IPC\Capabilities.cs</Link>
+    </Compile>
     <Compile Include="..\VSRAD.DebugServer\IPC\Commands.cs">
       <Link>Server\IPC\Commands.cs</Link>
     </Compile>

--- a/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
@@ -16,7 +16,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             byte[] systemBytes = new byte[system.Length * 4];
             Buffer.BlockCopy(system, 0, systemBytes, 0, systemBytes.Length);
             var data = new BreakStateData(new ReadOnlyCollection<string>(new List<string>()),
-                new BreakStateOutputFile(Array.Empty<string>(), false, 0, default, dwordCount: system.Length), systemBytes);
+                new BreakStateOutputFile("", false, 0, default, dwordCount: system.Length), systemBytes);
             _ = data.ChangeGroupWithWarningsAsync(null, groupIndex: groupIndex, groupSize: groupSize, waveSize: waveSize, nGroups: 0).Result;
             var view = data.GetSystem();
             Assert.NotNull(view);

--- a/VSRAD.PackageTests/MockCommunicationChannel.cs
+++ b/VSRAD.PackageTests/MockCommunicationChannel.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using VSRAD.DebugServer.IPC;
 using VSRAD.DebugServer.IPC.Commands;
 using VSRAD.DebugServer.IPC.Responses;
 using VSRAD.Package.Server;
@@ -28,9 +29,12 @@ namespace VSRAD.PackageTests
 
         public void RaiseConnectionStateChanged() => _mock.Raise((m) => m.ConnectionStateChanged += null);
 
-        public MockCommunicationChannel()
+        public MockCommunicationChannel(ServerPlatform platform = ServerPlatform.Windows)
         {
             _mock = new Mock<ICommunicationChannel>();
+            _mock
+                .SetupGet(c => c.ServerCapabilities)
+                .Returns(new CapabilityInfo("", platform, CapabilityInfo.LatestServerCapabilities));
             _mock
                 .Setup((c) => c.SendWithReplyAsync<ExecutionCompleted>(It.IsAny<Execute>()))
                 .Returns<ICommand>((c) => Task.FromResult((ExecutionCompleted)HandleCommand(c)));

--- a/VSRAD.PackageTests/MockCommunicationChannel.cs
+++ b/VSRAD.PackageTests/MockCommunicationChannel.cs
@@ -33,8 +33,8 @@ namespace VSRAD.PackageTests
         {
             _mock = new Mock<ICommunicationChannel>();
             _mock
-                .SetupGet(c => c.ServerCapabilities)
-                .Returns(new CapabilityInfo("", platform, CapabilityInfo.LatestServerCapabilities));
+                .Setup(c => c.GetServerCapabilityInfoAsync())
+                .ReturnsAsync(new CapabilityInfo("", platform, CapabilityInfo.LatestServerCapabilities));
             _mock
                 .Setup((c) => c.SendWithReplyAsync<ExecutionCompleted>(It.IsAny<Execute>()))
                 .Returns<ICommand>((c) => Task.FromResult((ExecutionCompleted)HandleCommand(c)));

--- a/VSRAD.PackageTests/ProjectSystem/ActionLoggerTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/ActionLoggerTests.cs
@@ -16,20 +16,21 @@ namespace VSRAD.PackageTests.ProjectSystem
         [Fact]
         public async Task NestedRunResultLoggingTestAsync()
         {
-            var profile = new ProfileOptions();
-            profile.Actions.Add(new ActionProfileOptions { Name = "Exchange Soul" });
-            profile.Actions[0].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "cleanup", Arguments = "--skip" });
-            profile.Actions.Add(new ActionProfileOptions { Name = "Sign Contract" });
-            profile.Actions[1].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "obtain-contract", Arguments = "-i -mm" });
-            profile.Actions[1].Steps.Add(new RunActionStep { Name = "Exchange Soul" });
-            profile.Actions.Add(new ActionProfileOptions { Name = "Transform" });
-            profile.Actions[2].Steps.Add(new RunActionStep { Name = "Sign Contract" });
-            profile.Actions[2].Steps.Add(new CopyFileStep { Direction = FileCopyDirection.LocalToRemote, FailIfNotModified = true, TargetPath = "incubator", SourcePath = "soul" });
+            var actions = new ActionProfileOptions[3];
+            actions[0] = new ActionProfileOptions { Name = "Exchange Soul" };
+            actions[0].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "cleanup", Arguments = "--skip" });
+            actions[1] = new ActionProfileOptions { Name = "Sign Contract" };
+            actions[1].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "obtain-contract", Arguments = "-i -mm" });
+            actions[1].Steps.Add(new RunActionStep { Name = "Exchange Soul" });
+            actions[2] = new ActionProfileOptions { Name = "Transform" };
+            actions[2].Steps.Add(new RunActionStep { Name = "Sign Contract" });
+            actions[2].Steps.Add(new CopyFileStep { Direction = FileCopyDirection.LocalToRemote, FailIfNotModified = true, TargetPath = "incubator", SourcePath = "soul" });
 
             var evaluator = new Mock<IMacroEvaluator>();
             evaluator.Setup(e => e.EvaluateAsync(It.IsAny<string>())).Returns<string>(s => Task.FromResult<Result<string>>(s));
 
-            Assert.True((await profile.Actions[2].EvaluateAsync(evaluator.Object, profile)).TryGetResult(out var level1action, out _));
+            var env = new ActionEvaluationEnvironment("", "", false, new DebugServer.IPC.CapabilityInfo(default, default, default), actions);
+            Assert.True((await actions[2].EvaluateAsync(evaluator.Object, env)).TryGetResult(out var level1action, out _));
             var level2action = (RunActionStep)level1action.Steps[0];
             var level3action = (RunActionStep)level2action.EvaluatedSteps[1];
 
@@ -96,16 +97,16 @@ Captured stdout (exit code 2):
         [Fact]
         public async Task ContinueOnErrorTestAsync()
         {
-            var profile = new ProfileOptions();
-            profile.Actions.Add(new ActionProfileOptions { Name = "Shibahama Yūfō Taisen!" });
-            profile.Actions[0].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "draw_anime", Arguments = "--dont-miss-deadlines" });
-            profile.Actions[0].Steps.Add(new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, FailIfNotModified = false, TargetPath = "ending_theme.wav", SourcePath = "some_dudes_email" });
-            profile.Actions[0].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "combine_ending_animation_and_music", Arguments = "--hope-music-fits" });
-            profile.Actions[0].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "rework_ending", Arguments = "--one-night" });
-            profile.Actions[0].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "comet_a", Arguments = "--showcase" });
-            profile.Actions[0].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "sell_dvds", Arguments = "--lots" });
+            var actions = new ActionProfileOptions[1];
+            actions[0] = new ActionProfileOptions { Name = "Shibahama Yūfō Taisen!" };
+            actions[0].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "draw_anime", Arguments = "--dont-miss-deadlines" });
+            actions[0].Steps.Add(new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, FailIfNotModified = false, TargetPath = "ending_theme.wav", SourcePath = "some_dudes_email" });
+            actions[0].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "combine_ending_animation_and_music", Arguments = "--hope-music-fits" });
+            actions[0].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "rework_ending", Arguments = "--one-night" });
+            actions[0].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "comet_a", Arguments = "--showcase" });
+            actions[0].Steps.Add(new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "sell_dvds", Arguments = "--lots" });
 
-            var actionResult = new ActionRunResult(profile.Actions[0].Name, profile.Actions[0].Steps, false);
+            var actionResult = new ActionRunResult(actions[0].Name, actions[0].Steps, false);
 
             actionResult.StepResults[0] = new StepResult(true, "", "");
             actionResult.StepResults[1] = new StepResult(true, "", "");
@@ -141,8 +142,8 @@ Captured stdout (exit code 2):
 ";
             Assert.Equal(expectedMessage, logMessage);
 
-            profile.Actions[0].Name += " (without difficulties)";
-            TestHelper.SetReadOnlyProp(actionResult, nameof(actionResult.ActionName), profile.Actions[0].Name);
+            actions[0].Name += " (without difficulties)";
+            TestHelper.SetReadOnlyProp(actionResult, nameof(actionResult.ActionName), actions[0].Name);
             TestHelper.SetReadOnlyProp(actionResult, nameof(actionResult.ContinueOnError), true);
 
             warnings = await logger.LogActionWithWarningsAsync(actionResult);

--- a/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
@@ -60,7 +60,7 @@ namespace VSRAD.PackageTests.ProjectSystem
             var serviceProvider = new Mock<SVsServiceProvider>();
             serviceProvider.Setup(p => p.GetService(typeof(SVsStatusbar))).Returns(new Mock<IVsStatusbar>().Object);
 
-            var channel = new MockCommunicationChannel();
+            var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
             var sourceManager = new Mock<IProjectSourceManager>();
             var actionLauncher = new ActionLauncher(project, new Mock<IActionLogger>().Object, channel.Object, sourceManager.Object,
                 codeEditor.Object, breakpointTracker.Object, serviceProvider.Object);
@@ -69,7 +69,7 @@ namespace VSRAD.PackageTests.ProjectSystem
             /* Set up server responses */
 
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.FileNotFound }, (FetchMetadata timestampFetch) =>
-                Assert.Equal(new[] { "/periphery/votw", "output-path" }, timestampFetch.FilePath));
+                Assert.Equal(new[] { "/periphery/votw/output-path" }, timestampFetch.FilePath));
             channel.ThenRespond(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0 }, (Execute execute) =>
             {
                 Assert.Equal("ohmu", execute.Executable);

--- a/VSRAD.PackageTests/Server/BreakStateTests.cs
+++ b/VSRAD.PackageTests/Server/BreakStateTests.cs
@@ -16,7 +16,7 @@ namespace VSRAD.PackageTests.Server
         {
             var channel = new MockCommunicationChannel();
             var watches = new ReadOnlyCollection<string>(new[] { "local_id", "group_id", "group_size" });
-            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "madoka" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
+            var file = new BreakStateOutputFile("/home/kyubey/projects/madoka", binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
             var breakStateData = new BreakStateData(watches, file);
 
             var data = new int[1024]; // 2 groups by 2 waves (1 wave = 64 lanes), each containing 1 system dword and 3 watch dwords
@@ -117,7 +117,7 @@ namespace VSRAD.PackageTests.Server
 
             var channel = new MockCommunicationChannel();
             var watches = new ReadOnlyCollection<string>(new[] { "local_id" });
-            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "madoka" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: watchCount * laneCount);
+            var file = new BreakStateOutputFile("/home/kyubey/projects/madoka", binaryOutput: true, offset: 0, timestamp: default, dwordCount: watchCount * laneCount);
             var breakStateData = new BreakStateData(watches, file);
 
             Assert.Equal(groupCount, breakStateData.GetGroupCount(groupSize, waveSize, 0));
@@ -157,13 +157,13 @@ namespace VSRAD.PackageTests.Server
         {
             var channel = new MockCommunicationChannel();
             var watches = new ReadOnlyCollection<string>(new[] { "h" });
-            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "log.tar" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
+            var file = new BreakStateOutputFile("/home/kyubey/projects/log.tar", binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
             var breakStateData = new BreakStateData(watches, file);
 
             channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Array.Empty<byte>() },
             (command) =>
             {
-                Assert.Equal(new[] { "/home/kyubey/projects", "log.tar" }, command.FilePath);
+                Assert.Equal(new[] { "/home/kyubey/projects/log.tar" }, command.FilePath);
             });
             var warning = await breakStateData.ChangeGroupWithWarningsAsync(channel.Object, groupIndex: 0, groupSize: 512, waveSize: 64, nGroups: 1);
             Assert.Equal("Group #0 is incomplete: expected to read 4096 bytes but the output file contains 0.", warning);
@@ -176,7 +176,7 @@ namespace VSRAD.PackageTests.Server
         {
             var channel = new MockCommunicationChannel();
             var watches = new ReadOnlyCollection<string>(new[] { "h" });
-            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "log.tar" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
+            var file = new BreakStateOutputFile("/home/kyubey/projects/log.tar", binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
             var breakStateData = new BreakStateData(watches, file);
 
             Assert.Equal(2, breakStateData.GetGroupCount(groupSize: 256, waveSize: 64, nGroups: 4));
@@ -201,7 +201,7 @@ namespace VSRAD.PackageTests.Server
             Buffer.BlockCopy(data, 0, localData, 0, localData.Length);
 
             var watches = new ReadOnlyCollection<string>(new[] { "local_id" });
-            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "madoka" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: 2 * 256);
+            var file = new BreakStateOutputFile("/home/kyubey/projects/madoka", binaryOutput: true, offset: 0, timestamp: default, dwordCount: 2 * 256);
             var breakStateData = new BreakStateData(watches, file, localData);
 
             var warning = await breakStateData.ChangeGroupWithWarningsAsync(channel: null, groupIndex: 1, groupSize: 64, waveSize: 32, nGroups: 2);


### PR DESCRIPTION
This PR closes #160. See the issue for an overview of the capability checking mechanism.

In addition to the server capabilities check, this PR includes a change to how paths in action steps are resolved. Previously, remote paths that were relative to the working directory (`$(RemoteWorkDir)`) could not be converted to absolute paths on the extension side because we couldn't tell whether the remote host uses Windows or Unix paths. Now the server identifies its platform along with capabilities, so we can join paths on the VS side and send just the absolute path in IPC commands.