### PR TITLE
Fix syntax highlighting "disappearing" when the file is reloaded

### DIFF
--- a/VSRAD.Syntax/Core/DocumentTokenizer.cs
+++ b/VSRAD.Syntax/Core/DocumentTokenizer.cs
@@ -73,9 +73,17 @@ namespace VSRAD.Syntax.Core
             try
             {
                 // in some cases the text buffer may cause ContentChanged with 0 changes
-                if (args.Changes.Count == 0) return;
-
-                ApplyTextChange(args.Before, args.After, new JoinedTextChange(args.Changes), ct);
+                // CurrentSnapshot and CurrentResult still need to be updated because the snapshot version is incremented
+                // (otherwise the snapshot in IAnalysisResult won't match the snapshot VS provides to IClassifier)
+                if (args.Changes.Count == 0)
+                {
+                    CurrentSnapshot = args.After;
+                    RaiseTokensChanged(updated: new List<TrackingToken>(), ct);
+                }
+                else
+                {
+                    ApplyTextChange(args.Before, args.After, new JoinedTextChange(args.Changes), ct);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
As noted in the code, sometimes `ContentChanged` is raised when there are no changes to the buffer snapshot. This usually happens when the file is reloaded from disk but the content is unchanged (e.g. when using Disassemble/Preprocess actions from VSRAD.Package). The snapshot version in this case, however, gets incremented, so when `AnalysisClassifier.GetClassificationSpans` is called later, the early return condition (`analysisResult.Snapshot != span.Snapshot`) triggers, and the highlighting is no longer shown in the editor.