### PR TITLE
Syntax: fix ArgumentOutOfRangeException in function parameter autocompletion

### DIFF
--- a/VSRAD.Syntax/IntelliSense/SignatureHelp/Signature.cs
+++ b/VSRAD.Syntax/IntelliSense/SignatureHelp/Signature.cs
@@ -35,7 +35,7 @@ namespace VSRAD.Syntax.IntelliSense.SignatureHelp
 
         public void SetCurrentParameter(int idx)
         {
-            if (_parameters == null) return;
+            if (_parameters == null || _parameters.Count == 0) return;
 
             var newValue = idx < _parameters.Count 
                 ? _parameters[idx]


### PR DESCRIPTION
Steps to reproduce:
1. Enable IntelliSense support in _RadeonAsm Options_
1. Define a parameterless function (asm2)
2. Start typing an invocation of this function
3. When the opening brace is reached, `FunctionSignature.Initialize` calls `SetCurrentParameter(0)`, which causes this exception because the parameter list is empty