### PR TITLE
'assigned' asm2 keyword

### DIFF
--- a/VSRAD.Syntax/Core/Lexer/Asm2Lexer.cs
+++ b/VSRAD.Syntax/Core/Lexer/Asm2Lexer.cs
@@ -78,6 +78,7 @@ namespace VSRAD.Syntax.Core.Lexer
             { RadAsm2Lexer.TGID_Z_EN, RadAsmTokenType.Keyword },
             { RadAsm2Lexer.ALLOC_LDS, RadAsmTokenType.Keyword },
             { RadAsm2Lexer.WAVE_SIZE, RadAsmTokenType.Keyword },
+            { RadAsm2Lexer.ASSIGNED, RadAsmTokenType.Keyword },
 
             { RadAsm2Lexer.VAR, RadAsmTokenType.Keyword },
             { RadAsm2Lexer.RETURN, RadAsmTokenType.Keyword },

--- a/VSRAD.SyntaxParser/RadAsm2.g4
+++ b/VSRAD.SyntaxParser/RadAsm2.g4
@@ -30,6 +30,7 @@ TGID_Y_EN   : 'tgid_y_en' ;
 TGID_Z_EN   : 'tgid_z_en' ;
 ALLOC_LDS   : 'alloc_lds' ;
 WAVE_SIZE   : 'wave_size' ;
+ASSIGNED    : 'assigned' ;
 
 VAR         : 'var' ;
 RETURN      : 'return' ;


### PR DESCRIPTION
This PR adds `assigned` keyword for asm2 syntax