### PR TITLE
Fix intellisense autocomplete

### DIFF
--- a/VSRAD.Syntax/IntelliSense/Completion/CompletionSource.cs
+++ b/VSRAD.Syntax/IntelliSense/Completion/CompletionSource.cs
@@ -70,9 +70,9 @@ namespace VSRAD.Syntax.IntelliSense.Completion
 
         private bool ShouldTriggerCompletion(CompletionTrigger trigger, SnapshotPoint triggerLocation)
         {
-            // if trigger position is in the beginning or the end of file
+            // if triggered position is at the beginning of the text
             // then completion should not trigger
-            if (triggerLocation < 3 || triggerLocation == triggerLocation.Snapshot.Length)
+            if (triggerLocation < 3)
                 return false;
 
             if (trigger.Reason == CompletionTriggerReason.Insertion &&

--- a/VSRAD.Syntax/IntelliSense/Completion/TokenizerExtension.cs
+++ b/VSRAD.Syntax/IntelliSense/Completion/TokenizerExtension.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using VSRAD.Syntax.Core;
+using VSRAD.Syntax.Helpers;
+using VSRAD.SyntaxParser;
+
+namespace VSRAD.Syntax.IntelliSense.Completion
+{
+    internal static class TokenizerExtension
+    {
+        public static bool IsDismissToken(this IDocumentTokenizer documentTokenizer, int tokenId)
+        {
+            if (documentTokenizer.CurrentResult == null)
+                return false;
+
+            var asmType = documentTokenizer.CurrentResult.Snapshot.GetAsmType();
+            return _dismissToken[asmType].Contains(tokenId);
+        }
+
+        private static readonly Dictionary<AsmType, ISet<int>> _dismissToken = new Dictionary<AsmType, ISet<int>>()
+        {
+            {
+                AsmType.RadAsm,
+                new HashSet<int>
+                {
+                    RadAsmLexer.MACRO,
+                    RadAsmLexer.SET
+                }
+            },
+            {
+                AsmType.RadAsm2,
+                new HashSet<int>
+                {
+                    RadAsm2Lexer.FUNCTION,
+                    RadAsm2Lexer.VAR
+                }
+            },
+            {
+                AsmType.RadAsmDoc,
+                new HashSet<int>
+                {
+                    RadAsmDocLexer.LET
+                }
+            }
+        };
+    }
+}

--- a/VSRAD.Syntax/VSRAD.Syntax.csproj
+++ b/VSRAD.Syntax/VSRAD.Syntax.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Helpers\Utils.cs" />
     <Compile Include="IntelliSense\Completion\ItemManager.cs" />
     <Compile Include="IntelliSense\Completion\ItemManagerProvider.cs" />
+    <Compile Include="IntelliSense\Completion\TokenizerExtension.cs" />
     <Compile Include="IntelliSense\Completion\Providers\CompletionItem.cs" />
     <Compile Include="IntelliSense\Completion\Providers\RadCompletionProvider.cs" />
     <Compile Include="IntelliSense\Completion\Providers\FunctionCompletionProvider.cs" />


### PR DESCRIPTION
This PR fixes autocomplete trigger behavior. Now autocomplete will not trigger with **function** and **variable** declaration such as:
```
                                     
.macro someMacro
                ^ 
    not triggered at this position
.endm


.set someVariable
                 ^
    not triggered at this position
```