### PR TITLE
Add to Watches optional brackets matching

### DIFF
--- a/VSRAD.Package/Commands/AddToWatchesCommand.cs
+++ b/VSRAD.Package/Commands/AddToWatchesCommand.cs
@@ -36,7 +36,7 @@ namespace VSRAD.Package.Commands
 
         public void Execute(uint commandId, uint commandExecOpt, IntPtr variantIn, IntPtr variantOut)
         {
-            var watchName = _codeEditor.GetActiveWord();
+            var watchName = _codeEditor.GetActiveWord(_toolIntegration.ProjectOptions.VisualizerOptions.MatchBracketsOnAddToWatches);
             if (string.IsNullOrEmpty(watchName))
                 return;
 

--- a/VSRAD.Package/Options/VisualizerOptions.cs
+++ b/VSRAD.Package/Options/VisualizerOptions.cs
@@ -54,6 +54,10 @@ namespace VSRAD.Package.Options
         private bool _showWavemap;
         [DefaultValue(true)]
         public bool ShowWavemap { get => _showWavemap; set => SetField(ref _showWavemap, value); }
+
+        private bool _matchBracketsOnAddToWatches;
+        [DefaultValue(false)]
+        public bool MatchBracketsOnAddToWatches { get => _matchBracketsOnAddToWatches; set => SetField(ref _matchBracketsOnAddToWatches, value); }
     }
 
     public sealed class MagicNumberConverter : JsonConverter

--- a/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
+++ b/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
@@ -28,10 +28,8 @@ namespace VSRAD.Package.ProjectSystem
         private readonly SVsServiceProvider _serviceProvider;
         private readonly ITextDocumentFactoryService _textDocumentService;
 
-        // this regular find matches like `\vargs[kernarg_1:kernarg_2]`
-        private static readonly Regex _activeWordWithBracketsRegular = new Regex(@"[\w\\$]*\[[^\[\]]*\]", RegexOptions.Compiled | RegexOptions.Singleline);
-        // this regular find empty brackets
-        private static readonly Regex _emptyBracketsRegex = new Regex(@"\[\s*\]", RegexOptions.Compiled);
+        // this regex matches words like `\vargs` without indices like [0]
+        private static readonly Regex _activeWordWithoutBracketsRegex = new Regex(@"[\w\\$]*", RegexOptions.Compiled | RegexOptions.Singleline);
 
         [ImportingConstructor]
         public ActiveCodeEditor(SVsServiceProvider serviceProvider, ITextDocumentFactoryService textDocumentService)
@@ -62,7 +60,7 @@ namespace VSRAD.Package.ProjectSystem
             if (activeWord.Length == 0)
             {
                 var wpfTextView = GetTextViewFromVsTextView(GetActiveTextView());
-                activeWord = _emptyBracketsRegex.Replace(GetWordOnPosition(wpfTextView.TextBuffer, wpfTextView.Caret.Position.BufferPosition), "");
+                activeWord = GetWordOnPosition(wpfTextView.TextBuffer, wpfTextView.Caret.Position.BufferPosition);
             }
             return activeWord.Trim();
         }
@@ -73,8 +71,8 @@ namespace VSRAD.Package.ProjectSystem
             var lineText = line.GetText();
             var caretIndex = position - line.Start;
 
-            // check actual word with open and close brackets
-            foreach (Match match in _activeWordWithBracketsRegular.Matches(lineText))
+            // check actual word
+            foreach (Match match in _activeWordWithoutBracketsRegex.Matches(lineText))
             {
                 if (match.Index <= caretIndex && (match.Index + match.Length) >= caretIndex)
                 {

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -107,6 +107,10 @@
                             IsChecked="{Binding Options.DebuggerOptions.SingleActiveBreakpoint, UpdateSourceTrigger=PropertyChanged}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Height="25">
+                    <CheckBox Content="Match brackets on Add To Watches" VerticalAlignment="Center" Padding="4,0,0,0"
+                                IsChecked="{Binding Options.VisualizerOptions.MatchBracketsOnAddToWatches, UpdateSourceTrigger=PropertyChanged}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Height="25">
                     <Label Content="Break mode:" VerticalAlignment="Center" Margin="15,0,0,0"/>
                     <ComboBox SelectedItem="{Binding Options.DebuggerOptions.BreakMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                               ItemsSource="{Binding Source={StaticResource BreakMode}}" VerticalContentAlignment="Center">


### PR DESCRIPTION
Added new `Match brackets on Add To Watches` property in Options window, that specifies whether brackets (`[]`) and their contents should be ignored on `Add to Watches` operation.