### PR TITLE
IntelliSense syntax fixes

### DIFF
--- a/VSRAD.Syntax/Core/Tokens/DefinitionToken.cs
+++ b/VSRAD.Syntax/Core/Tokens/DefinitionToken.cs
@@ -6,12 +6,6 @@ namespace VSRAD.Syntax.Core.Tokens
     public interface IDefinitionToken : IAnalysisToken
     {
         ICollection<IAnalysisToken> References { get; }
-
-        /// <summary>
-        /// Return token description, for example comments 
-        /// </summary>
-        /// <returns>string if present; otherwise, null</returns>
-        string GetDescription();
     }
 
     public class DefinitionToken : AnalysisToken, IDefinitionToken
@@ -30,10 +24,5 @@ namespace VSRAD.Syntax.Core.Tokens
             References.Add(reference);
 
         public override string GetText() => _text;
-
-        public string GetDescription()
-        {
-            return null;
-        }
     }
 }

--- a/VSRAD.Syntax/IntelliSense/Helper.cs
+++ b/VSRAD.Syntax/IntelliSense/Helper.cs
@@ -1,0 +1,102 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
+using VSRAD.Syntax.Core;
+using VSRAD.Syntax.Core.Tokens;
+using VSRAD.Syntax.Helpers;
+
+namespace VSRAD.Syntax.IntelliSense
+{
+    internal static class IntellisenseHelper
+    {
+        /// <summary>
+        /// Returns the description text of the definition in the comment to the right or above the definition.
+        /// </summary>
+        /// <returns>Description text if exists otherwise null</returns>
+        public static string GetDescription(this IDefinitionToken token)
+        {
+            var serviceProvider = ServiceProvider.GlobalProvider;
+            var documentFactory = serviceProvider.GetMefService<IDocumentFactory>();
+
+            var tokenEnd = token.Span.End;
+            var snapshot = token.Span.Snapshot;
+            var document = documentFactory.GetOrCreateDocument(snapshot.TextBuffer);
+            var tokenizer = document.DocumentTokenizer;
+            var tokenizerResult = tokenizer.CurrentResult;
+
+            if (tokenizerResult.Snapshot != snapshot)
+                return null;
+
+            return TryGetDescriptionToTheRight(tokenizer, tokenizerResult, tokenEnd)
+                   ?? TryGetDescriptionAbove(tokenizer, tokenizerResult, tokenEnd);
+        }
+
+        private static string TryGetDescriptionToTheRight(IDocumentTokenizer tokenizer, ITokenizerResult tokenizerResult, SnapshotPoint tokenEnd)
+        {
+            var currentLine = tokenEnd.GetContainingLine();
+            var currentLineComment = tokenizerResult
+                .GetTokens(new Span(tokenEnd, currentLine.End - tokenEnd))
+                .Where(t => tokenizer.IsTypeOf(t.Type, RadAsmTokenType.Comment))
+                .ToList();
+
+            if (currentLineComment.Count == 0)
+                return null;
+
+            var text = currentLineComment
+                .First()
+                .GetText(tokenEnd.Snapshot);
+
+            return GetCommentText(text);
+        }
+
+        private static string TryGetDescriptionAbove(IDocumentTokenizer tokenizer, ITokenizerResult tokenizerResult, SnapshotPoint tokenEnd)
+        {
+            var lines = new LinkedList<string>();
+            var currentLineNumber = tokenEnd.GetContainingLine().LineNumber - 1;
+            var snapshot = tokenEnd.Snapshot;
+
+            while (currentLineNumber >= 0)
+            {
+                var currentLine = snapshot.GetLineFromLineNumber(currentLineNumber);
+                var currentLineComment = tokenizerResult
+                    .GetTokens(new Span(currentLine.Start, currentLine.Length))
+                    .ToList();
+
+                // if there are some other tokens, then the comment ended
+                if (currentLineComment.Any(t =>
+                    !tokenizer.IsTypeOf(t.Type, RadAsmTokenType.Comment) &&
+                    !tokenizer.IsTypeOf(t.Type, RadAsmTokenType.Whitespace)))
+                    break;
+
+                currentLineComment.RemoveAll(t =>
+                    tokenizer.IsTypeOf(t.Type, RadAsmTokenType.Whitespace));
+
+                if (currentLineComment.Count != 1)
+                    break;
+
+                var trackingToken = currentLineComment.First();
+                var tokenSpan = new SnapshotSpan(snapshot, trackingToken.GetSpan(snapshot));
+                var tokenText = GetCommentText(tokenSpan.GetText());
+
+                lines.AddFirst(tokenText);
+                currentLineNumber = tokenSpan.Start.GetContainingLine().LineNumber - 1;
+            }
+
+            return lines.Count != 0
+                ? string.Join(System.Environment.NewLine, lines)
+                : null;
+        }
+
+        private static bool IsTypeOf(this IDocumentTokenizer tokenizer, int tokenType,
+            RadAsmTokenType targetTokenType) =>
+            tokenizer.GetTokenType(tokenType) == targetTokenType;
+
+        private static string GetCommentText(string text)
+        {
+            var comment = text.Trim('/', '*', ' ', '\t', '\r', '\n', '\f');
+            return Regex.Replace(comment, @"(?<=\n)\s*(\*|\/\/)", "", RegexOptions.Compiled);
+        }
+    }
+}

--- a/VSRAD.Syntax/IntelliSense/IntellisenseController.cs
+++ b/VSRAD.Syntax/IntelliSense/IntellisenseController.cs
@@ -110,6 +110,8 @@ namespace VSRAD.Syntax.IntelliSense
                         break;
                     case VSConstants.VSStd2KCmdID.BACKSPACE:
                     case VSConstants.VSStd2KCmdID.DELETE:
+                    case VSConstants.VSStd2KCmdID.DELETEWORDLEFT:
+                    case VSConstants.VSStd2KCmdID.DELETELINE:
                     case VSConstants.VSStd2KCmdID.LEFT:
                     case VSConstants.VSStd2KCmdID.RIGHT:
                         ChangeParameterSignatureSession();

--- a/VSRAD.Syntax/IntelliSense/IntellisenseController.cs
+++ b/VSRAD.Syntax/IntelliSense/IntellisenseController.cs
@@ -110,12 +110,14 @@ namespace VSRAD.Syntax.IntelliSense
                         break;
                     case VSConstants.VSStd2KCmdID.BACKSPACE:
                     case VSConstants.VSStd2KCmdID.DELETE:
+                    case VSConstants.VSStd2KCmdID.DELETETOEOL:
                     case VSConstants.VSStd2KCmdID.DELETEWORDLEFT:
-                    case VSConstants.VSStd2KCmdID.DELETELINE:
                     case VSConstants.VSStd2KCmdID.LEFT:
                     case VSConstants.VSStd2KCmdID.RIGHT:
                         ChangeParameterSignatureSession();
                         break;
+                    case VSConstants.VSStd2KCmdID.DELETELINE:
+                    case VSConstants.VSStd2KCmdID.DELETETOBOL:
                     case VSConstants.VSStd2KCmdID.RETURN:
                     case VSConstants.VSStd2KCmdID.CANCEL:
                         CancelSignatureSession();

--- a/VSRAD.Syntax/IntelliSense/IntellisenseTokenDescription.cs
+++ b/VSRAD.Syntax/IntelliSense/IntellisenseTokenDescription.cs
@@ -122,6 +122,8 @@ namespace VSRAD.Syntax.IntelliSense
                 }
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
+
             builder.SetAsElement();
             if (token.Definition is IDefinitionToken definitionToken)
             {

--- a/VSRAD.Syntax/IntelliSense/SignatureHelp/InstructionSignature.cs
+++ b/VSRAD.Syntax/IntelliSense/SignatureHelp/InstructionSignature.cs
@@ -63,7 +63,7 @@ namespace VSRAD.Syntax.IntelliSense.SignatureHelp
             _content = content.ToString();
             _displayParts = new ReadOnlyCollection<TextTag>(displayParts);
             _parameters = new ReadOnlyCollection<IParameter>(parameters);
-            _documentation = _token.GetDescription() ?? string.Empty;
+            _documentation = string.Empty;
 
             SetCurrentParameter(_initParameterIdx);
         }

--- a/VSRAD.Syntax/VSRAD.Syntax.csproj
+++ b/VSRAD.Syntax/VSRAD.Syntax.csproj
@@ -141,6 +141,7 @@
     <Compile Include="IntelliSense\Completion\Providers\InstructionCompletionProvider.cs" />
     <Compile Include="IntelliSense\Completion\CompletionSource.cs" />
     <Compile Include="IntelliSense\Completion\CompletionSourceProvider.cs" />
+    <Compile Include="IntelliSense\Helper.cs" />
     <Compile Include="IntelliSense\IntellisenseController.cs" />
     <Compile Include="IntelliSense\IntellisenseControllerProvider.cs" />
     <Compile Include="IntelliSense\IntellisenseTokenDescription.cs" />


### PR DESCRIPTION
- [x] Fix exception on _Peek Definition_
- [x] Return the definition description feature (it was temporarily disabled)
- [x] Dismiss signature help popup on word deletion (ctrl+backspace), line deletion (ctrl+shift+l), delete to Begin Of Line, delete to End Of Line (improve #144 usability)