### PR TITLE
Visualizer Improvements

### DIFF
--- a/VSRAD.Package/Commands/AddToWatchesCommand.cs
+++ b/VSRAD.Package/Commands/AddToWatchesCommand.cs
@@ -34,6 +34,13 @@ namespace VSRAD.Package.Commands
             return OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED;
         }
 
+        private void HandleCustomSlice(uint start, uint step, uint count, string watchName)
+        {
+            var arrayRangeWatch = ArrayRange.FormatCustomSlice(watchName, (int)start, (int)step, (int)count);
+            foreach (var watch in arrayRangeWatch)
+                _toolIntegration.AddWatchFromEditor(watch);
+        }
+
         public void Execute(uint commandId, uint commandExecOpt, IntPtr variantIn, IntPtr variantOut)
         {
             var watchName = _codeEditor.GetActiveWord(_toolIntegration.ProjectOptions.VisualizerOptions.MatchBracketsOnAddToWatches);
@@ -46,7 +53,7 @@ namespace VSRAD.Package.Commands
             }
             else if (commandId == Constants.AddToWatchesArrayCustomCommandId)
             {
-
+                new AddToWatchesCustomSliceEditor(HandleCustomSlice, watchName) { ShowInTaskbar = false }.ShowModal();
             }
             else if (commandId >= Constants.AddArrayToWatchesToIdOffset)
             {

--- a/VSRAD.Package/Commands/AddToWatchesCommand.cs
+++ b/VSRAD.Package/Commands/AddToWatchesCommand.cs
@@ -44,6 +44,10 @@ namespace VSRAD.Package.Commands
             {
                 _toolIntegration.AddWatchFromEditor(watchName);
             }
+            else if (commandId == Constants.AddToWatchesArrayCustomCommandId)
+            {
+
+            }
             else if (commandId >= Constants.AddArrayToWatchesToIdOffset)
             {
                 var fromIndex = Math.DivRem(commandId - Constants.AddArrayToWatchesToIdOffset, Constants.AddArrayToWatchesToFromOffset, out var toIndex);

--- a/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml
+++ b/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml
@@ -7,18 +7,14 @@
                          xmlns:platformui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
                          x:Class="VSRAD.Package.Commands.AddToWatchesCustomSliceEditor"
                          x:Name="Root" mc:Ignorable="d"
-                         Title="Add To Watches As Array" Height="160" Width="300" MinHeight="150" MinWidth="200"
+                         Title="Add To Watches As Array" Height="160" Width="240" MaxHeight="160" MaxWidth="240"
                          Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
                          Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}">
     <platformui:DialogWindow.Resources>
         <ResourceDictionary Source="../ToolWindows/ControlStyle.xaml"/>
     </platformui:DialogWindow.Resources>
-    <DockPanel Margin="4">
-        <StackPanel Margin="4" Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Bottom">
-            <Button Content="OK" Width="61" Height="22" Click="HandleOK"/>
-            <Button Content="Cancel" IsCancel="True" Width="61" Height="22" Margin="4,0,0,0" />
-        </StackPanel>
-        <Grid x:Name="HostGrid" Margin="4" Focusable="True">
+    <StackPanel Margin="4" Orientation="Vertical">
+        <Grid Margin="4">
             <Grid.RowDefinitions>
                 <RowDefinition/>
                 <RowDefinition/>
@@ -29,11 +25,15 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <TextBlock Text="Start:" VerticalAlignment="Center" Grid.Column="0" Grid.Row="0"/>
-            <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="StartControl" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="0"/>
+            <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="StartControl" Focusable="True" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="0"/>
             <TextBlock Text="Step:" VerticalAlignment="Center" Grid.Column="0" Grid.Row="1"/>
             <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="StepControl" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="1"/>
             <TextBlock Text="Count:" VerticalAlignment="Center" Grid.Column="0" Grid.Row="2"/>
             <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="CountControl" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="2"/>
         </Grid>
-    </DockPanel>
+        <StackPanel Margin="4" Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Bottom">
+            <Button Content="OK" Width="61" Height="22" Click="HandleOK" IsDefault="True"/>
+            <Button Content="Cancel" IsCancel="True" Width="61" Height="22" Margin="4,0,0,0"/>
+        </StackPanel>
+    </StackPanel>
 </platformui:DialogWindow>

--- a/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml
+++ b/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml
@@ -1,0 +1,39 @@
+﻿<platformui:DialogWindow xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                         xmlns:viz="clr-namespace:VSRAD.Package.DebugVisualizer"
+                         xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+                         xmlns:platformui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+                         x:Class="VSRAD.Package.Commands.AddToWatchesCustomSliceEditor"
+                         x:Name="Root" mc:Ignorable="d"
+                         Title="Add To Watches As Array" Height="160" Width="300" MinHeight="150" MinWidth="200"
+                         Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+                         Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}">
+    <platformui:DialogWindow.Resources>
+        <ResourceDictionary Source="../ToolWindows/ControlStyle.xaml"/>
+    </platformui:DialogWindow.Resources>
+    <DockPanel Margin="4">
+        <StackPanel Margin="4" Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Bottom">
+            <Button Content="OK" Width="61" Height="22" Click="HandleOK"/>
+            <Button Content="Cancel" IsCancel="True" Width="61" Height="22" Margin="4,0,0,0" />
+        </StackPanel>
+        <Grid x:Name="HostGrid" Margin="4" Focusable="True">
+            <Grid.RowDefinitions>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="60"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Text="Start:" VerticalAlignment="Center" Grid.Column="0" Grid.Row="0"/>
+            <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="StartControl" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="0"/>
+            <TextBlock Text="Step:" VerticalAlignment="Center" Grid.Column="0" Grid.Row="1"/>
+            <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="StepControl" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="1"/>
+            <TextBlock Text="Count:" VerticalAlignment="Center" Grid.Column="0" Grid.Row="2"/>
+            <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="CountControl" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="2"/>
+        </Grid>
+    </DockPanel>
+</platformui:DialogWindow>

--- a/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml
+++ b/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml
@@ -27,9 +27,9 @@
             <TextBlock Text="Start:" VerticalAlignment="Center" Grid.Column="0" Grid.Row="0"/>
             <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="StartControl" Focusable="True" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="0"/>
             <TextBlock Text="Step:" VerticalAlignment="Center" Grid.Column="0" Grid.Row="1"/>
-            <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="StepControl" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="1"/>
+            <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="StepControl" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="1" Minimum="1"/>
             <TextBlock Text="Count:" VerticalAlignment="Center" Grid.Column="0" Grid.Row="2"/>
-            <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="CountControl" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="2"/>
+            <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="CountControl" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="2" Minimum="1"/>
         </Grid>
         <StackPanel Margin="4" Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Bottom">
             <Button Content="OK" Width="61" Height="22" Click="HandleOK" IsDefault="True"/>

--- a/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml
+++ b/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml
@@ -29,7 +29,7 @@
             <TextBlock Text="Step:" VerticalAlignment="Center" Grid.Column="0" Grid.Row="1"/>
             <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="StepControl" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="1" Minimum="1"/>
             <TextBlock Text="Count:" VerticalAlignment="Center" Grid.Column="0" Grid.Row="2"/>
-            <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="CountControl" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="2" Minimum="1"/>
+            <viz:NumberInput Margin="5,0,0,0" Width="40" x:Name="CountControl" HorizontalAlignment="Left" Grid.Column="1" Grid.Row="2" Minimum="1" Maximum="256"/>
         </Grid>
         <StackPanel Margin="4" Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Bottom">
             <Button Content="OK" Width="61" Height="22" Click="HandleOK" IsDefault="True"/>

--- a/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml.cs
+++ b/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml.cs
@@ -28,6 +28,7 @@ namespace VSRAD.Package.Commands
 
         public AddToWatchesCustomSliceEditor(CreateSlice createSliceHandler, string watchName)
         {
+            Loaded += (s, e) => MoveFocus(new TraversalRequest(FocusNavigationDirection.First));
             _watchName = watchName;
             _createSlice = createSliceHandler;
             InitializeComponent();

--- a/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml.cs
+++ b/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.VisualStudio.PlatformUI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace VSRAD.Package.Commands
+{
+    /// <summary>
+    /// Interaction logic for UserControl1.xaml
+    /// </summary>
+    public partial class AddToWatchesCustomSliceEditor : DialogWindow
+    {
+        public delegate void CreateSlice(uint start, uint step, uint count, string watchName);
+        private CreateSlice _createSlice;
+
+        private string _watchName;
+
+        public AddToWatchesCustomSliceEditor(CreateSlice createSliceHandler, string watchName)
+        {
+            _watchName = watchName;
+            _createSlice = createSliceHandler;
+            InitializeComponent();
+        }
+
+        private void HandleOK(object sender, RoutedEventArgs e)
+        {
+            _createSlice(StartControl.Value, StepControl.Value, CountControl.Value, _watchName);
+            Close();
+        }
+    }
+}

--- a/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml.cs
+++ b/VSRAD.Package/Commands/AddToWatchesCustomSliceEditor.xaml.cs
@@ -17,7 +17,7 @@ using System.Windows.Shapes;
 namespace VSRAD.Package.Commands
 {
     /// <summary>
-    /// Interaction logic for UserControl1.xaml
+    /// Interaction logic for AddToWatchesCustomSliceEditor.xaml
     /// </summary>
     public partial class AddToWatchesCustomSliceEditor : DialogWindow
     {

--- a/VSRAD.Package/Constants.cs
+++ b/VSRAD.Package/Constants.cs
@@ -32,6 +32,7 @@ namespace VSRAD.Package
         public const int DebugActionCommandId = 0x13;
         public const int EvaluateSelectedCommandId = 0x0100;
         public const int AddToWatchesCommandId = 0x0100;
+        public const int AddToWatchesArrayCustomCommandId = 0x1900;
         public const int AddArrayToWatchesIndexCount = 16;
         public const int AddArrayToWatchesFromHeaderId = 0x1031;
         public const int AddArrayToWatchesToIdOffset = 0x1400;

--- a/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/ComputedColumnStyling.cs
@@ -22,7 +22,7 @@ namespace VSRAD.Package.DebugVisualizer
         private uint _groupSize;
         private uint _waveSize;
 
-        public void Recompute(VisualizerOptions options, ColumnStylingOptions styling, uint groupSize, uint waveSize, Server.WatchView system)
+        public void Recompute(VisualizerOptions options, VisualizerAppearance appearance, ColumnStylingOptions styling, uint groupSize, uint waveSize, Server.WatchView system)
         {
             _groupSize = groupSize;
             _waveSize = waveSize;
@@ -33,7 +33,7 @@ namespace VSRAD.Package.DebugVisualizer
                 ColumnState[i] |= ColumnStates.Visible;
 
             ComputeInactiveLanes(options, system);
-            ComputeLaneGrouping(options);
+            ComputeLaneGrouping(appearance);
             ComputeHiddenColumnSeparators();
         }
 
@@ -61,7 +61,7 @@ namespace VSRAD.Package.DebugVisualizer
             }
         }
 
-        private void ComputeLaneGrouping(VisualizerOptions options)
+        private void ComputeLaneGrouping(VisualizerAppearance options)
         {
             var laneGrouping = options.VerticalSplit ? options.LaneGrouping : 0;
             if (laneGrouping == 0 || laneGrouping > _groupSize)

--- a/VSRAD.Package/DebugVisualizer/NumberInput.xaml
+++ b/VSRAD.Package/DebugVisualizer/NumberInput.xaml
@@ -35,6 +35,7 @@
                  VerticalContentAlignment="Center" Height="24"
                  Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
                  Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
-                 BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
+                 BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"
+                 GotKeyboardFocus="SetSelectionOnTexboxKeyboardFocus"/>
     </DockPanel>
 </UserControl>

--- a/VSRAD.Package/DebugVisualizer/NumberInput.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/NumberInput.xaml.cs
@@ -115,5 +115,8 @@ namespace VSRAD.Package.DebugVisualizer
             // When the control loses focus, the displayed value should match the external binding (Value).
             RawValue = Value.ToString();
         }
+
+        private void SetSelectionOnTexboxKeyboardFocus(object sender, System.Windows.Input.KeyboardFocusChangedEventArgs e) =>
+            ((TextBox)sender).SelectAll();
     }
 }

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
@@ -27,7 +27,7 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
 
         public string this[int row, int column]
         {
-            get => DataFormatter.FormatDword(_type, _view[row, column]);
+            get => DataFormatter.FormatDword(_type, _view[row, column], 2, 0, true); // TODO: remove hardcode
         }
 
         public bool IsInactiveCell(int row, int column) => _view.IsInactiveCell(row, column);

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -163,6 +163,8 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                     );
                     break;
                 case nameof(Options.VisualizerOptions.BinHexSeparator):
+                case nameof(Options.VisualizerOptions.IntUintSeparator):
+                case nameof(Options.VisualizerOptions.BinHexLeadingZeroes):
                     foreach (System.Windows.Forms.DataGridViewRow row in _table.Rows)
                         SetRowContentsFromBreakState(row);
                     break;
@@ -185,7 +187,8 @@ To switch to manual grid size selection, right-click on the space next to the Gr
             if (row.Index == 0)
             {
                 RenderRowData(row, _context.Options.DebuggerOptions.GroupSize, _context.BreakData.GetSystem(),
-                    _context.Options.VisualizerOptions.BinHexSeparator, 3, true); // TODO: remove hardcode
+                    _context.Options.VisualizerOptions.BinHexSeparator, _context.Options.VisualizerOptions.IntUintSeparator,
+                    _context.Options.VisualizerOptions.BinHexLeadingZeroes);
             }
             else
             {
@@ -193,7 +196,8 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                 var watchData = _context.BreakData.GetWatch(watch);
                 if (watchData != null)
                     RenderRowData(row, _context.Options.DebuggerOptions.GroupSize, watchData,
-                        _context.Options.VisualizerOptions.BinHexSeparator, 3, true); // TODO: remove hardcode
+                        _context.Options.VisualizerOptions.BinHexSeparator, _context.Options.VisualizerOptions.IntUintSeparator,
+                        _context.Options.VisualizerOptions.BinHexLeadingZeroes);
                 else
                     EraseRowData(row, _table.DataColumnCount);
             }

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -137,9 +137,9 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                     break;
                 case nameof(Options.DebuggerOptions.GroupSize):
                 case nameof(Options.VisualizerOptions.MaskLanes):
-                case nameof(Options.VisualizerOptions.LaneGrouping):
                 case nameof(Options.VisualizerOptions.CheckMagicNumber):
-                case nameof(Options.VisualizerOptions.VerticalSplit):
+                case nameof(Options.VisualizerAppearance.LaneGrouping):
+                case nameof(Options.VisualizerAppearance.VerticalSplit):
                 case nameof(Options.VisualizerAppearance.LaneSeparatorWidth):
                 case nameof(Options.VisualizerAppearance.HiddenColumnSeparatorWidth):
                 case nameof(Options.VisualizerAppearance.DarkenAlternatingRowsBy):
@@ -162,9 +162,9 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                         _context.Options.VisualizerAppearance.HeadersAlignment
                     );
                     break;
-                case nameof(Options.VisualizerOptions.BinHexSeparator):
-                case nameof(Options.VisualizerOptions.IntUintSeparator):
-                case nameof(Options.VisualizerOptions.BinHexLeadingZeroes):
+                case nameof(Options.VisualizerAppearance.BinHexSeparator):
+                case nameof(Options.VisualizerAppearance.IntUintSeparator):
+                case nameof(Options.VisualizerAppearance.BinHexLeadingZeroes):
                     foreach (System.Windows.Forms.DataGridViewRow row in _table.Rows)
                         SetRowContentsFromBreakState(row);
                     break;
@@ -187,8 +187,8 @@ To switch to manual grid size selection, right-click on the space next to the Gr
             if (row.Index == 0)
             {
                 RenderRowData(row, _context.Options.DebuggerOptions.GroupSize, _context.BreakData.GetSystem(),
-                    _context.Options.VisualizerOptions.BinHexSeparator, _context.Options.VisualizerOptions.IntUintSeparator,
-                    _context.Options.VisualizerOptions.BinHexLeadingZeroes);
+                    _context.Options.VisualizerAppearance.BinHexSeparator, _context.Options.VisualizerAppearance.IntUintSeparator,
+                    _context.Options.VisualizerAppearance.BinHexLeadingZeroes);
             }
             else
             {
@@ -196,8 +196,8 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                 var watchData = _context.BreakData.GetWatch(watch);
                 if (watchData != null)
                     RenderRowData(row, _context.Options.DebuggerOptions.GroupSize, watchData,
-                        _context.Options.VisualizerOptions.BinHexSeparator, _context.Options.VisualizerOptions.IntUintSeparator,
-                        _context.Options.VisualizerOptions.BinHexLeadingZeroes);
+                        _context.Options.VisualizerAppearance.BinHexSeparator, _context.Options.VisualizerAppearance.IntUintSeparator,
+                        _context.Options.VisualizerAppearance.BinHexLeadingZeroes);
                 else
                     EraseRowData(row, _table.DataColumnCount);
             }

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -162,6 +162,10 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                         _context.Options.VisualizerAppearance.HeadersAlignment
                     );
                     break;
+                case nameof(Options.VisualizerOptions.BinHexSeparator):
+                    foreach (System.Windows.Forms.DataGridViewRow row in _table.Rows)
+                        SetRowContentsFromBreakState(row);
+                    break;
             }
         }
 
@@ -180,14 +184,16 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                 return;
             if (row.Index == 0)
             {
-                RenderRowData(row, _context.Options.DebuggerOptions.GroupSize, _context.BreakData.GetSystem());
+                RenderRowData(row, _context.Options.DebuggerOptions.GroupSize, _context.BreakData.GetSystem(),
+                    _context.Options.VisualizerOptions.BinHexSeparator, 3, true); // TODO: remove hardcode
             }
             else
             {
                 var watch = (string)row.Cells[VisualizerTable.NameColumnIndex].Value;
                 var watchData = _context.BreakData.GetWatch(watch);
                 if (watchData != null)
-                    RenderRowData(row, _context.Options.DebuggerOptions.GroupSize, watchData);
+                    RenderRowData(row, _context.Options.DebuggerOptions.GroupSize, watchData,
+                        _context.Options.VisualizerOptions.BinHexSeparator, 3, true); // TODO: remove hardcode
                 else
                     EraseRowData(row, _table.DataColumnCount);
             }
@@ -199,11 +205,12 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                 row.Cells[i + VisualizerTable.DataColumnOffset].Value = "";
         }
 
-        private static void RenderRowData(System.Windows.Forms.DataGridViewRow row, uint groupSize, WatchView data)
+        private static void RenderRowData(System.Windows.Forms.DataGridViewRow row, uint groupSize, WatchView data, uint binHexSeparator, uint intSeparator, bool leadingZeroes)
         {
             var variableType = VariableTypeUtils.TypeFromShortName(row.HeaderCell.Value.ToString());
             for (int i = 0; i < groupSize; i++)
-                row.Cells[i + VisualizerTable.DataColumnOffset].Value = DataFormatter.FormatDword(variableType, data[i]);
+                row.Cells[i + VisualizerTable.DataColumnOffset].Value = DataFormatter.FormatDword(variableType, data[i],
+                                                                            binHexSeparator, intSeparator, leadingZeroes);
         }
     }
 }

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -359,7 +359,7 @@ namespace VSRAD.Package.DebugVisualizer
 
             CreateMissingDataColumns((int)options.DebuggerOptions.GroupSize);
 
-            _computedStyling.Recompute(options.VisualizerOptions, options.VisualizerColumnStyling,
+            _computedStyling.Recompute(options.VisualizerOptions, options.VisualizerAppearance, options.VisualizerColumnStyling,
                 options.DebuggerOptions.GroupSize, options.DebuggerOptions.WaveSize, system);
 
             ApplyFontAndColorInfo();

--- a/VSRAD.Package/Options/VisualizerAppearance.cs
+++ b/VSRAD.Package/Options/VisualizerAppearance.cs
@@ -28,6 +28,12 @@ namespace VSRAD.Package.Options
         }
         #endregion
         #region diviers
+        private uint _laneGrouping;
+        public uint LaneGrouping { get => _laneGrouping; set => SetField(ref _laneGrouping, value); }
+
+        private bool _verticalSplit = true;
+        public bool VerticalSplit { get => _verticalSplit; set => SetField(ref _verticalSplit, value); }
+
         private int _laneSeparatorWidth = 3;
         public int LaneSeparatorWidth
         {
@@ -41,6 +47,16 @@ namespace VSRAD.Package.Options
             get => _hiddenColumnSeparatorWidth;
             set => SetField(ref _hiddenColumnSeparatorWidth, value);
         }
+        #endregion
+        private uint _binHexSeparator;
+        public uint BinHexSeparator { get => _binHexSeparator; set => SetField(ref _binHexSeparator, value); }
+
+        private uint _intUintSeparator;
+        public uint IntUintSeparator { get => _intUintSeparator; set => SetField(ref _intUintSeparator, value); }
+
+        private bool _binHexLeadingZeroes;
+        public bool BinHexLeadingZeroes { get => _binHexLeadingZeroes; set => SetField(ref _binHexLeadingZeroes, value); }
+        #region number separators
         #endregion
         private ScalingMode _scalingMode = ScalingMode.ResizeColumn;
 

--- a/VSRAD.Package/Options/VisualizerAppearance.cs
+++ b/VSRAD.Package/Options/VisualizerAppearance.cs
@@ -48,6 +48,7 @@ namespace VSRAD.Package.Options
             set => SetField(ref _hiddenColumnSeparatorWidth, value);
         }
         #endregion
+        #region number separators
         private uint _binHexSeparator;
         public uint BinHexSeparator { get => _binHexSeparator; set => SetField(ref _binHexSeparator, value); }
 
@@ -56,7 +57,6 @@ namespace VSRAD.Package.Options
 
         private bool _binHexLeadingZeroes;
         public bool BinHexLeadingZeroes { get => _binHexLeadingZeroes; set => SetField(ref _binHexLeadingZeroes, value); }
-        #region number separators
         #endregion
         private ScalingMode _scalingMode = ScalingMode.ResizeColumn;
 

--- a/VSRAD.Package/Options/VisualizerOptions.cs
+++ b/VSRAD.Package/Options/VisualizerOptions.cs
@@ -27,6 +27,12 @@ namespace VSRAD.Package.Options
         private uint _binHexSeparator;
         public uint BinHexSeparator { get => _binHexSeparator; set => SetField(ref _binHexSeparator, value); }
 
+        private uint _intUintSeparator;
+        public uint IntUintSeparator { get => _intUintSeparator; set => SetField(ref _intUintSeparator, value); }
+
+        private bool _binHexLeadingZeroes;
+        public bool BinHexLeadingZeroes { get => _binHexLeadingZeroes; set => SetField(ref _binHexLeadingZeroes, value); }
+
         private int _wavemapElementSize = 8;
         [DefaultValue(8)]
         public int WavemapElementSize { get => _wavemapElementSize; set => SetField(ref _wavemapElementSize, Math.Max(value, 7)); }

--- a/VSRAD.Package/Options/VisualizerOptions.cs
+++ b/VSRAD.Package/Options/VisualizerOptions.cs
@@ -18,21 +18,6 @@ namespace VSRAD.Package.Options
         private bool _ndrange3d = false;
         public bool NDRange3D { get => _ndrange3d; set => SetField(ref _ndrange3d, value); }
 
-        private bool _verticalSplit = true;
-        public bool VerticalSplit { get => _verticalSplit; set => SetField(ref _verticalSplit, value); }
-
-        private uint _laneGrouping;
-        public uint LaneGrouping { get => _laneGrouping; set => SetField(ref _laneGrouping, value); }
-
-        private uint _binHexSeparator;
-        public uint BinHexSeparator { get => _binHexSeparator; set => SetField(ref _binHexSeparator, value); }
-
-        private uint _intUintSeparator;
-        public uint IntUintSeparator { get => _intUintSeparator; set => SetField(ref _intUintSeparator, value); }
-
-        private bool _binHexLeadingZeroes;
-        public bool BinHexLeadingZeroes { get => _binHexLeadingZeroes; set => SetField(ref _binHexLeadingZeroes, value); }
-
         private int _wavemapElementSize = 8;
         [DefaultValue(8)]
         public int WavemapElementSize { get => _wavemapElementSize; set => SetField(ref _wavemapElementSize, Math.Max(value, 7)); }

--- a/VSRAD.Package/Options/VisualizerOptions.cs
+++ b/VSRAD.Package/Options/VisualizerOptions.cs
@@ -24,6 +24,9 @@ namespace VSRAD.Package.Options
         private uint _laneGrouping;
         public uint LaneGrouping { get => _laneGrouping; set => SetField(ref _laneGrouping, value); }
 
+        private uint _binHexSeparator;
+        public uint BinHexSeparator { get => _binHexSeparator; set => SetField(ref _binHexSeparator, value); }
+
         private int _wavemapElementSize = 8;
         [DefaultValue(8)]
         public int WavemapElementSize { get => _wavemapElementSize; set => SetField(ref _wavemapElementSize, Math.Max(value, 7)); }

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -159,16 +159,16 @@
                                             Value="{Binding Options.VisualizerAppearance.HiddenColumnSeparatorWidth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Height="25">
-                            <TextBlock Text="Insert separator in binary/hex mode between each" VerticalAlignment="Center"/>
+                            <TextBlock Text="Insert separator in binary/hex mode between groups of" VerticalAlignment="Center"/>
                             <viz:NumberInput Width="30" VerticalAlignment="Center" Margin="5,0,0,0" Padding="0"
                                         Value="{Binding Options.VisualizerAppearance.BinHexSeparator, UpdateSourceTrigger=PropertyChanged}"/>
-                            <TextBlock Text="numbers" VerticalAlignment="Center" Margin="5,0,0,0"/>
+                            <TextBlock Text="digits" VerticalAlignment="Center" Margin="5,0,0,0"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Height="25">
-                            <TextBlock Text="Insert separator in int/uint mode between each" VerticalAlignment="Center"/>
+                            <TextBlock Text="Insert separator in int/uint mode between groups of" VerticalAlignment="Center"/>
                             <viz:NumberInput Width="30" VerticalAlignment="Center" Margin="5,0,0,0" Padding="0"
                                         Value="{Binding Options.VisualizerAppearance.IntUintSeparator, UpdateSourceTrigger=PropertyChanged}"/>
-                            <TextBlock Text="numbers" VerticalAlignment="Center" Margin="5,0,0,0"/>
+                            <TextBlock Text="digits" VerticalAlignment="Center" Margin="5,0,0,0"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Height="25">
                             <TextBlock Text="Darken odd rows by" VerticalAlignment="Center"/>

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -92,13 +92,6 @@
                              Text="{Binding Options.VisualizerOptions.MagicNumber, Converter={StaticResource MagicNumberConverter}, UpdateSourceTrigger=PropertyChanged}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Height="25">
-                    <CheckBox Content="Vertical separator between each" VerticalAlignment="Center" Padding="4,0,0,0"
-                            IsChecked="{Binding Options.VisualizerOptions.VerticalSplit, UpdateSourceTrigger=PropertyChanged}"/>
-                    <TextBox Width="30" VerticalAlignment="Center" Margin="5,0,0,0" Padding="0"
-                                        Text="{Binding Options.VisualizerOptions.LaneGrouping, UpdateSourceTrigger=PropertyChanged}"/>
-                    <TextBlock Text="columns" VerticalAlignment="Center" Margin="5,0,0,0"/>
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Height="25">
                     <CheckBox Content="Autosave opened files" VerticalAlignment="Center" Padding="4,0,0,0"
                             IsChecked="{Binding Options.DebuggerOptions.Autosave, UpdateSourceTrigger=PropertyChanged}"/>
                 </StackPanel>
@@ -145,6 +138,17 @@
                             <Button Content="R" Click="AlignmentButtonClick" Width="20" Margin="5,0,0,0" Tag="data"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Height="25">
+                            <CheckBox Content="Vertical separator between each" VerticalAlignment="Center"
+                                IsChecked="{Binding Options.VisualizerAppearance.VerticalSplit, UpdateSourceTrigger=PropertyChanged}"/>
+                            <TextBox Width="30" VerticalAlignment="Center" Margin="5,0,0,0" Padding="0"
+                                        Text="{Binding Options.VisualizerAppearance.LaneGrouping, UpdateSourceTrigger=PropertyChanged}"/>
+                            <TextBlock Text="columns" VerticalAlignment="Center" Margin="5,0,0,0"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Height="25">
+                            <CheckBox Content="Append leading zeroes to binary/hex numbers" VerticalAlignment="Center"
+                                      IsChecked="{Binding Options.VisualizerAppearance.BinHexLeadingZeroes, UpdateSourceTrigger=PropertyChanged}"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Height="25">
                             <TextBlock Text="Column Separator Width:" VerticalAlignment="Center"/>
                             <viz:NumberInput VerticalAlignment="Center" Width="50" Minimum="1" Maximum="25" Margin="5,0,0,0"
                                             Value="{Binding Options.VisualizerAppearance.LaneSeparatorWidth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
@@ -155,19 +159,15 @@
                                             Value="{Binding Options.VisualizerAppearance.HiddenColumnSeparatorWidth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Height="25">
-                            <CheckBox Content="Append leading zeroes to binary/hex numbers" VerticalAlignment="Center"
-                                      IsChecked="{Binding Options.VisualizerOptions.BinHexLeadingZeroes, UpdateSourceTrigger=PropertyChanged}"/>
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Height="25">
                             <TextBlock Text="Insert separator in binary/hex mode between each" VerticalAlignment="Center"/>
                             <viz:NumberInput Width="30" VerticalAlignment="Center" Margin="5,0,0,0" Padding="0"
-                                        Value="{Binding Options.VisualizerOptions.BinHexSeparator, UpdateSourceTrigger=PropertyChanged}"/>
+                                        Value="{Binding Options.VisualizerAppearance.BinHexSeparator, UpdateSourceTrigger=PropertyChanged}"/>
                             <TextBlock Text="numbers" VerticalAlignment="Center" Margin="5,0,0,0"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Height="25">
                             <TextBlock Text="Insert separator in int/uint mode between each" VerticalAlignment="Center"/>
                             <viz:NumberInput Width="30" VerticalAlignment="Center" Margin="5,0,0,0" Padding="0"
-                                        Value="{Binding Options.VisualizerOptions.IntUintSeparator, UpdateSourceTrigger=PropertyChanged}"/>
+                                        Value="{Binding Options.VisualizerAppearance.IntUintSeparator, UpdateSourceTrigger=PropertyChanged}"/>
                             <TextBlock Text="numbers" VerticalAlignment="Center" Margin="5,0,0,0"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Height="25">

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -155,9 +155,19 @@
                                             Value="{Binding Options.VisualizerAppearance.HiddenColumnSeparatorWidth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Height="25">
+                            <CheckBox Content="Append leading zeroes to binary/hex numbers" VerticalAlignment="Center"
+                                      IsChecked="{Binding Options.VisualizerOptions.BinHexLeadingZeroes, UpdateSourceTrigger=PropertyChanged}"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Height="25">
                             <TextBlock Text="Insert separator in binary/hex mode between each" VerticalAlignment="Center"/>
                             <viz:NumberInput Width="30" VerticalAlignment="Center" Margin="5,0,0,0" Padding="0"
                                         Value="{Binding Options.VisualizerOptions.BinHexSeparator, UpdateSourceTrigger=PropertyChanged}"/>
+                            <TextBlock Text="numbers" VerticalAlignment="Center" Margin="5,0,0,0"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Height="25">
+                            <TextBlock Text="Insert separator in int/uint mode between each" VerticalAlignment="Center"/>
+                            <viz:NumberInput Width="30" VerticalAlignment="Center" Margin="5,0,0,0" Padding="0"
+                                        Value="{Binding Options.VisualizerOptions.IntUintSeparator, UpdateSourceTrigger=PropertyChanged}"/>
                             <TextBlock Text="numbers" VerticalAlignment="Center" Margin="5,0,0,0"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Height="25">

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -155,6 +155,12 @@
                                             Value="{Binding Options.VisualizerAppearance.HiddenColumnSeparatorWidth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Height="25">
+                            <TextBlock Text="Insert separator in binary/hex mode between each" VerticalAlignment="Center"/>
+                            <viz:NumberInput Width="30" VerticalAlignment="Center" Margin="5,0,0,0" Padding="0"
+                                        Value="{Binding Options.VisualizerOptions.BinHexSeparator, UpdateSourceTrigger=PropertyChanged}"/>
+                            <TextBlock Text="numbers" VerticalAlignment="Center" Margin="5,0,0,0"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Height="25">
                             <TextBlock Text="Darken odd rows by" VerticalAlignment="Center"/>
                             <viz:NumberInput VerticalAlignment="Center" Width="50" Minimum="0" Maximum="100" Margin="5,0,0,0"
                                             Value="{Binding Options.VisualizerAppearance.DarkenAlternatingRowsBy, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>

--- a/VSRAD.Package/Utils/ArrayRange.cs
+++ b/VSRAD.Package/Utils/ArrayRange.cs
@@ -38,5 +38,26 @@ namespace VSRAD.Package.Utils
             }
             return result;
         }
+
+        public static string[] FormatCustomSlice(string name, int start, int step, int count)
+        {
+            var numericMatch = _numericIndexPattern.Match(name);
+            var symbolMatch = _symbolIndexPattern.Match(name);
+
+            var result = new string[count];
+            if (numericMatch.Success || (!numericMatch.Success && !symbolMatch.Success))
+            {
+                for (int i = 0; i < count; i++)
+                    result[i] = $"{name}[{start + (i * step)}]";
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                    result[i] = start + (i * step) < 0
+                        ? name.Replace(symbolMatch.Value, $"{symbolMatch.Value.TrimEnd(']')}{start + (i * step)}]")
+                        : name.Replace(symbolMatch.Value, $"{symbolMatch.Value.TrimEnd(']')}+{start + (i * step)}]");
+            }
+            return result;
+        }
     }
 }

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -40,9 +40,9 @@ namespace VSRAD.Package.Utils
                 case VariableType.Float:
                     return BitConverter.ToSingle(BitConverter.GetBytes(data), 0).ToString();
                 case VariableType.Uint:
-                    return data.ToString();
+                    return intSeparator == 0 ? data.ToString() : InsertNumberSeparators(data.ToString(), intSeparator);
                 case VariableType.Int:
-                    return ((int)data).ToString();
+                    return intSeparator == 0 ? ((int)data).ToString() : InsertNumberSeparators(((int)data).ToString(), intSeparator);
                 case VariableType.Half:
                     byte[] bytes = BitConverter.GetBytes(data);
                     float firstHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 0));

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -1,16 +1,42 @@
 ﻿using System;
+using System.Text;
 using VSRAD.Package.DebugVisualizer;
 
 namespace VSRAD.Package.Utils
 {
     static class DataFormatter
     {
-        public static string FormatDword(VariableType variableType, uint data)
+        private static string InsertNumberSeparators(string str, uint sep)
+        {
+            var sb = new StringBuilder();
+            // If leading zeroes option is turned off we want separators
+            // to be between N characters starting from last one, not the
+            // first: 0x3 13, not 0x31 3, considering we have separators
+            // between every two numbers. That's why string is actually
+            // processed from the last character to first
+            for (int i = str.Length - 1, s = (int)sep - 1; i >= 0; i--, s--)
+            {
+                sb.Insert(0, str[i]);
+                if (s == 0 && i != 0) // exclude i == 0 to avoid extra space after type prefix
+                {
+                    sb.Insert(0, " ");
+                    s = (int)sep;
+                }
+            }
+            return sb.ToString();
+        }
+
+        public static string FormatDword(VariableType variableType, uint data, uint binHexSeparator, uint intSeparator, bool leadingZeroes)
         {
             switch (variableType)
             {
                 case VariableType.Hex:
-                    return "0x" + data.ToString("x");
+                    var hex = data.ToString("x");
+                    if (leadingZeroes)
+                        hex = hex.PadLeft(8, '0');
+                    if (binHexSeparator != 0)
+                        hex = InsertNumberSeparators(hex, binHexSeparator);
+                    return "0x" + hex;
                 case VariableType.Float:
                     return BitConverter.ToSingle(BitConverter.GetBytes(data), 0).ToString();
                 case VariableType.Uint:
@@ -23,7 +49,12 @@ namespace VSRAD.Package.Utils
                     float secondHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 2));
                     return $"({firstHalf}; {secondHalf})";
                 case VariableType.Bin:
-                    return "0b" + Convert.ToString(data, 2);
+                    var bin = Convert.ToString(data, 2);
+                    if (leadingZeroes)
+                        bin = bin.PadLeft(32, '0');
+                    if (binHexSeparator != 0)
+                        bin = InsertNumberSeparators(bin, binHexSeparator);
+                    return "0b" + bin;
                 default:
                     return string.Empty;
             }

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -136,6 +136,9 @@
     <Compile Include="Commands\ToolWindowCommand.cs" />
     <Compile Include="Commands\EvaluateSelectedCommand.cs" />
     <Compile Include="Commands\ForceRunToCursorCommand.cs" />
+    <Compile Include="Commands\AddToWatchesCustomSliceEditor.xaml.cs">
+      <DependentUpon>AddToWatchesCustomSliceEditor.xaml</DependentUpon>
+    </Compile>
     <Compile Include="DebugVisualizer\CellStyling.cs" />
     <Compile Include="DebugVisualizer\ComputedColumnStyling.cs" />
     <Compile Include="DebugVisualizer\FontAndColorState.cs" />
@@ -398,6 +401,10 @@
     </XamlPropertyRule>
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Commands\AddToWatchesCustomSliceEditor.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="DebugVisualizer\NumberInputStyle.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/VSRAD.Package/VSRAD.Package.tt
+++ b/VSRAD.Package/VSRAD.Package.tt
@@ -167,6 +167,14 @@
           <LocCanonicalName>RadDebug.AddToWatches</LocCanonicalName>
         </Strings>
       </Button>
+      <Button guid="guidCmdSetAddToWatches" id="AddToWatchesCustomCommandId" priority="0x1401" type="Button">
+        <Parent guid="guidCmdSetAddToWatches" id="AddArrayToWatchesMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Custom</ButtonText>
+        </Strings>
+      </Button>
       <Button guid="guidCmdSetAddToWatches" id="AddArrayToWatchesFromHeaderId" priority="0x1000">
         <Parent guid="guidCmdSetAddToWatches" id="AddArrayToWatchesMenuGroup" />
         <CommandFlag>DynamicVisibility</CommandFlag>
@@ -315,6 +323,7 @@
       <IDSymbol value="0x1025" name="AddArrayToWatchesMenuGroup" />
       <IDSymbol value="0x1030" name="AddArrayToWatchesMenuId" />
       <IDSymbol value="0x1031" name="AddArrayToWatchesFromHeaderId" />
+      <IDSymbol value="0x1900" name="AddToWatchesCustomCommandId" />
 <# for (int i = 0; i < 16; ++i) { #>
       <IDSymbol value="0x<#= (0x1100 + i).ToString("x") #>" name="AddArrayToWatchesMenuFrom<#= i #>Id" />
       <IDSymbol value="0x<#= (0x4100 + i).ToString("x") #>" name="AddArrayToWatchesMenuFrom<#= i #>Group" />

--- a/VSRAD.PackageTests/DebugVisualizer/ColumnStylingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/ColumnStylingTests.cs
@@ -28,7 +28,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             var columns = GenerateTestColumns();
 
             var computedStyling = new ComputedColumnStyling();
-            computedStyling.Recompute(new VisualizerOptions(), options, groupSize: 32, waveSize: 32, system: null);
+            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance(), options, groupSize: 32, waveSize: 32, system: null);
 
             new ColumnStyling(new VisualizerAppearance(), options, computedStyling, MakeColorState()).Apply(columns);
 
@@ -57,7 +57,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             var computedStyling = new ComputedColumnStyling();
             var options = new ColumnStylingOptions { BackgroundColors = null, ForegroundColors = "" };
 
-            computedStyling.Recompute(visualizerOptions, options, groupSize: 8, waveSize: 8, system: null);
+            computedStyling.Recompute(visualizerOptions, new VisualizerAppearance(), options, groupSize: 8, waveSize: 8, system: null);
             new ColumnStyling(appearance, options, computedStyling, MakeColorState()).Apply(columns);
             for (int i = 0; i < 8; ++i)
             {
@@ -67,7 +67,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
 
             columns = GenerateTestColumns();
             options = new ColumnStylingOptions { BackgroundColors = null, ForegroundColors = "rgbJKFJ" + new string(' ', 512 - "rgbJKFJ".Length) };
-            computedStyling.Recompute(visualizerOptions, options, groupSize: 8, waveSize: 8, system: null);
+            computedStyling.Recompute(visualizerOptions, new VisualizerAppearance(), options, groupSize: 8, waveSize: 8, system: null);
             new ColumnStyling(appearance, options, computedStyling, MakeColorState()).Apply(columns);
 
             for (int i = 0; i < 8; ++i)
@@ -88,7 +88,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
 
             options = new ColumnStylingOptions { BackgroundColors = bgString, ForegroundColors = fgString };
 
-            computedStyling.Recompute(visualizerOptions, options, groupSize: 8, waveSize: 8, system: null);
+            computedStyling.Recompute(visualizerOptions, new VisualizerAppearance(), options, groupSize: 8, waveSize: 8, system: null);
             new ColumnStyling(appearance, options, computedStyling, MakeColorState()).Apply(columns);
 
             for (int i = 0; i < 8; ++i)
@@ -114,7 +114,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             var columns = GenerateTestColumns();
 
             var computedStyling = new ComputedColumnStyling();
-            computedStyling.Recompute(new VisualizerOptions { LaneGrouping = 4 }, options, groupSize: 32, waveSize: 32, system: null);
+            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 4 }, options, groupSize: 32, waveSize: 32, system: null);
             new ColumnStyling(appearance, options, computedStyling, MakeColorState()).Apply(columns);
 
             // 2 3 | 4 5 6 || 8 9 || 11 | 12 || 14 15 | 16
@@ -137,15 +137,15 @@ namespace VSRAD.PackageTests.DebugVisualizer
             Assert.Equal(laneSep, columns[15].DividerWidth);
 
             options.VisibleColumns = "0-511";
-            computedStyling.Recompute(new VisualizerOptions { LaneGrouping = 3 }, options, groupSize: 512, waveSize: 32, system: null);
+            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 3}, options, groupSize: 512, waveSize: 32, system: null);
             new ColumnStyling(new VisualizerAppearance(), options, computedStyling, MakeColorState()).Apply(columns);
             // no assertions here, this is just to trigger an index out of bounds if we're not careful with grouping
 
-            computedStyling.Recompute(new VisualizerOptions { LaneGrouping = 1 }, options, groupSize: 512, waveSize: 32, system: null);
+            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 1 }, options, groupSize: 512, waveSize: 32, system: null);
             new ColumnStyling(new VisualizerAppearance(), options, computedStyling, MakeColorState()).Apply(columns);
             Assert.NotEqual(0, columns[0].DividerWidth); // 0 should be separated
 
-            computedStyling.Recompute(new VisualizerOptions { LaneGrouping = 0 }, options, groupSize: 512, waveSize: 32, system: null);
+            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 0 }, options, groupSize: 512, waveSize: 32, system: null);
             new ColumnStyling(new VisualizerAppearance(), options, computedStyling, MakeColorState()).Apply(columns);
             for (int i = 0; i < 256; i++)
                 Assert.Equal(0, columns[i].DividerWidth);
@@ -160,7 +160,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             options.VisibleColumns = "0,111111111111111111111,34-111111111111111111111,111111111111111111111-34,1-2";
 
             var computedStyling = new ComputedColumnStyling();
-            computedStyling.Recompute(new VisualizerOptions { LaneGrouping = 1 }, options, groupSize: 512, waveSize: 32, system: null);
+            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 1 }, options, groupSize: 512, waveSize: 32, system: null);
             new ColumnStyling(new VisualizerAppearance(), options, computedStyling, MakeColorState()).Apply(columns);
 
             Assert.True(columns[0].Visible);

--- a/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
@@ -41,7 +41,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             system[9] = (uint)tmp[0];
 
             var styling = new ComputedColumnStyling();
-            styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = false }, new ColumnStylingOptions(),
+            styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = false }, new VisualizerAppearance(), new ColumnStylingOptions(),
                 groupSize: 64, waveSize: 64, system: GetSystemView(system, groupSize: 64, waveSize: 64));
 
             for (int i = 0; i < 5; i++)
@@ -56,7 +56,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             for (int i = 46; i < 64; i++)
                 Assert.True((styling.ColumnState[i] & ColumnStates.Inactive) != 0);
 
-            styling.Recompute(new VisualizerOptions { MaskLanes = false, CheckMagicNumber = false }, new ColumnStylingOptions(),
+            styling.Recompute(new VisualizerOptions { MaskLanes = false, CheckMagicNumber = false }, new VisualizerAppearance(), new ColumnStylingOptions(),
                 groupSize: 64, waveSize: 64, system: GetSystemView(system, groupSize: 64, waveSize: 64));
 
             for (int i = 0; i < 64; i++)
@@ -72,7 +72,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
         {
             var system = new uint[waveSize];
             var styling = new ComputedColumnStyling();
-            styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = false }, new ColumnStylingOptions(),
+            styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = false }, new VisualizerAppearance(), new ColumnStylingOptions(),
                 groupSize: (uint)waveSize, waveSize: (uint)waveSize, system: GetSystemView(system, groupSize: waveSize, waveSize: waveSize));
 
             for (int i = 0; i < waveSize; ++i)
@@ -86,7 +86,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             system[8] = 0b11_0111_0111;
 
             var styling = new ComputedColumnStyling();
-            styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = false }, new ColumnStylingOptions(),
+            styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = false }, new VisualizerAppearance(), new ColumnStylingOptions(),
                 groupSize: 12, waveSize: 10, system: GetSystemView(system, groupSize: 12, waveSize: 10));
 
             Assert.True((styling.ColumnState[0] & ColumnStates.Inactive) == 0); // 1 = active
@@ -112,7 +112,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             var system = new uint[dataSize];
 
             var styling = new ComputedColumnStyling();
-            styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = true, MagicNumber = 0 }, new ColumnStylingOptions(),
+            styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = true, MagicNumber = 0 }, new VisualizerAppearance(), new ColumnStylingOptions(),
                 groupSize: (uint)groupSize, waveSize: (uint)waveSize, system: GetSystemView(system, groupSize: groupSize, waveSize: waveSize, groupIndex: groupIndex));
 
             for (int i = 0; i < 12; ++i)
@@ -124,7 +124,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
         {
             // No assertions, this test simply hangs if we don't handle groupSize < laneGrouping in the code
             var styling = new ComputedColumnStyling();
-            styling.Recompute(new VisualizerOptions { LaneGrouping = 4 }, new ColumnStylingOptions(), groupSize: 3, waveSize: 3, system: null);
+            styling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 4 }, new ColumnStylingOptions(), groupSize: 3, waveSize: 3, system: null);
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
 
             var visualizerOptions = new VisualizerOptions { MaskLanes = false, CheckMagicNumber = true, MagicNumber = 0x7 };
             var styling = new ComputedColumnStyling();
-            styling.Recompute(visualizerOptions, new ColumnStylingOptions(),
+            styling.Recompute(visualizerOptions, new VisualizerAppearance(), new ColumnStylingOptions(),
                 groupSize: 256, waveSize: 64, system: GetSystemView(system, groupSize: 256, waveSize: 64));
 
             for (int i = 0; i < 63; i++)
@@ -162,7 +162,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
 
             var visualizerOptions = new VisualizerOptions { MaskLanes = false, CheckMagicNumber = true, MagicNumber = 0x7 };
             var styling = new ComputedColumnStyling();
-            styling.Recompute(visualizerOptions, new ColumnStylingOptions(),
+            styling.Recompute(visualizerOptions, new VisualizerAppearance(), new ColumnStylingOptions(),
                 groupSize: 144, waveSize: 32, system: GetSystemView(system, groupSize: 144, waveSize: 32));
 
             for (int i = 0; i < 32; i++)


### PR DESCRIPTION
# Added:

* New feature `Append leading zeroes to binary/hex numbers` available in Visualizer Appearance tab inside Options window.
When active, it will make hex numbers presented as 8 digits (`0x00000001`) and binary as 32 digits.
* New feature `Insert separator in binary/hex mode between groups of X digits` available in Visualizer Appearance tab inside Options window. When `X` is not zero, it will insert whitespaces each `X` characters in bin/hex representations starting from last digit (`0x4 23 13`).
* New feature `Insert separator in int/uint mode between groups of X digits` available in Visualizer Appearance tab inside Options window. When `X` is not zero, it will insert whitespaces each `X` characters in int/uint representations starting from last digit (`1 000 000`).
* Custom array slices for `Add To Watches As Array` feature. In context menu after all predefined starting indexes appeared new button with label `Custom`. Hitting it will open dialog window with `Start`, `Step` and `Count` input fields and `OK`/`Cancel` buttons. After clicking `OK`, the slice defined by input fields will be added to watch list.

# Changed:

* `Vertical separator between each X columns` setting moved to the Visualizer Appearance tab.