### PR TITLE
Obsolete config format import

### DIFF
--- a/VSRAD.Package/BuildSystem/DeployedBuildSystem/RADProject.targets
+++ b/VSRAD.Package/BuildSystem/DeployedBuildSystem/RADProject.targets
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <SourceFile Include="**/*"/>
-    <SourceFile Remove="*.radproj; *.radproj.user; *.radproj.user.json; *.radproj.conf.json"/>
+    <SourceFile Remove="*.radproj; *.radproj.user; *.radproj.user.json; *.radproj.conf.json; *.radproj.profiles.json"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/VSRAD.Package/Options/ProjectOptions.cs
+++ b/VSRAD.Package/Options/ProjectOptions.cs
@@ -94,10 +94,12 @@ namespace VSRAD.Package.Options
             if (options == null && optionsException != null)
             {
                 if (optionsException is FileNotFoundException)
+                {
                     if (oldOptionsException != null && !(oldOptionsException is FileNotFoundException))
                         Errors.ShowWarning($"An error has occurred while loading the options: {oldOptionsException.Message}\r\nProceeding with defaults.");
-                    else
-                        Errors.ShowWarning($"An error has occurred while loading the options: {optionsException.Message}\r\nProceeding with defaults.");
+                }
+                else
+                    Errors.ShowWarning($"An error has occurred while loading the options: {optionsException.Message}\r\nProceeding with defaults.");
 
                 options = new ProjectOptions();
             }
@@ -109,10 +111,12 @@ namespace VSRAD.Package.Options
             if (profiles == null && profilesException != null)
             {
                 if (profilesException is FileNotFoundException)
+                {
                     if (oldProfilesException != null && !(oldProfilesException is FileNotFoundException))
                         Errors.ShowWarning($"An error has occurred while loading the profiles: {oldProfilesException.Message}\r\nProceeding with defaults.");
-                    else
-                        Errors.ShowWarning($"An error has occurred while loading the profiles: {profilesException.Message}\r\nProceeding with defaults.");
+                }
+                else
+                    Errors.ShowWarning($"An error has occurred while loading the profiles: {profilesException.Message}\r\nProceeding with defaults.");
             }
 
             if (profiles != null)

--- a/VSRAD.Package/Options/ProjectOptions.cs
+++ b/VSRAD.Package/Options/ProjectOptions.cs
@@ -98,7 +98,8 @@ namespace VSRAD.Package.Options
                 Errors.ShowWarning($"An error has occurred while loading the project options: {e.Message}\r\nProceeding with defaults.");
             }
 
-            if (options == null) // Note that DeserializeObject can return null even on success (e.g. if the file is empty)
+            var optionsLoaded = options != null; // Note that DeserializeObject can return null even on success (e.g. if the file is empty)
+            if (!optionsLoaded)
                 options = new ProjectOptions();
 
             try
@@ -111,6 +112,7 @@ namespace VSRAD.Package.Options
             {
                 try
                 {
+                    if (!optionsLoaded) options = ProfileTransferManager.ImportObsoleteOptions(profilesOptionsPath);
                     var profiles = ProfileTransferManager.ImportObsolete(profilesOptionsPath);
                     options.SetProfiles(profiles, options.ActiveProfile);
                 }

--- a/VSRAD.Package/Options/ProjectOptions.cs
+++ b/VSRAD.Package/Options/ProjectOptions.cs
@@ -81,107 +81,63 @@ namespace VSRAD.Package.Options
         #endregion
 
         #region Read/Write
-        public static ProjectOptions Read(string visualizerOptionsPath, string profilesOptionsPath, string oldOptionsPath)
+        public static ProjectOptions Read(string userOptionsPath, string profilesOptionsPath, string oldConfigPath)
         {
-            Exception optionsException,
-                      oldOptionsException = null,
-                      profilesException,
-                      oldProfilesException = null;
-            var options = ReadProjectOptions(visualizerOptionsPath, out optionsException); // Try to parse .user.json
-            if (options == null)
-                options = ReadObsoleteProjectOptions(oldOptionsPath, out oldOptionsException);
-
-            if (options == null && optionsException != null)
+            ProjectOptions options = null;
+            // Handle options and profiles loading in separate try blocks since we want them
+            // to load indepentently, i.e use default configs if corresponding file is missing
+            // in each case without affecting one another
+            try // Try to load .user.json in the first place
             {
-                if (optionsException is FileNotFoundException)
+                var optionsJson = JObject.Parse(File.ReadAllText(userOptionsPath));
+                options = optionsJson.ToObject<ProjectOptions>(new JsonSerializer { DefaultValueHandling = DefaultValueHandling.Populate });
+            }
+            catch (FileNotFoundException)
+            {
+                try // Try to load options from .conf.json if .user.json is missing
                 {
-                    if (oldOptionsException != null && !(oldOptionsException is FileNotFoundException))
-                        Errors.ShowWarning($"An error has occurred while loading the options: {oldOptionsException.Message}\r\nProceeding with defaults.");
+                    options = ProfileTransferManager.ImportObsoleteOptions(oldConfigPath);
                 }
-                else
-                    Errors.ShowWarning($"An error has occurred while loading the options: {optionsException.Message}\r\nProceeding with defaults.");
+                catch (FileNotFoundException) { } // Don't show an error if the configuration file is missing, just load defaults
+                catch (Exception e)
+                {
+                    Errors.ShowWarning($"An error has occurred while loading the project options: {e.Message}\r\nProceeding with defaults.");
+                }
+            }
+            catch (Exception e)
+            {
+                Errors.ShowWarning($"An error has occurred while loading the project options: {e.Message}\r\nProceeding with defaults.");
+            }
 
+            if (options == null) // Note that DeserializeObject can return null even on success (e.g. if the file is empty)
                 options = new ProjectOptions();
-            }
 
-            var profiles = ReadProfiles(profilesOptionsPath, out profilesException);
-            if (profiles == null)
-                profiles = ReadObsoleteProfiles(oldOptionsPath, out oldProfilesException);
-
-            if (profiles == null && profilesException != null)
+            try // Try to load .profiles.json in the first place
             {
-                if (profilesException is FileNotFoundException)
-                {
-                    if (oldProfilesException != null && !(oldProfilesException is FileNotFoundException))
-                        Errors.ShowWarning($"An error has occurred while loading the profiles: {oldProfilesException.Message}\r\nProceeding with defaults.");
-                }
-                else
-                    Errors.ShowWarning($"An error has occurred while loading the profiles: {profilesException.Message}\r\nProceeding with defaults.");
-            }
-
-            if (profiles != null)
+                var profiles = ProfileTransferManager.Import(profilesOptionsPath);
                 options.SetProfiles(profiles, options.ActiveProfile);
+            }
+            catch (FileNotFoundException)
+            {
+                try // Try to load profiles from .conf.json if .profiles.json is missing
+                {
+                    var profiles = ProfileTransferManager.ImportObsolete(oldConfigPath);
+                    options.SetProfiles(profiles, options.ActiveProfile);
+                }
+                catch (FileNotFoundException) { } // Don't show an error if the configuration file is missing, just load defaults
+                catch (Exception e)
+                {
+                    Errors.ShowWarning($"An error has occurred while loading the profiles: {e.Message}\r\nProceeding with defaults.");
+                }
+            }
+            catch (Exception e)
+            {
+                Errors.ShowWarning($"An error has occurred while loading the profiles: {e.Message}\r\nProceeding with defaults.");
+            }
 
             if (options.Profiles.Count > 0 && !options.Profiles.ContainsKey(options.ActiveProfile))
                 options.ActiveProfile = options.Profiles.Keys.First();
             return options;
-        }
-
-        private static ProjectOptions ReadProjectOptions(string optionsPath, out Exception exception)
-        {
-            exception = null;
-            try
-            {
-                var optionsJson = JObject.Parse(File.ReadAllText(optionsPath));
-                return optionsJson.ToObject<ProjectOptions>(new JsonSerializer { DefaultValueHandling = DefaultValueHandling.Populate });
-            }
-            catch (Exception e)
-            {
-                exception = e;
-                return null;
-            }
-        }
-
-        private static ProjectOptions ReadObsoleteProjectOptions(string optionsPath, out Exception exception)
-        {
-            exception = null;
-            try
-            {
-                return ProfileTransferManager.ImportObsoleteOptions(optionsPath);
-            }
-            catch (Exception e)
-            {
-                exception = e;
-                return null;
-            }
-        }
-
-        private static Dictionary<string, ProfileOptions> ReadProfiles(string profilesPath, out Exception exception)
-        {
-            exception = null;
-            try
-            {
-                return ProfileTransferManager.Import(profilesPath);
-            }
-            catch (Exception e)
-            {
-                exception = e;
-                return null;
-            }
-        }
-
-        private static Dictionary<string, ProfileOptions> ReadObsoleteProfiles(string profilesPath, out Exception exception)
-        {
-            exception = null;
-            try
-            {
-                return ProfileTransferManager.ImportObsolete(profilesPath);
-            }
-            catch (Exception e)
-            {
-                exception = e;
-                return null;
-            }
         }
 
         public void Write(string visualConfigPath, string profilesConfigPath)

--- a/VSRAD.Package/Options/ProjectOptions.cs
+++ b/VSRAD.Package/Options/ProjectOptions.cs
@@ -109,7 +109,15 @@ namespace VSRAD.Package.Options
             catch (FileNotFoundException) { } // Don't show an error if the configuration file is missing, just load defaults
             catch (Exception e)
             {
-                Errors.ShowWarning($"An error has occurred while loading the profiles: {e.Message}\r\nProceeding with defaults.");
+                try
+                {
+                    var profiles = ProfileTransferManager.ImportObsolete(profilesOptionsPath);
+                    options.SetProfiles(profiles, options.ActiveProfile);
+                }
+                catch (Exception ex)
+                {
+                    Errors.ShowWarning($"An error has occurred while loading the profiles: {ex.Message}\r\nProceeding with defaults.");
+                }
             }
 
             if (options.Profiles.Count > 0 && !options.Profiles.ContainsKey(options.ActiveProfile))

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
@@ -15,6 +15,12 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             return json.ToObject<Dictionary<string, ProfileOptions>>();
         }
 
+        public static Dictionary<string, ProfileOptions> ImportObsolete(string path)
+        {
+            var json = JObject.Parse(File.ReadAllText(path));
+            return json["Profiles"].ToObject<Dictionary<string, ProfileOptions>>();
+        }
+
         public static void Export(IDictionary<string, ProfileOptions> profiles, string oath) =>
             File.WriteAllText(oath, JsonConvert.SerializeObject(profiles, Formatting.Indented));
     }

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
@@ -21,6 +21,31 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             return json["Profiles"].ToObject<Dictionary<string, ProfileOptions>>();
         }
 
+        public static ProjectOptions ImportObsoleteOptions(string path)
+        {
+            var json = JObject.Parse(File.ReadAllText(path));
+            var debuggerOptions = json["DebuggerOptions"].ToObject<DebuggerOptions>();
+            var visualizerOptions = json["VisualizerOptions"].ToObject<VisualizerOptions>();
+            var sliceVisualizerOptions = json["SliceVisualizerOptions"].ToObject<SliceVisualizerOptions>();
+            var visualizerAppearance = json["VisualizerAppearance"].ToObject<VisualizerAppearance>();
+            var visualizerColumnStyling = json["VisualizerColumnStyling"].ToObject<DebugVisualizer.ColumnStylingOptions>();
+            var targetHosts = json["TargetHosts"].ToObject<List<string>>();
+            var activeProfile = json["ActiveProfile"].ToString();
+
+            var options = new ProjectOptions(
+                debuggerOptions,
+                visualizerOptions,
+                sliceVisualizerOptions,
+                visualizerAppearance,
+                visualizerColumnStyling
+            );
+            foreach (var host in targetHosts)
+                options.TargetHosts.Add(host);
+            options.ActiveProfile = activeProfile;
+
+            return options;
+        }
+
         public static void Export(IDictionary<string, ProfileOptions> profiles, string oath) =>
             File.WriteAllText(oath, JsonConvert.SerializeObject(profiles, Formatting.Indented));
     }

--- a/VSRAD.Package/ProjectSystem/Project.cs
+++ b/VSRAD.Package/ProjectSystem/Project.cs
@@ -40,7 +40,8 @@ namespace VSRAD.Package.ProjectSystem
         public string RootPath { get; }
 
         private readonly string _visualOptionsFilePath;
-        private readonly string _optionsFilePath;
+        private readonly string _profilesFilePath;
+        private readonly string _oldOptionsFilePath;
 
         private bool _loaded = false;
         private readonly List<Action<ProjectOptions>> _onLoadCallbacks = new List<Action<ProjectOptions>>();
@@ -49,7 +50,8 @@ namespace VSRAD.Package.ProjectSystem
         public Project(UnconfiguredProject unconfiguredProject)
         {
             RootPath = Path.GetDirectoryName(unconfiguredProject.FullPath);
-            _optionsFilePath = unconfiguredProject.FullPath + ".conf.json";
+            _profilesFilePath = unconfiguredProject.FullPath + ".profiles.json";
+            _oldOptionsFilePath = unconfiguredProject.FullPath + ".conf.json";
             _visualOptionsFilePath = unconfiguredProject.FullPath + ".user.json";
             UnconfiguredProject = unconfiguredProject;
         }
@@ -64,7 +66,7 @@ namespace VSRAD.Package.ProjectSystem
 
         public void Load()
         {
-            Options = ProjectOptions.Read(_visualOptionsFilePath, _optionsFilePath);
+            Options = ProjectOptions.Read(_visualOptionsFilePath, _profilesFilePath, _oldOptionsFilePath);
 
             Options.PropertyChanged += OptionsPropertyChanged;
             Options.DebuggerOptions.PropertyChanged += OptionsPropertyChanged;
@@ -85,7 +87,7 @@ namespace VSRAD.Package.ProjectSystem
 
         public void Unload() => Unloaded?.Invoke();
 
-        public void SaveOptions() => Options.Write(_visualOptionsFilePath, _optionsFilePath);
+        public void SaveOptions() => Options.Write(_visualOptionsFilePath, _profilesFilePath);
 
         public IProjectProperties GetProjectProperties()
         {


### PR DESCRIPTION
Renamed `.conf.json` to `.profiles.json` so old config would not be overwritten.

This PR adds the ability to successfully run the project with old `.conf.json` config. After first updating of configs, the configs will be updated to match the new `.profiles/.user` format, that makes the migration to new configs format seamless for user.