### PR TITLE
Fix memory leaks

### DIFF
--- a/VSRAD.Syntax/Collapse/OutliningTaggerProvider.cs
+++ b/VSRAD.Syntax/Collapse/OutliningTaggerProvider.cs
@@ -25,7 +25,8 @@ namespace VSRAD.Syntax.Collapse
             if (document == null)
                 return null;
 
-            return new OutliningTagger(document) as ITagger<T>;
+            return buffer.Properties.GetOrCreateSingletonProperty(() => 
+                new OutliningTagger(document)) as ITagger<T>;
         }
     }
 }

--- a/VSRAD.Syntax/Collapse/OutliningTaggerProvider.cs
+++ b/VSRAD.Syntax/Collapse/OutliningTaggerProvider.cs
@@ -22,8 +22,10 @@ namespace VSRAD.Syntax.Collapse
         public ITagger<T> CreateTagger<T>(ITextBuffer buffer) where T : ITag
         {
             var document = _documentFactory.GetOrCreateDocument(buffer);
+            if (document == null)
+                return null;
 
-            return buffer.Properties.GetOrCreateSingletonProperty(() => new OutliningTagger(document.DocumentAnalysis) as ITagger<T>);
+            return new OutliningTagger(document) as ITagger<T>;
         }
     }
 }

--- a/VSRAD.Syntax/Core/CodeDocument.cs
+++ b/VSRAD.Syntax/Core/CodeDocument.cs
@@ -1,16 +1,29 @@
 ﻿using Microsoft.VisualStudio.Text;
 using VSRAD.Syntax.Core.Lexer;
 using VSRAD.Syntax.Core.Parser;
+using VSRAD.Syntax.Helpers;
 using VSRAD.Syntax.Options.Instructions;
 
 namespace VSRAD.Syntax.Core
 {
     internal class CodeDocument : Document
     {
+        private readonly IInstructionListManager _instructionListManager;
+
         public CodeDocument(IInstructionListManager instructionListManager, ITextDocument textDocument, ILexer lexer, IParser parser)
             : base(textDocument, lexer, parser)
         {
-            instructionListManager.InstructionsUpdated += (s, t) => DocumentTokenizer.Rescan(RescanReason.InstructionsChanged);
+            _instructionListManager = instructionListManager;
+            _instructionListManager.InstructionsUpdated += InstructionsUpdated;
         }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            _instructionListManager.InstructionsUpdated -= InstructionsUpdated;
+        }
+
+        private void InstructionsUpdated(IInstructionListManager manager, AsmType asmType) =>
+            DocumentTokenizer.Rescan(RescanReason.InstructionsChanged);
     }
 }

--- a/VSRAD.Syntax/Core/DocumentAnalysis.cs
+++ b/VSRAD.Syntax/Core/DocumentAnalysis.cs
@@ -13,6 +13,7 @@ namespace VSRAD.Syntax.Core
     internal class DocumentAnalysis : IDocumentAnalysis
     {
         private readonly IDocument _document;
+        private readonly IDocumentTokenizer _tokenizer;
         private readonly IParser _parser;
         private readonly FixedSizeDictionary<ITextSnapshot, Task<IAnalysisResult>> _resultsRequests;
 
@@ -22,11 +23,12 @@ namespace VSRAD.Syntax.Core
         public DocumentAnalysis(IDocument document, IDocumentTokenizer tokenizer, IParser parser)
         {
             _document = document;
+            _tokenizer = tokenizer;
             _parser = parser;
             _resultsRequests = new FixedSizeDictionary<ITextSnapshot, Task<IAnalysisResult>>(100);
 
-            tokenizer.TokenizerUpdated += TokenizerUpdated;
-            TokenizerUpdated(tokenizer.CurrentResult, RescanReason.ContentChanged, CancellationToken.None);
+            _tokenizer.TokenizerUpdated += TokenizerUpdated;
+            TokenizerUpdated(_tokenizer.CurrentResult, RescanReason.ContentChanged, CancellationToken.None);
         }
 
         public async Task<IAnalysisResult> GetAnalysisResultAsync(ITextSnapshot textSnapshot)
@@ -71,6 +73,11 @@ namespace VSRAD.Syntax.Core
             {
                 throw new OperationCanceledException();
             }
+        }
+
+        public void Dispose()
+        {
+            _tokenizer.TokenizerUpdated -= TokenizerUpdated;
         }
     }
 }

--- a/VSRAD.Syntax/Core/DocumentTokenizer.cs
+++ b/VSRAD.Syntax/Core/DocumentTokenizer.cs
@@ -13,6 +13,7 @@ namespace VSRAD.Syntax.Core
     internal class DocumentTokenizer : IDocumentTokenizer
     {
         private readonly TrackingToken.NonOverlappingComparer _comparer;
+        private readonly ITextBuffer _buffer;
         private readonly ILexer _lexer;
         private TokenizerCollection CurrentTokens;
         private CancellationTokenSource _cts;
@@ -28,13 +29,14 @@ namespace VSRAD.Syntax.Core
 
         public DocumentTokenizer(ITextBuffer buffer, ILexer lexer)
         {
+            _buffer = buffer;
             _lexer = lexer;
             _comparer = new TrackingToken.NonOverlappingComparer();
             CurrentSnapshot = buffer.CurrentSnapshot;
             _cts = new CancellationTokenSource();
 
             Initialize();
-            buffer.Changed += BufferChanged;
+            _buffer.Changed += BufferChanged;
         }
 
         private void Initialize() => Rescan(RescanReason.ContentChanged);
@@ -206,6 +208,12 @@ namespace VSRAD.Syntax.Core
             public int OldLength { get { throw new NotImplementedException(); } }
             public int OldPosition { get { throw new NotImplementedException(); } }
             public string OldText { get { throw new NotImplementedException(); } }
+        }
+
+        public void Dispose()
+        {
+            _buffer.Changed -= BufferChanged;
+            _cts?.Dispose();
         }
     }
 }

--- a/VSRAD.Syntax/Core/IDocument.cs
+++ b/VSRAD.Syntax/Core/IDocument.cs
@@ -4,6 +4,7 @@ using System;
 namespace VSRAD.Syntax.Core
 {
     public delegate void DocumentRenamedEventHandler(IDocument document, string oldPath, string newPath);
+    public delegate void DocumentClosedEventHandler(IDocument document);
 
     public interface IDocument : IDisposable
     {
@@ -11,9 +12,9 @@ namespace VSRAD.Syntax.Core
         IDocumentTokenizer DocumentTokenizer { get; }
         string Path { get; }
         ITextSnapshot CurrentSnapshot { get; }
-        bool IsDisposed { get; }
 
         event DocumentRenamedEventHandler DocumentRenamed;
+        event DocumentClosedEventHandler DocumentClosed;
         void OpenDocumentInEditor();
         void NavigateToPosition(int position);
     }

--- a/VSRAD.Syntax/Core/IDocumentAnalysis.cs
+++ b/VSRAD.Syntax/Core/IDocumentAnalysis.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.Text;
+﻿using System;
+using Microsoft.VisualStudio.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -6,7 +7,7 @@ namespace VSRAD.Syntax.Core
 {
     public delegate void AnalysisUpdatedEventHandler(IAnalysisResult analysisResult, RescanReason reason, CancellationToken cancellationToken);
 
-    public interface IDocumentAnalysis
+    public interface IDocumentAnalysis : IDisposable
     {
         IAnalysisResult CurrentResult { get; }
         Task<IAnalysisResult> GetAnalysisResultAsync(ITextSnapshot textSnapshot);

--- a/VSRAD.Syntax/Core/IDocumentTokenizer.cs
+++ b/VSRAD.Syntax/Core/IDocumentTokenizer.cs
@@ -1,11 +1,12 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using VSRAD.Syntax.Core.Tokens;
 
 namespace VSRAD.Syntax.Core
 {
     public delegate void TokenizerUpdatedEventHandler(ITokenizerResult result, RescanReason rescanReason, CancellationToken cancellationToken);
 
-    public interface IDocumentTokenizer
+    public interface IDocumentTokenizer : IDisposable
     {
         ITokenizerResult CurrentResult { get; }
         void Rescan(RescanReason rescanReason);

--- a/VSRAD.Syntax/Core/Lexer/Asm1Lexer.cs
+++ b/VSRAD.Syntax/Core/Lexer/Asm1Lexer.cs
@@ -6,8 +6,10 @@ using VSRAD.SyntaxParser;
 
 namespace VSRAD.Syntax.Core.Lexer
 {
-    public class AsmLexer : ILexer
+    public class Asm1Lexer : ILexer
     {
+        public static ILexer Instance = new Asm1Lexer();
+
         public IEnumerable<TokenSpan> Run(IEnumerable<string> textSegments, int offset)
         {
             var lexer = new RadAsmLexer(new UnbufferedCharStream(new TextSegmentsCharStream(textSegments)));

--- a/VSRAD.Syntax/Core/Lexer/Asm2Lexer.cs
+++ b/VSRAD.Syntax/Core/Lexer/Asm2Lexer.cs
@@ -9,6 +9,8 @@ namespace VSRAD.Syntax.Core.Lexer
 {
     public class Asm2Lexer : ILexer
     {
+        public static ILexer Instance = new Asm2Lexer();
+
         public IEnumerable<TokenSpan> Run(IEnumerable<string> textSegments, int offset)
         {
             var lexer = new RadAsm2Lexer(new UnbufferedCharStream(new TextSegmentsCharStream(textSegments)));

--- a/VSRAD.Syntax/Core/Lexer/AsmDocLexer.cs
+++ b/VSRAD.Syntax/Core/Lexer/AsmDocLexer.cs
@@ -1,6 +1,5 @@
 ﻿using Antlr4.Runtime;
 using Microsoft.VisualStudio.Text;
-using System;
 using System.Collections.Generic;
 using VSRAD.Syntax.Core.Tokens;
 using VSRAD.SyntaxParser;
@@ -9,6 +8,8 @@ namespace VSRAD.Syntax.Core.Lexer
 {
     class AsmDocLexer : ILexer
     {
+        public static ILexer Instance = new AsmDocLexer();
+
         public IEnumerable<TokenSpan> Run(IEnumerable<string> textSegments, int offset)
         {
             var lexer = new RadAsmDocLexer(new UnbufferedCharStream(new TextSegmentsCharStream(textSegments)));

--- a/VSRAD.Syntax/Core/LexerParserFactory.cs
+++ b/VSRAD.Syntax/Core/LexerParserFactory.cs
@@ -1,4 +1,5 @@
-﻿using VSRAD.Syntax.Core.Lexer;
+﻿using System.Collections.Generic;
+using VSRAD.Syntax.Core.Lexer;
 using VSRAD.Syntax.Core.Parser;
 using VSRAD.Syntax.Helpers;
 
@@ -14,32 +15,50 @@ namespace VSRAD.Syntax.Core
 
     internal partial class DocumentFactory
     {
+        private Dictionary<AsmType, LexerParser> _asmSpecificLexerParser;
+
         private LexerParser? GetLexerParser(AsmType asmType)
         {
-            var instructionManager = _instructionManager.Value;
+            InitializeLexerParser();
 
-            switch (asmType)
+            if (_asmSpecificLexerParser.TryGetValue(asmType, out var lexerParser))
+                return lexerParser;
+
+            return null;
+        }
+
+        private void InitializeLexerParser()
+        {
+            if (_asmSpecificLexerParser != null)
+                return;
+
+            _asmSpecificLexerParser = new Dictionary<AsmType, LexerParser>()
             {
-                case AsmType.RadAsm:
-                    return new LexerParser()
+                {
+                    AsmType.RadAsm,
+                    new LexerParser()
                     {
-                        Lexer = new AsmLexer(),
-                        Parser = new Asm1Parser(this, instructionManager)
-                    };
-                case AsmType.RadAsm2:
-                    return new LexerParser()
+                        Lexer = Asm1Lexer.Instance,
+                        Parser = Asm1Parser.Instance
+                    }
+                },
+                {
+                    AsmType.RadAsm2,
+                    new LexerParser()
                     {
-                        Lexer = new Asm2Lexer(),
-                        Parser = new Asm2Parser(this, instructionManager)
-                    };
-                case AsmType.RadAsmDoc:
-                    return new LexerParser()
+                        Lexer = Asm2Lexer.Instance,
+                        Parser = Asm2Parser.Instance
+                    }
+                },
+                {
+                    AsmType.RadAsmDoc,
+                    new LexerParser()
                     {
-                        Lexer = new AsmDocLexer(),
-                        Parser = new AsmDocParser()
-                    };
-                default: return null;
-            }
+                        Lexer = AsmDocLexer.Instance,
+                        Parser = AsmDocParser.Instance
+                    }
+                }
+            };
         }
     }
 }

--- a/VSRAD.Syntax/Core/LexerParserFactory.cs
+++ b/VSRAD.Syntax/Core/LexerParserFactory.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using VSRAD.Syntax.Core.Lexer;
+﻿using VSRAD.Syntax.Core.Lexer;
 using VSRAD.Syntax.Core.Parser;
 using VSRAD.Syntax.Helpers;
 
@@ -15,50 +14,31 @@ namespace VSRAD.Syntax.Core
 
     internal partial class DocumentFactory
     {
-        private Dictionary<AsmType, LexerParser> _asmSpecificLexerParser;
-
-        private LexerParser? GetLexerParser(AsmType asmType)
+        private static LexerParser? GetLexerParser(AsmType asmType)
         {
-            InitializeLexerParser();
 
-            if (_asmSpecificLexerParser.TryGetValue(asmType, out var lexerParser))
-                return lexerParser;
-
-            return null;
-        }
-
-        private void InitializeLexerParser()
-        {
-            if (_asmSpecificLexerParser != null)
-                return;
-
-            _asmSpecificLexerParser = new Dictionary<AsmType, LexerParser>()
+            switch (asmType)
             {
-                {
-                    AsmType.RadAsm,
-                    new LexerParser()
+                case AsmType.RadAsm:
+                    return new LexerParser()
                     {
                         Lexer = Asm1Lexer.Instance,
                         Parser = Asm1Parser.Instance
-                    }
-                },
-                {
-                    AsmType.RadAsm2,
-                    new LexerParser()
+                    };
+                case AsmType.RadAsm2:
+                    return new LexerParser()
                     {
                         Lexer = Asm2Lexer.Instance,
                         Parser = Asm2Parser.Instance
-                    }
-                },
-                {
-                    AsmType.RadAsmDoc,
-                    new LexerParser()
+                    };
+                case AsmType.RadAsmDoc:
+                    return new LexerParser()
                     {
                         Lexer = AsmDocLexer.Instance,
                         Parser = AsmDocParser.Instance
-                    }
-                }
-            };
+                    };
+                default: return null;
+            }
         }
     }
 }

--- a/VSRAD.Syntax/Core/Parser/AbstractCodeParser.cs
+++ b/VSRAD.Syntax/Core/Parser/AbstractCodeParser.cs
@@ -103,7 +103,13 @@ namespace VSRAD.Syntax.Core.Parser
                     default: return true;
                 }
 
-                block.AddToken(new ReferenceToken(referenceType, token, version, definitionToken));
+                var referenceToken = new ReferenceToken(referenceType, token, version, definitionToken);
+
+                // definition contains only references from the same document
+                if (referenceToken.Snapshot == definitionToken.Snapshot)
+                    definitionToken.AddReference(referenceToken);
+
+                block.AddToken(referenceToken);
                 return true;
             }
 

--- a/VSRAD.Syntax/Core/Parser/AsmDocParser.cs
+++ b/VSRAD.Syntax/Core/Parser/AsmDocParser.cs
@@ -12,6 +12,8 @@ namespace VSRAD.Syntax.Core.Parser
 {
     internal class AsmDocParser : IParser
     {
+        public static IParser Instance = new AsmDocParser();
+
         public Task<IParserResult> RunAsync(IDocument document, ITextSnapshot version, ITokenizerCollection<TrackingToken> trackingTokens, CancellationToken cancellation)
         {
             var definitions = new Dictionary<string, DefinitionToken>();

--- a/VSRAD.Syntax/Core/Tokens/ReferenceToken.cs
+++ b/VSRAD.Syntax/Core/Tokens/ReferenceToken.cs
@@ -10,7 +10,6 @@ namespace VSRAD.Syntax.Core.Tokens
             : base (tokenType, trackingToken, snapshot)
         {
             Definition = definitionToken;
-            Definition.AddReference(this);
         }
     }
 }

--- a/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
@@ -86,6 +86,8 @@ namespace VSRAD.Syntax.FunctionList
             ThreadHelper.ThrowIfNotOnUIThread();
             items = new List<FunctionListItem>();
             tokens.Items.Clear();
+
+            ClearHighlightItem();
         }
 
         public void HighlightItemAtLine(int lineNumber)

--- a/VSRAD.Syntax/FunctionList/FunctionListProvider.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionListProvider.cs
@@ -1,4 +1,4 @@
-using Microsoft.VisualStudio.Shell;
+﻿using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
@@ -137,7 +137,7 @@ namespace VSRAD.Syntax.FunctionList
 
         private void ClearFunctionList()
         {
-            _functionListControl.ClearList();
+            _functionListControl?.ClearList();
             _lastResult = null;
         }
 

--- a/VSRAD.Syntax/Guide/IndentGuideFactory.cs
+++ b/VSRAD.Syntax/Guide/IndentGuideFactory.cs
@@ -33,7 +33,8 @@ namespace VSRAD.Syntax.Guide
             if (document == null)
                 return;
 
-            var _ = new IndentGuide(textView, document.DocumentAnalysis, _optionsProvider);
+            textView.Properties.GetOrCreateSingletonProperty(() => 
+                new IndentGuide(textView, document.DocumentAnalysis, _optionsProvider));
         }
     }
 }

--- a/VSRAD.Syntax/Guide/IndentGuideFactory.cs
+++ b/VSRAD.Syntax/Guide/IndentGuideFactory.cs
@@ -30,8 +30,10 @@ namespace VSRAD.Syntax.Guide
         public void TextViewCreated(IWpfTextView textView)
         {
             var document = _documentFactory.GetOrCreateDocument(textView.TextBuffer);
-            if (document != null)
-                textView.Properties.AddProperty(typeof(IndentGuide), new IndentGuide(textView, document.DocumentAnalysis, _optionsProvider));
+            if (document == null)
+                return;
+
+            var _ = new IndentGuide(textView, document.DocumentAnalysis, _optionsProvider);
         }
     }
 }

--- a/VSRAD.Syntax/Helpers/DocumentObserver.cs
+++ b/VSRAD.Syntax/Helpers/DocumentObserver.cs
@@ -1,0 +1,20 @@
+﻿using VSRAD.Syntax.Core;
+
+namespace VSRAD.Syntax.Helpers
+{
+    public abstract class DocumentObserver
+    {
+        protected DocumentObserver(IDocument document)
+        {
+            document.DocumentClosed += DocumentClosedEventHandler;
+        }
+
+        protected abstract void OnClosingDocument(IDocument document);
+
+        private void DocumentClosedEventHandler(IDocument document)
+        {
+            document.DocumentClosed -= DocumentClosedEventHandler;
+            OnClosingDocument(document);
+        }
+    }
+}

--- a/VSRAD.Syntax/IntelliSense/Completion/CompletionSourceProvider.cs
+++ b/VSRAD.Syntax/IntelliSense/Completion/CompletionSourceProvider.cs
@@ -48,7 +48,8 @@ namespace VSRAD.Syntax.IntelliSense.Completion
             var document = _documentFactory.GetOrCreateDocument(textView.TextBuffer);
             if (document == null) return null;
 
-            return new CompletionSource(document, _descriptionBuilder, _providers);
+            return textView.Properties.GetOrCreateSingletonProperty(() => 
+                new CompletionSource(document, _descriptionBuilder, _providers));
         }
     }
 }

--- a/VSRAD.Syntax/IntelliSense/Navigation/NavigableSymbolSourceProvider.cs
+++ b/VSRAD.Syntax/IntelliSense/Navigation/NavigableSymbolSourceProvider.cs
@@ -25,9 +25,11 @@ namespace VSRAD.Syntax.IntelliSense.Navigation
         public INavigableSymbolSource TryCreateNavigableSymbolSource(ITextView textView, ITextBuffer buffer)
         {
             var document = _documentFactory.GetOrCreateDocument(buffer);
-            return (document != null)
-                ? new NavigableSymbolSource(_navigationService)
-                : null;
+            if (document == null)
+                return null;
+
+            return buffer.Properties.GetOrCreateSingletonProperty(() => 
+                new NavigableSymbolSource(_navigationService));
         }
     }
 }

--- a/VSRAD.Syntax/SyntaxHighlighter/BraceMatchingHighlighter/BraceHighlighter.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/BraceMatchingHighlighter/BraceHighlighter.cs
@@ -38,6 +38,16 @@ namespace VSRAD.Syntax.SyntaxHighlighter.BraceMatchingHighlighter
 
             _view.Caret.PositionChanged += CaretPositionChanged;
             _view.LayoutChanged += ViewLayoutChanged;
+            _view.Closed += ViewClosedEventHandler;
+        }
+
+        private void ViewClosedEventHandler(object sender, EventArgs e)
+        {
+            _view.Caret.PositionChanged -= CaretPositionChanged;
+            _view.LayoutChanged -= ViewLayoutChanged;
+            _view.Closed -= ViewClosedEventHandler;
+
+            indentCts?.Dispose();
         }
 
         private void ViewLayoutChanged(object sender, TextViewLayoutChangedEventArgs e)

--- a/VSRAD.Syntax/SyntaxHighlighter/BraceMatchingHighlighter/BraceHighlighterProvider.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/BraceMatchingHighlighter/BraceHighlighterProvider.cs
@@ -29,7 +29,8 @@ namespace VSRAD.Syntax.SyntaxHighlighter.BraceMatchingHighlighter
             if (document == null)
                 return null;
 
-            return new BraceHighlighter(textView, buffer, document.DocumentTokenizer) as ITagger<T>;
+            return textView.Properties.GetOrCreateSingletonProperty(() => 
+                new BraceHighlighter(textView, buffer, document.DocumentTokenizer)) as ITagger<T>;
         }
     }
 

--- a/VSRAD.Syntax/SyntaxHighlighter/BraceMatchingHighlighter/BraceHighlighterProvider.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/BraceMatchingHighlighter/BraceHighlighterProvider.cs
@@ -3,7 +3,6 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 using System.ComponentModel.Composition;
-using VSRAD.Syntax.IntelliSense;
 using VSRAD.Syntax.Core;
 
 namespace VSRAD.Syntax.SyntaxHighlighter.BraceMatchingHighlighter
@@ -27,6 +26,9 @@ namespace VSRAD.Syntax.SyntaxHighlighter.BraceMatchingHighlighter
                 return null;
 
             var document = _documentFactory.GetOrCreateDocument(buffer);
+            if (document == null)
+                return null;
+
             return new BraceHighlighter(textView, buffer, document.DocumentTokenizer) as ITagger<T>;
         }
     }

--- a/VSRAD.Syntax/SyntaxHighlighter/ClassifierProvider.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/ClassifierProvider.cs
@@ -30,7 +30,7 @@ namespace VSRAD.Syntax.SyntaxHighlighter
         public IClassifier GetClassifier(ITextBuffer textBuffer)
         {
             var document = _documentFactory.GetOrCreateDocument(textBuffer);
-            return textBuffer.Properties.GetOrCreateSingletonProperty(() => new AnalysisClassifier(document.DocumentAnalysis, _classificationTypeRegistryService));
+            return new AnalysisClassifier(document, _classificationTypeRegistryService);
         }
     }
 
@@ -43,7 +43,9 @@ namespace VSRAD.Syntax.SyntaxHighlighter
         private readonly IDocumentFactory _documentFactory;
 
         [ImportingConstructor]
-        public TokenizerClassifierProvider(IStandardClassificationService classificationService, IDocumentFactory documentFactory)
+        public TokenizerClassifierProvider(
+            IStandardClassificationService classificationService, 
+            IDocumentFactory documentFactory)
         {
             _classificationService = classificationService;
             _documentFactory = documentFactory;
@@ -52,7 +54,7 @@ namespace VSRAD.Syntax.SyntaxHighlighter
         public ITagger<T> CreateTagger<T>(ITextBuffer buffer) where T : ITag
         {
             var document = _documentFactory.GetOrCreateDocument(buffer);
-            return buffer.Properties.GetOrCreateSingletonProperty(() => new TokenizerClassifier(document.DocumentTokenizer, _classificationService)) as ITagger<T>;
+            return new TokenizerClassifier(document, _classificationService) as ITagger<T>;
         }
     }
 }

--- a/VSRAD.Syntax/SyntaxHighlighter/ClassifierProvider.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/ClassifierProvider.cs
@@ -30,7 +30,8 @@ namespace VSRAD.Syntax.SyntaxHighlighter
         public IClassifier GetClassifier(ITextBuffer textBuffer)
         {
             var document = _documentFactory.GetOrCreateDocument(textBuffer);
-            return new AnalysisClassifier(document, _classificationTypeRegistryService);
+            return textBuffer.Properties.GetOrCreateSingletonProperty(() => 
+                new AnalysisClassifier(document, _classificationTypeRegistryService));
         }
     }
 
@@ -54,7 +55,8 @@ namespace VSRAD.Syntax.SyntaxHighlighter
         public ITagger<T> CreateTagger<T>(ITextBuffer buffer) where T : ITag
         {
             var document = _documentFactory.GetOrCreateDocument(buffer);
-            return new TokenizerClassifier(document, _classificationService) as ITagger<T>;
+            return buffer.Properties.GetOrCreateSingletonProperty(() => 
+                new TokenizerClassifier(document, _classificationService)) as ITagger<T>;
         }
     }
 }

--- a/VSRAD.Syntax/SyntaxHighlighter/ErrorHighlighter/ErrorHighlighterTaggerProvider.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/ErrorHighlighter/ErrorHighlighterTaggerProvider.cs
@@ -45,7 +45,8 @@ namespace VSRAD.Syntax.SyntaxHighlighter.ErrorHighlighter
             if (textView.TextBuffer != buffer)
                 return null;
 
-            return new ErrorHighlighterTagger(this, textView, buffer) as ITagger<T>;
+            return textView.Properties.GetOrCreateSingletonProperty(() => 
+                new ErrorHighlighterTagger(this, textView, buffer)) as ITagger<T>;
         }
     }
 

--- a/VSRAD.Syntax/SyntaxHighlighter/ErrorHighlighter/SyntaxErrorHighlighterTaggerProvider.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/ErrorHighlighter/SyntaxErrorHighlighterTaggerProvider.cs
@@ -10,7 +10,7 @@ namespace VSRAD.Syntax.SyntaxHighlighter.ErrorHighlighter
     [Export(typeof(IViewTaggerProvider))]
     [ContentType(Constants.RadeonAsmSyntaxContentType)]
     [TagType(typeof(IErrorTag))]
-    public sealed class SyntaxErrorHighlighterTaggerProvider : IViewTaggerProvider
+    internal sealed class SyntaxErrorHighlighterTaggerProvider : IViewTaggerProvider
     {
         private readonly IDocumentFactory _documentFactory;
 
@@ -25,7 +25,7 @@ namespace VSRAD.Syntax.SyntaxHighlighter.ErrorHighlighter
             var document = _documentFactory.GetOrCreateDocument(buffer);
             if (document == null) return null;
 
-            return new SyntaxErrorHighlighterTagger(document.DocumentAnalysis) as ITagger<T>;
+            return new SyntaxErrorHighlighterTagger(document) as ITagger<T>;
         }
     }
 }

--- a/VSRAD.Syntax/SyntaxHighlighter/ErrorHighlighter/SyntaxErrorHighlighterTaggerProvider.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/ErrorHighlighter/SyntaxErrorHighlighterTaggerProvider.cs
@@ -25,7 +25,8 @@ namespace VSRAD.Syntax.SyntaxHighlighter.ErrorHighlighter
             var document = _documentFactory.GetOrCreateDocument(buffer);
             if (document == null) return null;
 
-            return new SyntaxErrorHighlighterTagger(document) as ITagger<T>;
+            return buffer.Properties.GetOrCreateSingletonProperty(() =>  
+                new SyntaxErrorHighlighterTagger(document)) as ITagger<T>;
         }
     }
 }

--- a/VSRAD.Syntax/SyntaxHighlighter/IdentifiersHighliter/IdentifierHighliterTagger.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/IdentifiersHighliter/IdentifierHighliterTagger.cs
@@ -49,6 +49,16 @@ namespace VSRAD.Syntax.SyntaxHighlighter.IdentifiersHighliter
 
             _view.Caret.PositionChanged += CaretPositionChanged;
             _view.LayoutChanged += ViewLayoutChanged;
+            _view.Closed += ViewClosedEventHandler;
+        }
+
+        private void ViewClosedEventHandler(object sender, EventArgs e)
+        {
+            _view.Caret.PositionChanged -= CaretPositionChanged;
+            _view.LayoutChanged -= ViewLayoutChanged;
+            _view.Closed -= ViewClosedEventHandler;
+
+            indentCts?.Dispose();
         }
 
         private void ViewLayoutChanged(object sender, TextViewLayoutChangedEventArgs e)

--- a/VSRAD.Syntax/SyntaxHighlighter/IdentifiersHighliter/IdentifierHighliterTaggerProvider.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/IdentifiersHighliter/IdentifierHighliterTaggerProvider.cs
@@ -29,7 +29,8 @@ namespace VSRAD.Syntax.SyntaxHighlighter.IdentifiersHighliter
             if (document == null)
                 return null;
 
-            return new HighlightWordTagger(textView, buffer, document.DocumentAnalysis) as ITagger<T>;
+            return textView.Properties.GetOrCreateSingletonProperty(() => 
+                new HighlightWordTagger(textView, buffer, document.DocumentAnalysis)) as ITagger<T>;
         }
     }
 }

--- a/VSRAD.Syntax/SyntaxHighlighter/IdentifiersHighliter/IdentifierHighliterTaggerProvider.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/IdentifiersHighliter/IdentifierHighliterTaggerProvider.cs
@@ -3,9 +3,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 using System.ComponentModel.Composition;
-using VSRAD.Syntax.IntelliSense;
 using VSRAD.Syntax.Core;
-using EnvDTE;
 
 namespace VSRAD.Syntax.SyntaxHighlighter.IdentifiersHighliter
 {
@@ -28,6 +26,9 @@ namespace VSRAD.Syntax.SyntaxHighlighter.IdentifiersHighliter
                 return null;
 
             var document = _documentFactory.GetOrCreateDocument(buffer);
+            if (document == null)
+                return null;
+
             return new HighlightWordTagger(textView, buffer, document.DocumentAnalysis) as ITagger<T>;
         }
     }

--- a/VSRAD.Syntax/VSRAD.Syntax.csproj
+++ b/VSRAD.Syntax/VSRAD.Syntax.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
@@ -120,6 +120,7 @@
     <Compile Include="FunctionList\Helper.cs" />
     <Compile Include="Guide\IndentGuide.cs" />
     <Compile Include="Guide\IndentGuideFactory.cs" />
+    <Compile Include="Helpers\DocumentObserver.cs" />
     <Compile Include="Helpers\Error.cs" />
     <Compile Include="Helpers\NotifyPropertyChanged.cs" />
     <Compile Include="Helpers\AnalysisResultExtension.cs" />

--- a/VSRAD.Syntax/VSRAD.Syntax.csproj
+++ b/VSRAD.Syntax/VSRAD.Syntax.csproj
@@ -86,7 +86,7 @@
     <Compile Include="Core\LexerParserFactory.cs" />
     <Compile Include="Core\Lexer\Asm2Lexer.cs" />
     <Compile Include="Core\Lexer\AsmDocLexer.cs" />
-    <Compile Include="Core\Lexer\AsmLexer.cs" />
+    <Compile Include="Core\Lexer\Asm1Lexer.cs" />
     <Compile Include="Core\Lexer\Lexer.cs" />
     <Compile Include="Core\Parser\AbstractCodeParser.cs" />
     <Compile Include="Core\Parser\Asm2Parser.cs" />


### PR DESCRIPTION
This PR fixes syntax extension memory leaks.
In fact, this PR contains three independent parts (one commit for each part), so the reviewer has luxury to skip what he is not interested in:
- Fix memory leak when closing document. 
Basically, this is an unsubscribe from document events when it is actually closed.
- Fix memory leak when closing document window. 
Basically, this is an unsubscribe from document window events when it is closed.
- Fix unreasonable memory usage by the lexer/parser.
Previously, for each document, an object of the parser class was created, which stored a copy of the instruction set. Now lexer/parser are singletons.