### PR TITLE
Fix unhandled syntax exceptions

### DIFF
--- a/VSRAD.Syntax/Core/DocumentAnalysis.cs
+++ b/VSRAD.Syntax/Core/DocumentAnalysis.cs
@@ -35,7 +35,7 @@ namespace VSRAD.Syntax.Core
             if (_resultsRequests.TryGetValue(textSnapshot, out var task))
                 return await task.ConfigureAwait(false);
 
-            throw new TaskCanceledException("Buffer changes have not yet been processed");
+            throw new OperationCanceledException("Buffer changes have not yet been processed");
         }
 
         public void Rescan(RescanReason rescanReason, CancellationToken cancellationToken)

--- a/VSRAD.Syntax/IntelliSense/Helper.cs
+++ b/VSRAD.Syntax/IntelliSense/Helper.cs
@@ -13,16 +13,33 @@ namespace VSRAD.Syntax.IntelliSense
     {
         /// <summary>
         /// Returns the description text of the definition in the comment to the right or above the definition.
+        /// Must be on UI thread
         /// </summary>
         /// <returns>Description text if exists otherwise null</returns>
         public static string GetDescription(this IDefinitionToken token)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             var serviceProvider = ServiceProvider.GlobalProvider;
             var documentFactory = serviceProvider.GetMefService<IDocumentFactory>();
 
+            return documentFactory != null 
+                ? GetDescription(token, documentFactory)
+                : null;
+        }
+
+        /// <summary>
+        /// Returns the description text of the definition in the comment to the right or above the definition.
+        /// </summary>
+        /// <returns>Description text if exists otherwise null</returns>
+        public static string GetDescription(this IDefinitionToken token, IDocumentFactory documentFactory)
+        {
             var tokenEnd = token.Span.End;
             var snapshot = token.Span.Snapshot;
+
             var document = documentFactory.GetOrCreateDocument(snapshot.TextBuffer);
+            if (document == null)
+                return null;
+
             var tokenizer = document.DocumentTokenizer;
             var tokenizerResult = tokenizer.CurrentResult;
 

--- a/VSRAD.Syntax/IntelliSense/IntellisenseTokenDescription.cs
+++ b/VSRAD.Syntax/IntelliSense/IntellisenseTokenDescription.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.Text.Adornments;
+﻿using System;
+using Microsoft.VisualStudio.Text.Adornments;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
@@ -8,6 +9,7 @@ using VSRAD.Syntax.Core.Tokens;
 using System.Threading.Tasks;
 using VSRAD.Syntax.Core.Blocks;
 using System.Threading;
+using VSRAD.Syntax.Core;
 
 namespace VSRAD.Syntax.IntelliSense
 {
@@ -21,11 +23,13 @@ namespace VSRAD.Syntax.IntelliSense
     internal class IntellisenseDescriptionBuilder : IIntellisenseDescriptionBuilder
     {
         private readonly INavigationTokenService _navigationTokenService;
+        private readonly Lazy<IDocumentFactory> _documentFactoryLazy;
 
         [ImportingConstructor]
-        public IntellisenseDescriptionBuilder(INavigationTokenService navigationTokenService)
+        public IntellisenseDescriptionBuilder(INavigationTokenService navigationTokenService, Lazy<IDocumentFactory> documentFactory)
         {
             _navigationTokenService = navigationTokenService;
+            _documentFactoryLazy = documentFactory;
         }
 
         public async Task<object> GetColorizedDescriptionAsync(IReadOnlyList<INavigationToken> tokens, CancellationToken cancellationToken)
@@ -127,7 +131,7 @@ namespace VSRAD.Syntax.IntelliSense
             builder.SetAsElement();
             if (token.Definition is IDefinitionToken definitionToken)
             {
-                var description = definitionToken.GetDescription();
+                var description = definitionToken.GetDescription(_documentFactoryLazy.Value);
                 if (description != null)
                     builder.AddClassifiedText(description).SetAsElement();
             }

--- a/VSRAD.Syntax/Options/GeneralOptionPage.cs
+++ b/VSRAD.Syntax/Options/GeneralOptionPage.cs
@@ -8,13 +8,11 @@ namespace VSRAD.Syntax.Options
 {
     public class GeneralOptionPage : DialogPage
     {
-        private readonly GeneralOptionProvider _generalOptionEventProvider;
-        private readonly GeneralOptionModel _model;
+        private readonly GeneralOptionProvider _optionProvider;
 
         public GeneralOptionPage()
         {
-            _generalOptionEventProvider = GeneralOptionProvider.Instance;
-            _model = GeneralOptionModel.Instance;
+            _optionProvider = GeneralOptionProvider.Instance;
         }
 
         [Category("Function list")]
@@ -22,8 +20,8 @@ namespace VSRAD.Syntax.Options
         [Description("Set default sort option for Function List")]
         public SortState SortOptions
         {
-            get => _generalOptionEventProvider.SortOptions;
-            set => _generalOptionEventProvider.SortOptions = value;
+            get => _optionProvider.SortOptions;
+            set => _optionProvider.SortOptions = value;
         }
 
         [Category("Function list")]
@@ -31,8 +29,8 @@ namespace VSRAD.Syntax.Options
         [Description("Scroll to current function in the function list automatically")]
         public bool AutoScroll
         {
-            get => _generalOptionEventProvider.AutoScroll;
-            set => _generalOptionEventProvider.AutoScroll = value;
+            get => _optionProvider.AutoScroll;
+            set => _optionProvider.AutoScroll = value;
         }
 
         [Category("Syntax highlight")]
@@ -40,8 +38,8 @@ namespace VSRAD.Syntax.Options
         [Description("Enable/disable indent guide lines")]
         public bool IsEnabledIndentGuides
         {
-            get => _generalOptionEventProvider.IsEnabledIndentGuides;
-            set => _generalOptionEventProvider.IsEnabledIndentGuides = value;
+            get => _optionProvider.IsEnabledIndentGuides;
+            set => _optionProvider.IsEnabledIndentGuides = value;
         }
 
 #if DEBUG
@@ -49,16 +47,16 @@ namespace VSRAD.Syntax.Options
         [DisplayName("Indent guide line thickness")]
         public double IndentGuideThickness
         {
-            get => _generalOptionEventProvider.IndentGuideThickness;
-            set => _generalOptionEventProvider.IndentGuideThickness = value;
+            get => _optionProvider.IndentGuideThickness;
+            set => _optionProvider.IndentGuideThickness = value;
         }
 
         [Category("Syntax highlight")]
         [DisplayName("Indent guide dash size")]
         public double IndentGuideDashSize
         {
-            get => _generalOptionEventProvider.IndentGuideDashSize;
-            set => _generalOptionEventProvider.IndentGuideDashSize = value;
+            get => _optionProvider.IndentGuideDashSize;
+            set => _optionProvider.IndentGuideDashSize = value;
         }
 
         [Category("Syntax highlight")]
@@ -66,24 +64,24 @@ namespace VSRAD.Syntax.Options
         [Description("Space size between indent lines")]
         public double IndentGuideSpaceSize
         {
-            get => _generalOptionEventProvider.IndentGuideSpaceSize;
-            set => _generalOptionEventProvider.IndentGuideSpaceSize = value;
+            get => _optionProvider.IndentGuideSpaceSize;
+            set => _optionProvider.IndentGuideSpaceSize = value;
         }
 
         [Category("Syntax highlight")]
         [DisplayName("Indent guide line offset X")]
         public double IndentGuideOffsetX
         {
-            get => _generalOptionEventProvider.IndentGuideOffsetX;
-            set => _generalOptionEventProvider.IndentGuideOffsetX = value;
+            get => _optionProvider.IndentGuideOffsetX;
+            set => _optionProvider.IndentGuideOffsetX = value;
         }
 
         [Category("Syntax highlight")]
         [DisplayName("Indent guide line offset Y")]
         public double IndentGuideOffsetY
         {
-            get => _generalOptionEventProvider.IndentGuideOffsetY;
-            set => _generalOptionEventProvider.IndentGuideOffsetY = value;
+            get => _optionProvider.IndentGuideOffsetY;
+            set => _optionProvider.IndentGuideOffsetY = value;
         }
 #endif
 
@@ -92,8 +90,8 @@ namespace VSRAD.Syntax.Options
         [Description("List of file extensions for the asm1 syntax")]
         public string Asm1FileExtensions
         {
-            get => ConvertListTo(_generalOptionEventProvider.Asm1FileExtensions);
-            set => _generalOptionEventProvider.Asm1FileExtensions = ConvertListFrom(value);
+            get => ConvertListTo(_optionProvider.Asm1FileExtensions);
+            set => _optionProvider.Asm1FileExtensions = ConvertListFrom(value);
         }
 
         [Category("Syntax file extensions")]
@@ -101,8 +99,8 @@ namespace VSRAD.Syntax.Options
         [Description("List of file extensions for the asm2 syntax")]
         public string Asm2FileExtensions
         {
-            get => ConvertListTo(_generalOptionEventProvider.Asm2FileExtensions);
-            set => _generalOptionEventProvider.Asm2FileExtensions = ConvertListFrom(value);
+            get => ConvertListTo(_optionProvider.Asm2FileExtensions);
+            set => _optionProvider.Asm2FileExtensions = ConvertListFrom(value);
         }
 
         [Category("Syntax instruction folder paths")]
@@ -111,8 +109,8 @@ namespace VSRAD.Syntax.Options
         [Editor(typeof(FolderPathsEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string InstructionsPaths
         {
-            get => ConvertListTo(_generalOptionEventProvider.InstructionsPaths);
-            set => _generalOptionEventProvider.InstructionsPaths = ConvertListFrom(value);
+            get => ConvertListTo(_optionProvider.InstructionsPaths);
+            set => _optionProvider.InstructionsPaths = ConvertListFrom(value);
         }
 
         [Category("Intellisense")]
@@ -120,8 +118,8 @@ namespace VSRAD.Syntax.Options
         [Description("Autocomplete instructions")]
         public bool AutocompleteInstructions
         {
-            get => _generalOptionEventProvider.AutocompleteInstructions;
-            set => _generalOptionEventProvider.AutocompleteInstructions = value;
+            get => _optionProvider.AutocompleteInstructions;
+            set => _optionProvider.AutocompleteInstructions = value;
         }
 
         [Category("Intellisense")]
@@ -129,8 +127,8 @@ namespace VSRAD.Syntax.Options
         [Description("Autocomplete function name")]
         public bool AutocompleteFunctions
         {
-            get => _generalOptionEventProvider.AutocompleteFunctions;
-            set => _generalOptionEventProvider.AutocompleteFunctions = value;
+            get => _optionProvider.AutocompleteFunctions;
+            set => _optionProvider.AutocompleteFunctions = value;
         }
 
         [Category("Intellisense")]
@@ -138,8 +136,8 @@ namespace VSRAD.Syntax.Options
         [Description("Autocomplete labels")]
         public bool AutocompleteLabels
         {
-            get => _generalOptionEventProvider.AutocompleteLabels;
-            set => _generalOptionEventProvider.AutocompleteLabels = value;
+            get => _optionProvider.AutocompleteLabels;
+            set => _optionProvider.AutocompleteLabels = value;
         }
 
         [Category("Intellisense")]
@@ -147,16 +145,16 @@ namespace VSRAD.Syntax.Options
         [Description("Autocomplete global variables, local variables, function arguments")]
         public bool AutocompleteVariables
         {
-            get => _generalOptionEventProvider.AutocompleteVariables;
-            set => _generalOptionEventProvider.AutocompleteVariables = value;
+            get => _optionProvider.AutocompleteVariables;
+            set => _optionProvider.AutocompleteVariables = value;
         }
 
         [Category("Intellisense")]
         [DisplayName("Signature help")]
         public bool SignatureHelp
         {
-            get => _generalOptionEventProvider.SignatureHelp;
-            set => _generalOptionEventProvider.SignatureHelp = value;
+            get => _optionProvider.SignatureHelp;
+            set => _optionProvider.SignatureHelp = value;
         }
 
         public enum SortState
@@ -171,16 +169,15 @@ namespace VSRAD.Syntax.Options
             ByNameDescending = 4,
         }
 
-        // hack to avoid installation errors when reinstalling the extension
         public override void LoadSettingsFromStorage() =>
-            _model.Load();
+            _optionProvider.Load();
 
         public override void SaveSettingsToStorage() =>
-            _model.Save();
+            _optionProvider.Save();
 
         protected override void OnApply(PageApplyEventArgs e)
         {
-            if (!_model.Validate())
+            if (!_optionProvider.Validate())
                 e.ApplyBehavior = ApplyKind.Cancel;
 
             base.OnApply(e);

--- a/VSRAD.Syntax/Options/Instructions/InstructionListLoader.cs
+++ b/VSRAD.Syntax/Options/Instructions/InstructionListLoader.cs
@@ -43,9 +43,7 @@ namespace VSRAD.Syntax.Options.Instructions
             _sets = new Dictionary<string, IInstructionSet>(StringComparer.OrdinalIgnoreCase);
             _instructionSetPaths = new Dictionary<string, ITextDocument>(StringComparer.OrdinalIgnoreCase);
 
-            var optionProvider = GeneralOptionProvider.Instance;
-            optionProvider.OptionsUpdated += OptionsUpdated;
-            OptionsUpdated(optionProvider);
+            GeneralOptionProvider.Instance.OptionsUpdated += OptionsUpdated;
         }
 
         private void OptionsUpdated(GeneralOptionProvider provider)

--- a/VSRAD.Syntax/Package.cs
+++ b/VSRAD.Syntax/Package.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using VSRAD.Syntax.IntelliSense.Navigation.NavigationList;
 using System.ComponentModel.Design;
-using System.Threading.Tasks;
 using VSRAD.Syntax.Options.Instructions;
 
 namespace VSRAD.Syntax
@@ -30,9 +29,6 @@ namespace VSRAD.Syntax
         {
             Instance = this;
             await base.InitializeAsync(cancellationToken, progress);
-            var thread = new Thread(() => GeneralOptionModel.GetInstanceAsync());
-            thread.Start();
-
             var commandService = await GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
 
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();


### PR DESCRIPTION
Exception logs:
<details>
<summary>Log 1</summary>
<description>System.AggregateException: One or more errors occurred. ---&gt; System.Threading.Tasks.TaskCanceledException: Buffer changes have not yet been processed&#x000D;&#x000A;   at VSRAD.Syntax.Core.DocumentAnalysis.&lt;GetAnalysisResultAsync&gt;d__12.MoveNext() in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\Core\DocumentAnalysis.cs:line 38&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at VSRAD.Syntax.IntelliSense.NavigationTokenService.&lt;GetNavigationsAsync&gt;d__4.MoveNext() in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\IntelliSense\Navigation\NavigationTokenService.cs:line 47&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at VSRAD.Syntax.IntelliSense.QuickInfo.QuickInfoSource.&lt;GetQuickInfoItemAsync&gt;d__4.MoveNext() in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\IntelliSense\QuickInfo\QuickInfoSource.cs:line 29&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at Microsoft.VisualStudio.Language.Intellisense.Implementation.AsyncQuickInfoSession.&lt;ComputeSourceContentAsync&gt;d__39.MoveNext()&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at Microsoft.VisualStudio.Telemetry.WindowsErrorReporting.WatsonReport.GetClrWatsonExceptionInfo(Exception exceptionObject)&#x000D;&#x000A;   --- End of inner exception stack trace ---&#x000D;&#x000A;   at Microsoft.VisualStudio.Language.Intellisense.Implementation.AsyncQuickInfoSession.&lt;UpdateAsync&gt;d__32.MoveNext()&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at Microsoft.VisualStudio.Language.Intellisense.Implementation.AsyncQuickInfoPresentationSession.&lt;UpdateAsync&gt;d__5.MoveNext()&#x000D;&#x000A;---&gt; (Inner Exception #0) System.Threading.Tasks.TaskCanceledException: Buffer changes have not yet been processed&#x000D;&#x000A;   at VSRAD.Syntax.Core.DocumentAnalysis.&lt;GetAnalysisResultAsync&gt;d__12.MoveNext() in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\Core\DocumentAnalysis.cs:line 38&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at VSRAD.Syntax.IntelliSense.NavigationTokenService.&lt;GetNavigationsAsync&gt;d__4.MoveNext() in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\IntelliSense\Navigation\NavigationTokenService.cs:line 47&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at VSRAD.Syntax.IntelliSense.QuickInfo.QuickInfoSource.&lt;GetQuickInfoItemAsync&gt;d__4.MoveNext() in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\IntelliSense\QuickInfo\QuickInfoSource.cs:line 29&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at Microsoft.VisualStudio.Language.Intellisense.Implementation.AsyncQuickInfoSession.&lt;ComputeSourceContentAsync&gt;d__39.MoveNext()&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at Microsoft.VisualStudio.Telemetry.WindowsErrorReporting.WatsonReport.GetClrWatsonExceptionInfo(Exception exceptionObject)&lt;---&#x000D;&#x000A;</description>
</details>

<details>
<summary>Log 2</summary>
<description>System.AggregateException: One or more errors occurred. ---&gt; System.NullReferenceException: Object reference not set to an instance of an object.&#x000D;&#x000A;   at VSRAD.Syntax.IntelliSense.IntellisenseHelper.GetDescription(IDefinitionToken token) in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\IntelliSense\Helper.cs:line 20&#x000D;&#x000A;   at VSRAD.Syntax.IntelliSense.IntellisenseDescriptionBuilder.&lt;GetColorizedDescriptionAsync&gt;d__4.MoveNext() in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\IntelliSense\IntellisenseTokenDescription.cs:line 128&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at VSRAD.Syntax.IntelliSense.IntellisenseDescriptionBuilder.&lt;GetColorizedDescriptionAsync&gt;d__2.MoveNext() in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\IntelliSense\IntellisenseTokenDescription.cs:line 34&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at VSRAD.Syntax.IntelliSense.QuickInfo.QuickInfoSource.&lt;GetQuickInfoItemAsync&gt;d__4.MoveNext() in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\IntelliSense\QuickInfo\QuickInfoSource.cs:line 34&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at Microsoft.VisualStudio.Language.Intellisense.Implementation.AsyncQuickInfoSession.&lt;ComputeSourceContentAsync&gt;d__39.MoveNext()&#x000D;&#x000A;   --- End of inner exception stack trace ---&#x000D;&#x000A;   at Microsoft.VisualStudio.Language.Intellisense.Implementation.AsyncQuickInfoSession.&lt;UpdateAsync&gt;d__32.MoveNext()&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at Microsoft.VisualStudio.Language.Intellisense.Implementation.AsyncQuickInfoPresentationSession.&lt;UpdateAsync&gt;d__5.MoveNext()&#x000D;&#x000A;---&gt; (Inner Exception #0) System.NullReferenceException: Object reference not set to an instance of an object.&#x000D;&#x000A;   at VSRAD.Syntax.IntelliSense.IntellisenseHelper.GetDescription(IDefinitionToken token) in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\IntelliSense\Helper.cs:line 20&#x000D;&#x000A;   at VSRAD.Syntax.IntelliSense.IntellisenseDescriptionBuilder.&lt;GetColorizedDescriptionAsync&gt;d__4.MoveNext() in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\IntelliSense\IntellisenseTokenDescription.cs:line 128&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at VSRAD.Syntax.IntelliSense.IntellisenseDescriptionBuilder.&lt;GetColorizedDescriptionAsync&gt;d__2.MoveNext() in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\IntelliSense\IntellisenseTokenDescription.cs:line 34&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at VSRAD.Syntax.IntelliSense.QuickInfo.QuickInfoSource.&lt;GetQuickInfoItemAsync&gt;d__4.MoveNext() in D:\tmp\radeon-asm-debugger\VSRAD.Syntax\IntelliSense\QuickInfo\QuickInfoSource.cs:line 34&#x000D;&#x000A;--- End of stack trace from previous location where exception was thrown ---&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)&#x000D;&#x000A;   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)&#x000D;&#x000A;   at Microsoft.VisualStudio.Language.Intellisense.Implementation.AsyncQuickInfoSession.&lt;ComputeSourceContentAsync&gt;d__39.MoveNext()&lt;---&#x000D;&#x000A;</description>
</details>