### PR TITLE
IntelliSense fixes

### DIFF
--- a/VSRAD.Syntax/IntelliSense/Completion/Providers/FunctionCompletionProvider.cs
+++ b/VSRAD.Syntax/IntelliSense/Completion/Providers/FunctionCompletionProvider.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.Text;
+﻿using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Adornments;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,7 +11,7 @@ namespace VSRAD.Syntax.IntelliSense.Completion.Providers
 {
     internal class FunctionCompletionProvider : RadCompletionProvider
     {
-        private static readonly ImageElement FunctionIcon = GetImageElement(KnownImageIds.Method);
+        private static readonly ImageElement Icon = RadAsmTokenType.FunctionName.GetImageElement();
         private bool _autocompleteFunctions;
         private readonly INavigationTokenService _navigationTokenService;
 
@@ -35,10 +34,10 @@ namespace VSRAD.Syntax.IntelliSense.Completion.Providers
             var completionItems = analysisResult.Root.Tokens
                 .AsParallel()
                 .WithCancellation(cancellationToken)
-                .Where(t => t.Type == Core.Tokens.RadAsmTokenType.FunctionName)
+                .Where(t => t.Type == RadAsmTokenType.FunctionName)
                 .Cast<IDefinitionToken>()
                 .Select(t => _navigationTokenService.CreateToken(t, document))
-                .Select(t => new CompletionItem(t, FunctionIcon));
+                .Select(t => new CompletionItem(t, Icon));
 
             return new RadCompletionContext(completionItems.ToList());
         }

--- a/VSRAD.Syntax/IntelliSense/Completion/Providers/InstructionCompletionProvider.cs
+++ b/VSRAD.Syntax/IntelliSense/Completion/Providers/InstructionCompletionProvider.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.Text;
+﻿using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Adornments;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,12 +8,13 @@ using VSRAD.Syntax.Core;
 using VSRAD.Syntax.Options.Instructions;
 using VSRAD.Syntax.Helpers;
 using System.Threading;
+using VSRAD.Syntax.Core.Tokens;
 
 namespace VSRAD.Syntax.IntelliSense.Completion.Providers
 {
     internal class InstructionCompletionProvider : RadCompletionProvider
     {
-        private static readonly ImageElement Icon = GetImageElement(KnownImageIds.Assembly);
+        private static readonly ImageElement Icon = RadAsmTokenType.Instruction.GetImageElement();
         private bool _autocomplete;
         private readonly List<InstructionCompletionItem> _asm1InstructionCompletions;
         private readonly List<InstructionCompletionItem> _asm2InstructionCompletions;

--- a/VSRAD.Syntax/IntelliSense/Completion/Providers/RadCompletionProvider.cs
+++ b/VSRAD.Syntax/IntelliSense/Completion/Providers/RadCompletionProvider.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.VisualStudio.Core.Imaging;
-using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Adornments;
-using System;
+﻿using Microsoft.VisualStudio.Text;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using VSRAD.Syntax.Options;
@@ -23,7 +20,7 @@ namespace VSRAD.Syntax.IntelliSense.Completion.Providers
 
     internal abstract class RadCompletionProvider
     {
-        public RadCompletionProvider(GeneralOptionProvider generalOptionProvider)
+        protected RadCompletionProvider(GeneralOptionProvider generalOptionProvider)
         {
             generalOptionProvider.OptionsUpdated += DisplayOptionsUpdated;
         }
@@ -31,10 +28,5 @@ namespace VSRAD.Syntax.IntelliSense.Completion.Providers
         public abstract Task<RadCompletionContext> GetContextAsync(IDocument document, SnapshotPoint triggerLocation, SnapshotSpan applicableToSpan, CancellationToken cancellationToken);
 
         public abstract void DisplayOptionsUpdated(GeneralOptionProvider sender);
-
-        public static ImageElement GetImageElement(int imageId) =>
-            new ImageElement(new ImageId(ImageCatalogGuid, imageId));
-
-        private static readonly Guid ImageCatalogGuid = Guid.Parse(/* image catalog guid */ "ae27a6b0-e345-4288-96df-5eaf394ee369");
     }
 }

--- a/VSRAD.Syntax/IntelliSense/Completion/Providers/ScopedCompletionProvider.cs
+++ b/VSRAD.Syntax/IntelliSense/Completion/Providers/ScopedCompletionProvider.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.Text;
+﻿using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Adornments;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,10 +12,9 @@ namespace VSRAD.Syntax.IntelliSense.Completion.Providers
 {
     internal class ScopedCompletionProvider : RadCompletionProvider
     {
-        private static readonly ImageElement LabelIcon = GetImageElement(KnownImageIds.Label);
-        private static readonly ImageElement GlobalVariableIcon = GetImageElement(KnownImageIds.GlobalVariable);
-        private static readonly ImageElement LocalVariableIcon = GetImageElement(KnownImageIds.LocalVariable);
-        private static readonly ImageElement ArgumentIcon = GetImageElement(KnownImageIds.Parameter);
+        private static readonly ImageElement LabelIcon = RadAsmTokenType.Label.GetImageElement();
+        private static readonly ImageElement GlobalVariableIcon = RadAsmTokenType.GlobalVariable.GetImageElement();
+        private static readonly ImageElement LocalVariableIcon = RadAsmTokenType.LocalVariable.GetImageElement();
         private readonly INavigationTokenService _navigationTokenService;
 
         private bool _autocompleteLabels;
@@ -60,7 +58,7 @@ namespace VSRAD.Syntax.IntelliSense.Completion.Providers
 
                     if (_autocompleteLabels && token.Type == RadAsmTokenType.Label)
                     {
-                        yield return CreateCompletionItem(token, LabelIcon); break;
+                        yield return CreateCompletionItem(token, LabelIcon);
                     }
                     else if (_autocompleteVariables)
                     {
@@ -69,9 +67,8 @@ namespace VSRAD.Syntax.IntelliSense.Completion.Providers
                             case RadAsmTokenType.GlobalVariable:
                                 yield return CreateCompletionItem(token, GlobalVariableIcon); break;
                             case RadAsmTokenType.LocalVariable:
-                                yield return CreateCompletionItem(token, LocalVariableIcon); break;
                             case RadAsmTokenType.FunctionParameter:
-                                yield return CreateCompletionItem(token, ArgumentIcon); break;
+                                yield return CreateCompletionItem(token, LocalVariableIcon); break;
                         }
                     }
                 }

--- a/VSRAD.Syntax/IntelliSense/Helper.cs
+++ b/VSRAD.Syntax/IntelliSense/Helper.cs
@@ -1,8 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.Core.Imaging;
+using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Adornments;
 using VSRAD.Syntax.Core;
 using VSRAD.Syntax.Core.Tokens;
 using VSRAD.Syntax.Helpers;
@@ -115,5 +119,43 @@ namespace VSRAD.Syntax.IntelliSense
             var comment = text.Trim('/', '*', ' ', '\t', '\r', '\n', '\f');
             return Regex.Replace(comment, @"(?<=\n)\s*(\*|\/\/)", "", RegexOptions.Compiled);
         }
+    }
+
+    internal static class TokenTypeExtension
+    {
+        public static ImageElement GetImageElement(this RadAsmTokenType type) =>
+            new ImageElement(GetImageId(type));
+
+        private static ImageId GetImageId(RadAsmTokenType type)
+        {
+            switch (type)
+            {
+                case RadAsmTokenType.FunctionName:
+                case RadAsmTokenType.FunctionReference:
+                    return new ImageId(ImageCatalogGuid, KnownImageIds.MethodPublic);
+
+                case RadAsmTokenType.FunctionParameter:
+                case RadAsmTokenType.FunctionParameterReference:
+                case RadAsmTokenType.LocalVariable:
+                case RadAsmTokenType.LocalVariableReference:
+                    return new ImageId(ImageCatalogGuid, KnownImageIds.LocalVariable);
+
+                case RadAsmTokenType.GlobalVariable:
+                case RadAsmTokenType.GlobalVariableReference:
+                    return new ImageId(ImageCatalogGuid, KnownImageIds.ConstantPublic);
+
+                case RadAsmTokenType.Label:
+                case RadAsmTokenType.LabelReference:
+                    return new ImageId(ImageCatalogGuid, KnownImageIds.Label);
+
+                case RadAsmTokenType.Instruction:
+                    return new ImageId(ImageCatalogGuid, KnownImageIds.Assembly);
+
+                default:
+                    throw new ArgumentException("Invalid RadAsmTokenType");
+            }
+        }
+
+        private static readonly Guid ImageCatalogGuid = Guid.Parse(/* image catalog guid */ "ae27a6b0-e345-4288-96df-5eaf394ee369");
     }
 }

--- a/VSRAD.Syntax/IntelliSense/IntellisenseTokenDescription.cs
+++ b/VSRAD.Syntax/IntelliSense/IntellisenseTokenDescription.cs
@@ -82,6 +82,7 @@ namespace VSRAD.Syntax.IntelliSense
             var snapshot = document.CurrentSnapshot;
 
             var builder = new ClassifiedTextBuilder();
+            builder.AddTokenIcon(token);
 
             if (token.Type == RadAsmTokenType.Instruction)
             {
@@ -141,21 +142,32 @@ namespace VSRAD.Syntax.IntelliSense
         public class ClassifiedTextBuilder
         {
             private readonly LinkedList<ClassifiedTextRun> _classifiedTextRuns;
-            private readonly LinkedList<ClassifiedTextElement> _classifiedTextElements;
+            private readonly LinkedList<object> _classifiedTextElements;
+            private readonly LinkedList<object> _containerElements;
 
             public ClassifiedTextBuilder()
             {
                 _classifiedTextRuns = new LinkedList<ClassifiedTextRun>();
-                _classifiedTextElements = new LinkedList<ClassifiedTextElement>();
+                _containerElements = new LinkedList<object>();
+                _classifiedTextElements = new LinkedList<object>();
             }
 
             public ContainerElement Build() =>
-                new ContainerElement(ContainerElementStyle.Stacked, _classifiedTextElements);
+                new ContainerElement(ContainerElementStyle.Stacked, _containerElements);
 
             public ClassifiedTextBuilder SetAsElement()
             {
                 _classifiedTextElements.AddLast(new ClassifiedTextElement(_classifiedTextRuns));
+                _containerElements.AddLast(new ContainerElement(ContainerElementStyle.Wrapped, _classifiedTextElements));
+
+                _classifiedTextElements.Clear();
                 _classifiedTextRuns.Clear();
+                return this;
+            }
+
+            public ClassifiedTextBuilder AddTokenIcon(INavigationToken navigationToken)
+            {
+                _classifiedTextElements.AddLast(navigationToken.Type.GetImageElement());
                 return this;
             }
 

--- a/VSRAD.Syntax/Options/GeneralOptionModel.cs
+++ b/VSRAD.Syntax/Options/GeneralOptionModel.cs
@@ -77,9 +77,10 @@ namespace VSRAD.Syntax.Options
             var settingsStore = manager.GetWritableSettingsStore(SettingsScope.UserSettings);
 
             if (settingsStore.CollectionExists(CollectionName))
-            {
                 settingsStore.DeleteCollection(CollectionName);
-            }
+
+            if (settingsStore.CollectionExists(InstructionCollectionName))
+                settingsStore.DeleteCollection(InstructionCollectionName);
         }
 
         /// <summary>


### PR DESCRIPTION
- Fixed autocomplete trigger when writing function signature and variable declaration. Now it will not trigger after `.macro` `.set` asm1 keywords and `function` `var` asm2 keywords.
- IntelliSense icons changed. Added icons in the Quick Info popup (see the picture below).

![image](https://user-images.githubusercontent.com/40007198/118497477-c74c2680-b72d-11eb-803f-26e1d1f0108d.png)
