### PR TITLE
Expand asm2 syntax keywords

### DIFF
--- a/VSRAD.Syntax/Core/Lexer/Asm2Lexer.cs
+++ b/VSRAD.Syntax/Core/Lexer/Asm2Lexer.cs
@@ -78,6 +78,9 @@ namespace VSRAD.Syntax.Core.Lexer
             { RadAsm2Lexer.TGID_Z_EN, RadAsmTokenType.Keyword },
             { RadAsm2Lexer.ALLOC_LDS, RadAsmTokenType.Keyword },
             { RadAsm2Lexer.WAVE_SIZE, RadAsmTokenType.Keyword },
+            { RadAsm2Lexer.ASSIGNED, RadAsmTokenType.Keyword },
+            { RadAsm2Lexer.LABEL, RadAsmTokenType.Keyword },
+            { RadAsm2Lexer.PRINT, RadAsmTokenType.Keyword },
 
             { RadAsm2Lexer.VAR, RadAsmTokenType.Keyword },
             { RadAsm2Lexer.RETURN, RadAsmTokenType.Keyword },

--- a/VSRAD.SyntaxParser/RadAsm2.g4
+++ b/VSRAD.SyntaxParser/RadAsm2.g4
@@ -30,6 +30,9 @@ TGID_Y_EN   : 'tgid_y_en' ;
 TGID_Z_EN   : 'tgid_z_en' ;
 ALLOC_LDS   : 'alloc_lds' ;
 WAVE_SIZE   : 'wave_size' ;
+ASSIGNED    : 'assigned' ;
+LABEL       : 'label' ;
+PRINT       : 'print' ;
 
 VAR         : 'var' ;
 RETURN      : 'return' ;


### PR DESCRIPTION
This PR adds `assigned`, `label` and `print` keywords to the asm2 syntax.
They are highlighted in the text with a default color for keywords.