### PR TITLE
Add to watches as array brackets matching

### DIFF
--- a/VSRAD.Package/Commands/AddToWatchesCommand.cs
+++ b/VSRAD.Package/Commands/AddToWatchesCommand.cs
@@ -47,7 +47,8 @@ namespace VSRAD.Package.Commands
             else if (commandId >= Constants.AddArrayToWatchesToIdOffset)
             {
                 var fromIndex = Math.DivRem(commandId - Constants.AddArrayToWatchesToIdOffset, Constants.AddArrayToWatchesToFromOffset, out var toIndex);
-                var arrayRangeWatch = ArrayRange.FormatArrayRangeWatch(watchName, (int)fromIndex, (int)toIndex);
+                var arrayRangeWatch = ArrayRange.FormatArrayRangeWatch(watchName, (int)fromIndex, (int)toIndex,
+                                        _toolIntegration.ProjectOptions.VisualizerOptions.MatchBracketsOnAddToWatches);
 
                 foreach (var watch in arrayRangeWatch)
                     _toolIntegration.AddWatchFromEditor(watch);

--- a/VSRAD.Package/Utils/ArrayRange.cs
+++ b/VSRAD.Package/Utils/ArrayRange.cs
@@ -16,7 +16,7 @@ namespace VSRAD.Package.Utils
         //data_N0HW_base_addr[i]
 
         // else add new brackets
-        public static string[] FormatArrayRangeWatch(string name, int from, int to)
+        public static string[] FormatArrayRangeWatch(string name, int from, int to, bool matchBrackets)
         {
             var numericMatch = _numericIndexPattern.Match(name);
             var symbolMatch = _symbolIndexPattern.Match(name);
@@ -24,7 +24,7 @@ namespace VSRAD.Package.Utils
             var count = to - from + 1;
             var result = new string[count];
 
-            if (numericMatch.Success || (!numericMatch.Success && !symbolMatch.Success))
+            if ((numericMatch.Success || (!numericMatch.Success && !symbolMatch.Success)) || !matchBrackets)
             {
                 for (int i = 0; i < count; i++)
                     result[i] = $"{name}[{from + i}]";

--- a/VSRAD.PackageTests/Utils/ArrayRangeTests.cs
+++ b/VSRAD.PackageTests/Utils/ArrayRangeTests.cs
@@ -11,7 +11,7 @@ namespace VSRAD.PackageTests.Utils
             var name = "eva-syncro-levels[1][2]";
             var from = -3;
             var to = 4;
-            var results = ArrayRange.FormatArrayRangeWatch(name, from, to);
+            var results = ArrayRange.FormatArrayRangeWatch(name, from, to, true);
             Assert.Equal("eva-syncro-levels[1][2][-3]", results[0]);
             Assert.Equal("eva-syncro-levels[1][2][-2]", results[1]);
             Assert.Equal("eva-syncro-levels[1][2][-1]", results[2]);
@@ -22,7 +22,7 @@ namespace VSRAD.PackageTests.Utils
             Assert.Equal("eva-syncro-levels[1][2][4]", results[7]);
 
             name = "eva-internal-battery-countdown";
-            results = ArrayRange.FormatArrayRangeWatch(name, from, to);
+            results = ArrayRange.FormatArrayRangeWatch(name, from, to, true);
             Assert.Equal("eva-internal-battery-countdown[-3]", results[0]);
             Assert.Equal("eva-internal-battery-countdown[-2]", results[1]);
             Assert.Equal("eva-internal-battery-countdown[-1]", results[2]);
@@ -39,7 +39,7 @@ namespace VSRAD.PackageTests.Utils
             var name = "eva-pilot-pulse[offset]";
             var from = -3;
             var to = 4;
-            var results = ArrayRange.FormatArrayRangeWatch(name, from, to);
+            var results = ArrayRange.FormatArrayRangeWatch(name, from, to, true);
             Assert.Equal("eva-pilot-pulse[offset-3]", results[0]);
             Assert.Equal("eva-pilot-pulse[offset-2]", results[1]);
             Assert.Equal("eva-pilot-pulse[offset-1]", results[2]);
@@ -50,7 +50,7 @@ namespace VSRAD.PackageTests.Utils
             Assert.Equal("eva-pilot-pulse[offset+4]", results[7]);
 
             name = "eva-gun-voltage[0][offset]";
-            results = ArrayRange.FormatArrayRangeWatch(name, from, to);
+            results = ArrayRange.FormatArrayRangeWatch(name, from, to, true);
             Assert.Equal("eva-gun-voltage[0][offset-3]", results[0]);
             Assert.Equal("eva-gun-voltage[0][offset-2]", results[1]);
             Assert.Equal("eva-gun-voltage[0][offset-1]", results[2]);
@@ -59,6 +59,35 @@ namespace VSRAD.PackageTests.Utils
             Assert.Equal("eva-gun-voltage[0][offset+2]", results[5]);
             Assert.Equal("eva-gun-voltage[0][offset+3]", results[6]);
             Assert.Equal("eva-gun-voltage[0][offset+4]", results[7]);
+        }
+
+        [Fact]
+        public void AppendNewBracketsToManualSelection()
+        {
+            var name = "eva-cooling-system-temp[offset]";
+            var from = -3;
+            var to = 4;
+            var results = ArrayRange.FormatArrayRangeWatch(name, from, to, false);
+            Assert.Equal("eva-cooling-system-temp[offset][-3]", results[0]);
+            Assert.Equal("eva-cooling-system-temp[offset][-2]", results[1]);
+            Assert.Equal("eva-cooling-system-temp[offset][-1]", results[2]);
+            Assert.Equal("eva-cooling-system-temp[offset][0]", results[3]);
+            Assert.Equal("eva-cooling-system-temp[offset][1]", results[4]);
+            Assert.Equal("eva-cooling-system-temp[offset][2]", results[5]);
+            Assert.Equal("eva-cooling-system-temp[offset][3]", results[6]);
+            Assert.Equal("eva-cooling-system-temp[offset][4]", results[7]);
+
+            name = "eva-cores-info[0][offset]";
+            results = ArrayRange.FormatArrayRangeWatch(name, from, to, false);
+            Assert.Equal("eva-cores-info[0][offset][-3]", results[0]);
+            Assert.Equal("eva-cores-info[0][offset][-2]", results[1]);
+            Assert.Equal("eva-cores-info[0][offset][-1]", results[2]);
+            Assert.Equal("eva-cores-info[0][offset][0]", results[3]);
+            Assert.Equal("eva-cores-info[0][offset][1]", results[4]);
+            Assert.Equal("eva-cores-info[0][offset][2]", results[5]);
+            Assert.Equal("eva-cores-info[0][offset][3]", results[6]);
+            Assert.Equal("eva-cores-info[0][offset][4]", results[7]);
+
         }
     }
 }


### PR DESCRIPTION
This PR modifies behavior of `Add to watches as array` feature with `Match brackets` turned off when manually selecting text that contain brackets.

Assume the selected text is `v_buf[i]` and user selected array from 0 to 1:

- With match brackets turned on `v_buf[i+0]` and `v_buf[i+1]` will be added to watch list;
- With match brackets turned off `v_buf[i][0]` and `v_buf[i][1]` will be added to watch list.