### PR TITLE
Speed up text output parsing by ~10x

### DIFF
--- a/VSRAD.DebugServer/SharedUtils/TextDebuggerOutputParser.cs
+++ b/VSRAD.DebugServer/SharedUtils/TextDebuggerOutputParser.cs
@@ -1,41 +1,85 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
 
 namespace VSRAD.DebugServer.SharedUtils
 {
     public static class TextDebuggerOutputParser
     {
-        public static async Task<byte[]> ReadTextOutputAsync(Stream stream, int offsetBeforeData, int dataOffset = 0, int byteCount = 0)
+        public static List<uint> ReadTextOutput(string filePath, int lineOffset, int lineCount = 0)
         {
-            if (byteCount == 0)
-                byteCount = int.MaxValue; // We'll break out of the read loop upon encountering EOF
-
-            using (var reader = new StreamReader(stream))
+            sbyte[] hexDigitLookup = new sbyte[256];
+            for (int i = 0; i < 256; ++i)
             {
-                for (int i = 0; i < offsetBeforeData; i++)
-                    await reader.ReadLineAsync();
+                if (i >= '0' && i <= '9')
+                    hexDigitLookup[i] = (sbyte)(i - '0');
+                else if (i >= 'A' && i <= 'F')
+                    hexDigitLookup[i] = (sbyte)(i - 'A' + 10);
+                else if (i >= 'a' && i <= 'f')
+                    hexDigitLookup[i] = (sbyte)(i - 'a' + 10);
+                else
+                    hexDigitLookup[i] = -1;
+            }
+
+            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, 16384, FileOptions.SequentialScan))
+            {
+                if (lineCount == 0)
+                    lineCount = int.MaxValue; // Read until EOF
 
                 var values = new List<uint>();
-                var offset = (dataOffset % 4 == 0)
-                    ? dataOffset
-                    : dataOffset - (4 - dataOffset % 4);
-                var read = 0;
-                for (; read < offset + byteCount; read += 4)
+
+                byte[] buffer = new byte[16384];
+                int bytesRead;
+
+                bool scannedCr = false, scanningValue = false;
+                uint value = 0;
+
+                while ((bytesRead = stream.Read(buffer, 0, buffer.Length)) > 0)
                 {
-                    string line = await reader.ReadLineAsync();
-                    if (string.IsNullOrEmpty(line))
-                        break;
-                    if (read < offset)
-                        continue;
-                    if (uint.TryParse(line.Replace("0x", ""), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var hex))
-                        values.Add(hex);
+                    for (int i = 0; i < bytesRead; ++i)
+                    {
+                        if (scannedCr && buffer[i] == '\n') // Consume crlf (\r\n)
+                        {
+                            scannedCr = false;
+                            continue;
+                        }
+
+                        scannedCr = buffer[i] == '\r';
+                        bool scannedNewline = scannedCr || buffer[i] == '\n';
+
+                        if (lineOffset > 0)
+                        {
+                            if (scannedNewline)
+                                lineOffset--;
+                            continue;
+                        }
+
+                        if (scannedNewline)
+                        {
+                            if (scanningValue)
+                            {
+                                values.Add(value);
+                                value = 0;
+                                scanningValue = false;
+
+                                if (values.Count >= lineCount)
+                                    return values;
+                            }
+                            continue;
+                        }
+
+                        sbyte digit = hexDigitLookup[buffer[i]];
+                        if (digit >= 0)
+                        {
+                            scanningValue = true;
+                            value = value * 16 + (uint)digit;
+                        }
+                    }
                 }
-                byte[] data = new byte[values.Count * 4];
-                Buffer.BlockCopy(values.ToArray(), 0, data, 0, data.Length);
-                return data;
+
+                if (scanningValue)
+                    values.Add(value);
+
+                return values;
             }
         }
     }

--- a/VSRAD.DebugServer/SharedUtils/TextDebuggerOutputParser.cs
+++ b/VSRAD.DebugServer/SharedUtils/TextDebuggerOutputParser.cs
@@ -5,10 +5,16 @@ namespace VSRAD.DebugServer.SharedUtils
 {
     public static class TextDebuggerOutputParser
     {
+        // Amount of bytes to buffer while reading the file
+        // (In microbenchmarks for ReadTextOutput, smaller buffer sizes lead to a small slowdown, while larger buffer sizes don't seem to measurably improve performance)
+        private const int _readBufferSize = 16384;
+
+        private const int _charsInByte = 256;
+
         public static List<uint> ReadTextOutput(string filePath, int lineOffset, int lineCount = 0)
         {
-            sbyte[] hexDigitLookup = new sbyte[256];
-            for (int i = 0; i < 256; ++i)
+            sbyte[] hexDigitLookup = new sbyte[_charsInByte];
+            for (int i = 0; i < _charsInByte; ++i)
             {
                 if (i >= '0' && i <= '9')
                     hexDigitLookup[i] = (sbyte)(i - '0');
@@ -20,14 +26,14 @@ namespace VSRAD.DebugServer.SharedUtils
                     hexDigitLookup[i] = -1;
             }
 
-            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, 16384, FileOptions.SequentialScan))
+            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, _readBufferSize, FileOptions.SequentialScan))
             {
                 if (lineCount == 0)
                     lineCount = int.MaxValue; // Read until EOF
 
                 var values = new List<uint>();
 
-                byte[] buffer = new byte[16384];
+                byte[] buffer = new byte[_readBufferSize];
                 int bytesRead;
 
                 bool scannedCr = false, scanningValue = false;

--- a/VSRAD.Package/Server/BreakStateData.cs
+++ b/VSRAD.Package/Server/BreakStateData.cs
@@ -129,19 +129,24 @@ namespace VSRAD.Package.Server
         private readonly bool _localData;
         private BitArray _fetchedDataWaves; // 1 bit per wavefront data
 
-        public BreakStateData(ReadOnlyCollection<string> watches, BreakStateOutputFile file, byte[] localData = null)
+        public BreakStateData(ReadOnlyCollection<string> watches, BreakStateOutputFile file, uint[] localData = null)
         {
             Watches = watches;
             _outputFile = file;
             _laneDataSize = 1 /* system */ + watches.Count;
 
-            _data = new uint[file.DwordCount];
             _localData = localData != null;
             if (_localData)
             {
                 if (file.Offset != 0)
-                    throw new ArgumentException("Trim the offset before passing output data to BreakStateData");
-                Buffer.BlockCopy(localData, file.Offset, _data, 0, file.DwordCount * 4);
+                    throw new ArgumentException("Trim the offset before passing local output data to BreakStateData");
+                if (localData.Length != file.DwordCount)
+                    throw new ArgumentException("Local output data size must match file size");
+                _data = localData;
+            }
+            else
+            {
+                _data = new uint[file.DwordCount];
             }
         }
 

--- a/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using VSRAD.Package.DebugVisualizer;
@@ -13,10 +12,8 @@ namespace VSRAD.PackageTests.DebugVisualizer
     {
         private WatchView GetSystemView(uint[] system, int groupSize, int waveSize, int groupIndex = 0)
         {
-            byte[] systemBytes = new byte[system.Length * 4];
-            Buffer.BlockCopy(system, 0, systemBytes, 0, systemBytes.Length);
             var data = new BreakStateData(new ReadOnlyCollection<string>(new List<string>()),
-                new BreakStateOutputFile("", false, 0, default, dwordCount: system.Length), systemBytes);
+                new BreakStateOutputFile("", false, 0, default, dwordCount: system.Length), system);
             _ = data.ChangeGroupWithWarningsAsync(null, groupIndex: groupIndex, groupSize: groupSize, waveSize: waveSize, nGroups: 0).Result;
             var view = data.GetSystem();
             Assert.NotNull(view);

--- a/VSRAD.PackageTests/Server/BreakStateTests.cs
+++ b/VSRAD.PackageTests/Server/BreakStateTests.cs
@@ -196,19 +196,16 @@ namespace VSRAD.PackageTests.Server
         [Fact]
         public async Task BreakStateWithLocalDataTestAsync()
         {
-            var data = new int[2 * 256];
-            for (int i = 0; i < 256; ++i)
+            var data = new uint[2 * 256];
+            for (uint i = 0; i < 256; ++i)
             {
                 data[2 * i + 0] = i; // system = global id
                 data[2 * i + 1] = i % 32; // first watch = local id
             }
 
-            var localData = new byte[2 * 256 * sizeof(int)];
-            Buffer.BlockCopy(data, 0, localData, 0, localData.Length);
-
             var watches = new ReadOnlyCollection<string>(new[] { "local_id" });
             var file = new BreakStateOutputFile("/home/kyubey/projects/madoka", binaryOutput: true, offset: 0, timestamp: default, dwordCount: 2 * 256);
-            var breakStateData = new BreakStateData(watches, file, localData);
+            var breakStateData = new BreakStateData(watches, file, data);
 
             var warning = await breakStateData.ChangeGroupWithWarningsAsync(channel: null, groupIndex: 1, groupSize: 64, waveSize: 32, nGroups: 2);
             Assert.Null(warning);


### PR DESCRIPTION
See the commit message for a detailed description of the new approach. The difference in speed is quite noticeable: 230-270 ms with the old code, 22-23 ms with the new version, as tested on an FX-8120 machine with a typical output file (~2MB).