### PR TITLE
Open in Editor: Tab groups handling

### DIFF
--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -59,6 +59,14 @@ namespace VSRAD.Package.Options
         private BreakMode _breakMode;
         public BreakMode BreakMode { get => _breakMode; set => SetField(ref _breakMode, value); }
 
+        [DefaultValue(true)]
+        private bool _forceOppositeTab;
+        public bool ForceOppositeTab { get => _forceOppositeTab; set => SetField(ref _forceOppositeTab, value); }
+
+        [DefaultValue(false)]
+        private bool _preserveActiveDoc;
+        public bool PreserveActiveDoc { get => _preserveActiveDoc; set => SetField(ref _preserveActiveDoc, value); }
+
         public DebuggerOptions() { }
         public DebuggerOptions(List<Watch> watches) => Watches = watches;
 

--- a/VSRAD.Package/ProjectSystem/ActionLauncher.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLauncher.cs
@@ -248,7 +248,8 @@ namespace VSRAD.Package.ProjectSystem
         async Task IActionRunController.OpenFileInVsEditorAsync(string path, string lineMarker)
         {
             await VSPackage.TaskFactory.SwitchToMainThreadAsync();
-            VsEditor.OpenFileInEditor(_serviceProvider, path, lineMarker);
+            VsEditor.OpenFileInEditor(_serviceProvider, path, lineMarker,
+                _project.Options.DebuggerOptions.ForceOppositeTab, _project.Options.DebuggerOptions.PreserveActiveDoc);
         }
     }
 }

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -126,6 +126,14 @@
                         </ComboBox.ItemTemplate>
                     </ComboBox>
                 </StackPanel>
+                <StackPanel Orientation="Horizontal" Height="25">
+                    <CheckBox Content="Open in Editor: Force new document to be opened in the opposite tab" VerticalAlignment="Center" Padding="4,0,0,0"
+                                IsChecked="{Binding Options.DebuggerOptions.ForceOppositeTab, UpdateSourceTrigger=PropertyChanged}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Height="25">
+                    <CheckBox Content="Open in Editor: Preserve active document" VerticalAlignment="Center" Padding="4,0,0,0"
+                                IsChecked="{Binding Options.DebuggerOptions.PreserveActiveDoc, UpdateSourceTrigger=PropertyChanged}"/>
+                </StackPanel>
                 <Expander Header="Visualizer Appearance" Margin="0,8,0,0">
                     <StackPanel Margin="0,6,0,0">
                         <StackPanel Orientation="Horizontal" Height="25">

--- a/VSRAD.Package/Utils/VsEditor.cs
+++ b/VSRAD.Package/Utils/VsEditor.cs
@@ -1,10 +1,13 @@
 ﻿using EnvDTE;
 using Microsoft;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.IO;
+using System.Reflection;
 
 namespace VSRAD.Package.Utils
 {
@@ -46,64 +49,38 @@ namespace VSRAD.Package.Utils
             return markers;
         }
 
-        public static void OpenFileInEditor(SVsServiceProvider serviceProvider, string path, string lineMarker,
-            bool forceOppositeTab, bool preserveActiveDoc)
+        private static readonly Type _sVsWindowManagerType = Type.GetType("Microsoft.Internal.VisualStudio.Shell.Interop.SVsWindowManager, Microsoft.VisualStudio.Platform.WindowManagement");
+        private static readonly Type _viewManagerType = Type.GetType("Microsoft.VisualStudio.PlatformUI.Shell.ViewManager, Microsoft.VisualStudio.Shell.ViewManager");
+        private static readonly Type _viewDockOperationsType = Type.GetType("Microsoft.VisualStudio.PlatformUI.Shell.DockOperations, Microsoft.VisualStudio.Shell.ViewManager");
+
+        public static void OpenFileInEditor(SVsServiceProvider serviceProvider, string path, string lineMarker, bool forceOppositeTab, bool preserveActiveDoc)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             try
             {
-                var dte = serviceProvider.GetService(typeof(DTE)) as DTE;
-                Assumes.Present(dte);
+                var vsRunningDocumentTable = serviceProvider.GetService(typeof(SVsRunningDocumentTable)) as IVsRunningDocumentTable;
+                var vsUIShellOpenDocument = serviceProvider.GetService(typeof(SVsUIShellOpenDocument)) as IVsUIShellOpenDocument;
+                Assumes.Present(vsRunningDocumentTable);
+                Assumes.Present(vsUIShellOpenDocument);
 
-                // HACK: VS have some issues with saving focus
-                // on the initial active doc after execution of
-                // commands, that manipulate with tab groups.
-                // However, toggling pin state of active tab
-                // seems to solve this problem.
+                IVsWindowFrame newDocumentFrame;
+                var windowManager = serviceProvider.GetService(_sVsWindowManagerType);
+                Assumes.Present(windowManager);
+                // Using GetType() because _sVsWindowManagerType is just an interface; ActiveDocumentFrame is present only in the actual implementation class
+                dynamic originalDocumentFrame = windowManager.GetType().GetProperty("ActiveDocumentFrame", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(windowManager);
+
+                ErrorHandler.ThrowOnFailure(vsUIShellOpenDocument.OpenDocumentViaProject(path, Guid.Empty, out _, out _, out _, out newDocumentFrame));
+
+                if (forceOppositeTab)
+                    MoveToOppositeTab(newDocumentFrame, originalDocumentFrame, preserveActiveDoc);
+
                 if (preserveActiveDoc)
-                {
-                    dte.ExecuteCommand("Window.PinTab");
-                    dte.ExecuteCommand("Window.PinTab");
-                }
-
-                var orgNext = dte.Commands.Item("Window.MovetoNextTabGroup").IsAvailable;
-                var orgPrev = dte.Commands.Item("Window.MovetoPreviousTabGroup").IsAvailable;
-
-                var orgActiveFile = dte.ActiveDocument;
-
-                if (orgActiveFile.FullName != path)
-                {
-                    dte.ExecuteCommand("File.OpenFile", path);
-                    if (forceOppositeTab)
-                    {
-                        var curNext = dte.Commands.Item("Window.MovetoNextTabGroup").IsAvailable;
-                        var curPrev = dte.Commands.Item("Window.MovetoPreviousTabGroup").IsAvailable;
-
-                        if (curNext == orgNext && curPrev == orgPrev)
-                        {
-                            if (curNext)
-                                dte.ExecuteCommand("Window.MovetoNextTabGroup");
-                            else if (curPrev)
-                                dte.ExecuteCommand("Window.MovetoPreviousTabGroup");
-                            else if (dte.Commands.Item("Window.NewVerticalTabGroup").IsAvailable)
-                                dte.ExecuteCommand("Window.NewVerticalTabGroup");
-                        }
-                    }
-                }
+                    ErrorHandler.ThrowOnFailure(newDocumentFrame.ShowNoActivate());
+                else
+                    ErrorHandler.ThrowOnFailure(newDocumentFrame.Show());
 
                 if (!string.IsNullOrEmpty(lineMarker))
-                {
-                    var lineNumber = GetMarkedLineNumber(path, lineMarker);
-
-                    var textManager = serviceProvider.GetService(typeof(SVsTextManager)) as IVsTextManager2;
-                    Assumes.Present(textManager);
-
-                    textManager.GetActiveView2(0, null, (uint)_VIEWFRAMETYPE.vftCodeWindow, out var activeView);
-                    activeView.SetCaretPos(lineNumber, 0);
-                }
-
-                if (preserveActiveDoc)
-                    dte.ExecuteCommand("File.OpenFile", orgActiveFile.FullName);
+                    SetCaretAtLineMarker(newDocumentFrame, lineMarker);
             }
             catch (Exception e)
             {
@@ -111,16 +88,56 @@ namespace VSRAD.Package.Utils
             }
         }
 
-        private static int GetMarkedLineNumber(string file, string lineMarker)
+        private static void MoveToOppositeTab(IVsWindowFrame newDocumentFrame, dynamic originalDocumentFrame, bool preserveActiveDoc)
         {
-            var lineNumber = 0;
-            foreach (var line in File.ReadLines(file))
+            dynamic newDocumentFrameView = ((dynamic)newDocumentFrame).FrameView;
+            dynamic newDocumentTabGroup = newDocumentFrameView.Parent;
+            IList tabGroups = (IList)newDocumentTabGroup.Parent.VisibleChildren;
+
+            var viewManager = _viewManagerType.GetProperty("Instance").GetValue(null);
+            var createDocumentGroup = _viewManagerType.GetMethod("CreateDocumentGroup", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // If there's only one existing tab group, create a new one
+            if (tabGroups.Count == 1)
+                createDocumentGroup.Invoke(viewManager, new[] { newDocumentFrameView, 0 });
+
+            // Choose the tab group the document should be assigned to
+            int tabGroupIndex = tabGroups.IndexOf(newDocumentTabGroup);
+            dynamic newTabGroup;
+            if (tabGroupIndex + 1 < tabGroups.Count)
+                newTabGroup = tabGroups[tabGroupIndex + 1];
+            else
+                newTabGroup = tabGroups[tabGroupIndex - 1];
+
+            // Remove the document from the tab group it was assigned to
+            newDocumentFrameView.Detach();
+
+            // Assign the document to the new tab group
+            _viewDockOperationsType.GetMethod("Dock").Invoke(null, new[] { newTabGroup, newDocumentFrameView, 0 });
+
+            // The document automatically becomes selected in the new tab group; if it matches the original document's tab group, we need to restore SelectedElement
+            if (preserveActiveDoc && originalDocumentFrame != null && originalDocumentFrame.FrameView.Parent == newTabGroup)
+                newTabGroup.SelectedElement = originalDocumentFrame.FrameView;
+        }
+
+        private static void SetCaretAtLineMarker(IVsWindowFrame documentFrame, string lineMarker)
+        {
+            var vsTextView = VsShellUtilities.GetTextView(documentFrame);
+            ErrorHandler.ThrowOnFailure(vsTextView.GetBuffer(out var vsTextLines));
+            ErrorHandler.ThrowOnFailure(vsTextLines.GetLineCount(out var numLines));
+            for (int i = 0; i < numLines; ++i)
             {
-                if (line == lineMarker)
-                    return lineNumber;
-                ++lineNumber;
+                ErrorHandler.ThrowOnFailure(vsTextLines.GetLengthOfLine(i, out var lineLength));
+                if (lineLength != lineMarker.Length)
+                    continue;
+
+                ErrorHandler.ThrowOnFailure(vsTextLines.GetLineText(i, 0, i, lineLength, out var line));
+                if (line != lineMarker)
+                    continue;
+
+                ErrorHandler.ThrowOnFailure(vsTextView.SetCaretPos(i, 0));
+                break;
             }
-            return 0;
         }
     }
 }


### PR DESCRIPTION
This PR modifies the behavior of Open in Editor step.

Added two new settings to the Options Window:

* **Open in Editor: Force new document to be opened in the opposite tab**: if checked, new document will always be opened in the separate vertical tab group from current active document, in existing, if possible, or in new, if there is only one tab.
* **Open in Editor: Preserve active document**: if checked, Open in Editor step would not change the active document. Otherwise, opened document will become active.