### PR TITLE
Open in Editor preserving active document rollback

### DIFF
--- a/VSRAD.Package/Utils/VsEditor.cs
+++ b/VSRAD.Package/Utils/VsEditor.cs
@@ -67,7 +67,7 @@ namespace VSRAD.Package.Utils
                     activeView.SetCaretPos(lineNumber, 0);
                 }
 
-                dte.ItemOperations.OpenFile(activeFile.FullName); // preserving old active document
+                //dte.ItemOperations.OpenFile(activeFile.FullName); // preserving old active document
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This PR changes Open in Editor step so the focus will always be on opened file (as it was before #201).