### PR TITLE
Ux improvements

### DIFF
--- a/VSRAD.Package/Commands/AddToWatchesCommand.cs
+++ b/VSRAD.Package/Commands/AddToWatchesCommand.cs
@@ -43,7 +43,7 @@ namespace VSRAD.Package.Commands
 
         public void Execute(uint commandId, uint commandExecOpt, IntPtr variantIn, IntPtr variantOut)
         {
-            var watchName = _codeEditor.GetActiveWord();
+            var watchName = _codeEditor.GetActiveWord(_toolIntegration.ProjectOptions.VisualizerOptions.MatchBracketsOnAddToWatches);
             if (string.IsNullOrEmpty(watchName))
                 return;
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
@@ -9,7 +9,7 @@
              xmlns:utils="clr-namespace:VSRAD.Package.Utils"
              mc:Ignorable="d"
              x:Name="Root"
-             d:DesignHeight="140" d:DesignWidth="720">
+             d:DesignHeight="200" d:DesignWidth="720">
     <UserControl.ContextMenu>
         <ContextMenu>
             <MenuItem Header="Show hidden system variable" IsChecked="{Binding Options.VisualizerOptions.ShowSystemVariable, Mode=TwoWay}" IsCheckable="True"/>
@@ -18,7 +18,8 @@
             <MenuItem IsEnabled="False" Header="Show:"/>
             <MenuItem Header="Columns" IsChecked="{Binding Options.VisualizerOptions.ShowColumnsField, Mode=TwoWay}" IsCheckable="True"/>
             <MenuItem Header="App args" IsChecked="{Binding Options.VisualizerOptions.ShowAppArgsField, Mode=TwoWay}" IsCheckable="True"/>
-            <MenuItem Header="Break args" IsChecked="{Binding Options.VisualizerOptions.ShowBreakArgsField, Mode=TwoWay}" IsCheckable="True"/>
+            <MenuItem Header="App args 2" IsChecked="{Binding Options.VisualizerOptions.ShowAppArgs2Field, Mode=TwoWay}" IsCheckable="True"/>
+            <MenuItem Header="App args 3" IsChecked="{Binding Options.VisualizerOptions.ShowAppArgs3Field, Mode=TwoWay}" IsCheckable="True"/>
             <MenuItem Header="Wavemap" IsChecked="{Binding Options.VisualizerOptions.ShowWavemap, Mode=TwoWay}" IsCheckable="True"/>
         </ContextMenu>
     </UserControl.ContextMenu>
@@ -292,7 +293,19 @@
                         <Style TargetType="RowDefinition">
                             <Setter Property="Height" Value="Auto" />
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding Options.VisualizerOptions.ShowBreakArgsField}" Value="False">
+                                <DataTrigger Binding="{Binding Options.VisualizerOptions.ShowAppArgs2Field}" Value="False">
+                                    <Setter Property="Height" Value="0" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </RowDefinition.Style>
+                </RowDefinition>
+                <RowDefinition>
+                    <RowDefinition.Style>
+                        <Style TargetType="RowDefinition">
+                            <Setter Property="Height" Value="Auto" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Options.VisualizerOptions.ShowAppArgs3Field}" Value="False">
                                     <Setter Property="Height" Value="0" />
                                 </DataTrigger>
                             </Style.Triggers>
@@ -314,7 +327,8 @@
             </Grid.RowDefinitions>
             <Label Grid.Row="0" Grid.Column="0" Content="Columns:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
             <Label Grid.Row="1" Grid.Column="0" Content="App args:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
-            <Label Grid.Row="2" Grid.Column="0" Content="Break args:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
+            <Label Grid.Row="2" Grid.Column="0" Content="App args 2:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
+            <Label Grid.Row="3" Grid.Column="0" Content="App args 3:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
             <TextBox Text="{Binding Options.VisualizerColumnStyling.VisibleColumns, UpdateSourceTrigger=PropertyChanged}"
                      Grid.Row="0" Grid.Column="1" Height="24" VerticalContentAlignment="Center"
                      Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
@@ -324,12 +338,17 @@
                       IsEditable="True" Grid.Column="1" Height="24" VerticalContentAlignment="Center"
                       ItemsSource="{Binding Options.DebuggerOptions.LastAppArgs, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}"
                       DisplayMemberPath="Value" x:Name="LastAppArgsCombo" Grid.Row="1" IsTextSearchEnabled="False"/>
-            <TextBox Text="{Binding Options.DebuggerOptions.BreakArgs, UpdateSourceTrigger=PropertyChanged}"
+            <TextBox Text="{Binding Options.DebuggerOptions.AppArgs2, UpdateSourceTrigger=PropertyChanged}"
                      Grid.Row="2" Grid.Column="1" Height="24" VerticalContentAlignment="Center"
                      Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
                      Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
                      BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
-            <Grid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Stretch">
+            <TextBox Text="{Binding Options.DebuggerOptions.AppArgs3, UpdateSourceTrigger=PropertyChanged}"
+                     Grid.Row="3" Grid.Column="1" Height="24" VerticalContentAlignment="Center"
+                     Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+                     Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
+                     BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
+            <Grid Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Stretch">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="85"/>
                     <ColumnDefinition Width="*"/>

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -36,8 +36,11 @@ namespace VSRAD.Package.Options
         private string _appArgs = "";
         public string AppArgs { get => _appArgs; set => SetField(ref _appArgs, value); }
 
-        private string _breakArgs = "";
-        public string BreakArgs { get => _breakArgs; set => SetField(ref _breakArgs, value); }
+        private string _appArgs2 = "";
+        public string AppArgs2 { get => _appArgs2; set => SetField(ref _appArgs2, value); }
+
+        private string _appArgs3 = "";
+        public string AppArgs3 { get => _appArgs3; set => SetField(ref _appArgs3, value); }
 
         private bool _autosave = true;
         public bool Autosave { get => _autosave; set => SetField(ref _autosave, value); }

--- a/VSRAD.Package/Options/DefaultOptionValues.cs
+++ b/VSRAD.Package/Options/DefaultOptionValues.cs
@@ -14,7 +14,7 @@ namespace VSRAD.Package.Options
         #endregion
         #region Debugger
         public const string DebuggerExecutable = "python.exe";
-        public const string DebuggerArguments = "script.py -w $(" + RadMacros.Watches + ") -l $(" + RadMacros.BreakLine + ") -v \"$(" + RadMacros.DebugAppArgs + ")\" -t $(" + RadMacros.Counter + ") -p \"$(" + RadMacros.DebugBreakArgs + ")\" -f \"$(" + RadMacros.ActiveSourceFile + ")\" -o \"$(" + RadMacros.DebuggerOutputPath + ")\"";
+        public const string DebuggerArguments = "script.py -w $(" + RadMacros.Watches + ") -l $(" + RadMacros.BreakLine + ") -v \"$(" + RadMacros.DebugAppArgs + ")\" -t $(" + RadMacros.Counter + ") -p \"$(" + RadMacros.DebugAppArgs2 + ")\" -f \"$(" + RadMacros.ActiveSourceFile + ")\" -o \"$(" + RadMacros.DebuggerOutputPath + ")\"";
         public const string DebuggerWorkingDirectory = "$(" + RadMacros.DeployDirectory + ")";
         public const string DebuggerOutputPath = "";
         public const bool DebuggerBinaryOutput = false;

--- a/VSRAD.Package/Options/VisualizerOptions.cs
+++ b/VSRAD.Package/Options/VisualizerOptions.cs
@@ -52,6 +52,10 @@ namespace VSRAD.Package.Options
         private bool _showWavemap;
         [DefaultValue(true)]
         public bool ShowWavemap { get => _showWavemap; set => SetField(ref _showWavemap, value); }
+
+        private bool _matchBracketsOnAddToWatches;
+        [DefaultValue(false)]
+        public bool MatchBracketsOnAddToWatches { get => _matchBracketsOnAddToWatches; set => SetField(ref _matchBracketsOnAddToWatches, value); }
     }
 
     public sealed class MagicNumberConverter : JsonConverter

--- a/VSRAD.Package/Options/VisualizerOptions.cs
+++ b/VSRAD.Package/Options/VisualizerOptions.cs
@@ -41,9 +41,13 @@ namespace VSRAD.Package.Options
         [DefaultValue(true)]
         public bool ShowAppArgsField { get => _showAppArgsField; set => SetField(ref _showAppArgsField, value); }
 
-        private bool _showBreakArgsField;
+        private bool _showAppArgs2Field;
         [DefaultValue(true)]
-        public bool ShowBreakArgsField { get => _showBreakArgsField; set => SetField(ref _showBreakArgsField, value); }
+        public bool ShowAppArgs2Field { get => _showAppArgs2Field; set => SetField(ref _showAppArgs2Field, value); }
+
+        private bool _showAppArgs3Field;
+        [DefaultValue(true)]
+        public bool ShowAppArgs3Field { get => _showAppArgs3Field; set => SetField(ref _showAppArgs3Field, value); }
 
         private bool _showWavemap;
         [DefaultValue(true)]

--- a/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
+++ b/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
@@ -28,10 +28,8 @@ namespace VSRAD.Package.ProjectSystem
         private readonly SVsServiceProvider _serviceProvider;
         private readonly ITextDocumentFactoryService _textDocumentService;
 
-        // this regular find matches like `\vargs[kernarg_1:kernarg_2]`
-        private static readonly Regex _activeWordWithBracketsRegular = new Regex(@"[\w\\$]*\[[^\[\]]*\]", RegexOptions.Compiled | RegexOptions.Singleline);
-        // this regular find empty brackets
-        private static readonly Regex _emptyBracketsRegex = new Regex(@"\[\s*\]", RegexOptions.Compiled);
+        // this regex matches words like `\vargs` without indices like [0]
+        private static readonly Regex _activeWordWithoutBracketsRegex = new Regex(@"[\w\\$]*", RegexOptions.Compiled | RegexOptions.Singleline);
 
         [ImportingConstructor]
         public ActiveCodeEditor(SVsServiceProvider serviceProvider, ITextDocumentFactoryService textDocumentService)
@@ -62,7 +60,7 @@ namespace VSRAD.Package.ProjectSystem
             if (activeWord.Length == 0)
             {
                 var wpfTextView = GetTextViewFromVsTextView(GetActiveTextView());
-                activeWord = _emptyBracketsRegex.Replace(GetWordOnPosition(wpfTextView.TextBuffer, wpfTextView.Caret.Position.BufferPosition), "");
+                activeWord = GetWordOnPosition(wpfTextView.TextBuffer, wpfTextView.Caret.Position.BufferPosition);
             }
             return activeWord.Trim();
         }
@@ -73,8 +71,8 @@ namespace VSRAD.Package.ProjectSystem
             var lineText = line.GetText();
             var caretIndex = position - line.Start;
 
-            // check actual word with open and close brackets
-            foreach (Match match in _activeWordWithBracketsRegular.Matches(lineText))
+            // check actual word
+            foreach (Match match in _activeWordWithoutBracketsRegex.Matches(lineText))
             {
                 if (match.Index <= caretIndex && (match.Index + match.Length) >= caretIndex)
                 {

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
@@ -79,7 +79,8 @@ namespace VSRAD.Package.ProjectSystem.Macros
         public const string AWatches = "RadAWatches";
         public const string BreakLine = "RadBreakLine";
         public const string DebugAppArgs = "RadDebugAppArgs";
-        public const string DebugBreakArgs = "RadDebugBreakArgs";
+        public const string DebugAppArgs2 = "RadDebugAppArgs2";
+        public const string DebugAppArgs3 = "RadDebugAppArgs3";
         public const string Counter = "RadCounter";
         public const string NGroups = "RadNGroups";
         public const string GroupSize = "RadGroupSize";
@@ -134,7 +135,8 @@ namespace VSRAD.Package.ProjectSystem.Macros
                 { RadMacros.AWatches, string.Join(":", debuggerOptions.GetAWatchSnapshot()) },
                 { RadMacros.BreakLine, string.Join(":", values.BreakLines ?? new[] { 0u }) },
                 { RadMacros.DebugAppArgs, debuggerOptions.AppArgs },
-                { RadMacros.DebugBreakArgs, debuggerOptions.BreakArgs },
+                { RadMacros.DebugAppArgs2, debuggerOptions.AppArgs2 },
+                { RadMacros.DebugAppArgs3, debuggerOptions.AppArgs3 },
                 { RadMacros.Counter, debuggerOptions.Counter.ToString() },
                 { RadMacros.NGroups, debuggerOptions.NGroups.ToString() },
                 { RadMacros.GroupSize, debuggerOptions.GroupSize.ToString() }

--- a/VSRAD.Package/ProjectSystem/Macros/MacroListEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroListEditor.xaml.cs
@@ -48,7 +48,8 @@ namespace VSRAD.Package.ProjectSystem.Macros
             new MacroItem(RadMacros.Watches, "<visualizer watches, colon-separated>", userDefined: false),
             new MacroItem(RadMacros.BreakLine, "<next breakpoint line(s), colon-separated>", userDefined: false),
             new MacroItem(RadMacros.DebugAppArgs, "<app args, set in visualizer>", userDefined: false),
-            new MacroItem(RadMacros.DebugBreakArgs, "<break args, set in visualizer>", userDefined: false),
+            new MacroItem(RadMacros.DebugAppArgs2, "<app args 2, set in visualizer>", userDefined: false),
+            new MacroItem(RadMacros.DebugAppArgs3, "<app args 3, set in visualizer>", userDefined: false),
             new MacroItem(RadMacros.Counter, "<counter, set in visualizer>", userDefined: false),
             new MacroItem(RadMacros.NGroups, "<ngroups, set in visualizer>", userDefined: false),
             new MacroItem(RadMacros.GroupSize, "<group size, set in visualizer>", userDefined: false)

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
@@ -29,7 +29,6 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             var sliceVisualizerOptions = json["SliceVisualizerOptions"].ToObject<SliceVisualizerOptions>();
             var visualizerAppearance = json["VisualizerAppearance"].ToObject<VisualizerAppearance>();
             var visualizerColumnStyling = json["VisualizerColumnStyling"].ToObject<DebugVisualizer.ColumnStylingOptions>();
-            var targetHosts = json["TargetHosts"].ToObject<List<string>>();
             var activeProfile = json["ActiveProfile"].ToString();
             var breakArgs = json["DebuggerOptions"]["BreakArgs"].ToString();
 
@@ -44,8 +43,10 @@ namespace VSRAD.Package.ProjectSystem.Profiles
                 visualizerColumnStyling
             );
 
-            foreach (var host in targetHosts)
-                options.TargetHosts.Add(host);
+            if (json["TargetHosts"] != null)
+                foreach (var host in json["TargetHosts"].ToObject<List<string>>())
+                    options.TargetHosts.Add(host);
+
             options.ActiveProfile = activeProfile;
 
             return options;

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
@@ -31,6 +31,10 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             var visualizerColumnStyling = json["VisualizerColumnStyling"].ToObject<DebugVisualizer.ColumnStylingOptions>();
             var targetHosts = json["TargetHosts"].ToObject<List<string>>();
             var activeProfile = json["ActiveProfile"].ToString();
+            var breakArgs = json["DebuggerOptions"]["BreakArgs"].ToString();
+
+            if (breakArgs != null)
+                debuggerOptions.AppArgs2 = breakArgs;
 
             var options = new ProjectOptions(
                 debuggerOptions,
@@ -39,6 +43,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
                 visualizerAppearance,
                 visualizerColumnStyling
             );
+
             foreach (var host in targetHosts)
                 options.TargetHosts.Add(host);
             options.ActiveProfile = activeProfile;

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -109,6 +109,10 @@
                             IsChecked="{Binding Options.DebuggerOptions.SingleActiveBreakpoint, UpdateSourceTrigger=PropertyChanged}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Height="25">
+                    <CheckBox Content="Match brackets on Add To Watches" VerticalAlignment="Center" Padding="4,0,0,0"
+                                IsChecked="{Binding Options.VisualizerOptions.MatchBracketsOnAddToWatches, UpdateSourceTrigger=PropertyChanged}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Height="25">
                     <Label Content="Break mode:" VerticalAlignment="Center" Margin="15,0,0,0"/>
                     <ComboBox SelectedItem="{Binding Options.DebuggerOptions.BreakMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                               ItemsSource="{Binding Source={StaticResource BreakMode}}" VerticalContentAlignment="Center">

--- a/VSRAD.Package/Utils/VsEditor.cs
+++ b/VSRAD.Package/Utils/VsEditor.cs
@@ -53,7 +53,9 @@ namespace VSRAD.Package.Utils
             {
                 var dte = serviceProvider.GetService(typeof(DTE)) as DTE;
                 Assumes.Present(dte);
+                var activeFile = dte.ActiveDocument;
                 dte.ItemOperations.OpenFile(path);
+                dte.ItemOperations.OpenFile(activeFile.FullName); // preserving old active document
 
                 if (string.IsNullOrEmpty(lineMarker))
                     return;
@@ -63,6 +65,7 @@ namespace VSRAD.Package.Utils
                 var textManager = serviceProvider.GetService(typeof(SVsTextManager)) as IVsTextManager2;
                 Assumes.Present(textManager);
 
+                dte.ItemOperations.OpenFile(path); // change active document if line marker set
                 textManager.GetActiveView2(1, null, (uint)_VIEWFRAMETYPE.vftCodeWindow, out var activeView);
                 activeView.SetCaretPos(lineNumber, 0);
             }

--- a/VSRAD.Package/Utils/VsEditor.cs
+++ b/VSRAD.Package/Utils/VsEditor.cs
@@ -65,9 +65,10 @@ namespace VSRAD.Package.Utils
                 var textManager = serviceProvider.GetService(typeof(SVsTextManager)) as IVsTextManager2;
                 Assumes.Present(textManager);
 
-                dte.ItemOperations.OpenFile(path); // change active document if line marker set
+                dte.ItemOperations.OpenFile(path); // change active document to set active line according to line marker
                 textManager.GetActiveView2(1, null, (uint)_VIEWFRAMETYPE.vftCodeWindow, out var activeView);
                 activeView.SetCaretPos(lineNumber, 0);
+                dte.ItemOperations.OpenFile(activeFile.FullName); // preserving old active document
             }
             catch (Exception e)
             {

--- a/VSRAD.Package/Utils/VsEditor.cs
+++ b/VSRAD.Package/Utils/VsEditor.cs
@@ -54,20 +54,19 @@ namespace VSRAD.Package.Utils
                 var dte = serviceProvider.GetService(typeof(DTE)) as DTE;
                 Assumes.Present(dte);
                 var activeFile = dte.ActiveDocument;
-                dte.ItemOperations.OpenFile(path);
-                dte.ItemOperations.OpenFile(activeFile.FullName); // preserving old active document
+                dte.ItemOperations.OpenFile(path); // open requested file in VS editor
 
-                if (string.IsNullOrEmpty(lineMarker))
-                    return;
+                if (!string.IsNullOrEmpty(lineMarker))
+                {
+                    var lineNumber = GetMarkedLineNumber(path, lineMarker);
 
-                var lineNumber = GetMarkedLineNumber(path, lineMarker);
+                    var textManager = serviceProvider.GetService(typeof(SVsTextManager)) as IVsTextManager2;
+                    Assumes.Present(textManager);
 
-                var textManager = serviceProvider.GetService(typeof(SVsTextManager)) as IVsTextManager2;
-                Assumes.Present(textManager);
+                    textManager.GetActiveView2(1, null, (uint)_VIEWFRAMETYPE.vftCodeWindow, out var activeView);
+                    activeView.SetCaretPos(lineNumber, 0);
+                }
 
-                dte.ItemOperations.OpenFile(path); // change active document to set active line according to line marker
-                textManager.GetActiveView2(1, null, (uint)_VIEWFRAMETYPE.vftCodeWindow, out var activeView);
-                activeView.SetCaretPos(lineNumber, 0);
                 dte.ItemOperations.OpenFile(activeFile.FullName); // preserving old active document
             }
             catch (Exception e)


### PR DESCRIPTION
Changed:

* Renamed `Break Args` field to `App Args 2`, `RadDebugBreakArgs` macro to `RadDebugAppArgs2`;
* Previously, any `Open in editor` step would change the active document window to newly opened one even if this document is opened in a separate tab. Now the active document will remain the same as it was before running of the action. If `Line Marker` present, the corresponding line will be active in opened file once user change the tab to it.
* Previously, `Add to watches` feature selected active word including indices (`var[a][b][c]`), now it ignores them (in previous example just `var` will be added to the watch list).

Added:

* `App Args 3` field and corresponding macro `RadDebugAppArgs3`.

Fixed:

* NRE if old config file didn't had `TargetHosts` field