### PR TITLE
[WIP] Fix tokenization of preprocessor keyword

### DIFF
--- a/VSRAD.Syntax/Core/DocumentTokenizer.cs
+++ b/VSRAD.Syntax/Core/DocumentTokenizer.cs
@@ -67,7 +67,7 @@ namespace VSRAD.Syntax.Core
                 // in some cases the text buffer may cause ContentChanged with 0 changes
                 if (args.Changes.Count == 0) return;
 
-                ApplyTextChange(args.Before, args.After, new JoinedTextChange(args.Changes));
+                ApplyTextChange(args.Before, args.After, new JoinedTextChange(args.Changes, args.Before));
             }
             catch (Exception ex)
             {
@@ -187,10 +187,14 @@ namespace VSRAD.Syntax.Core
 
         private class JoinedTextChange : ITextChange
         {
-            public JoinedTextChange(INormalizedTextChangeCollection changes)
+            public JoinedTextChange(INormalizedTextChangeCollection changes, ITextSnapshot before)
             {
                 var oldStart = changes[0].OldSpan.Start;
                 var oldEnd = changes[changes.Count - 1].OldEnd;
+
+                // apply the change to the whole first line
+                oldStart = before.GetLineFromPosition(oldStart).Start;
+
                 OldSpan = new Span(oldStart, oldEnd - oldStart);
                 Delta = changes[changes.Count - 1].NewEnd - changes[changes.Count - 1].OldEnd;
             }


### PR DESCRIPTION
This PR fixes preprocessor keyword highlighting.

## Issue
Lexer result:
```
#i
^ CHARP
  ^ IDENTIFIER
```

After the preprocessor keyword is fully written: 
```
#if
```
The tokenizer will apply changes (changed text: `if`) only to the _IDENTIFIER_ token, because text changes intersect only with this token, but not with CSHARP. 

After that, lexer result for the changed text will be:
```
#if
^ CHARP
  ^ IF keyword
```

## Solution (TBD)
One of the easiest and most understandable solutions is to apply the lexer not only to the changed text, but also to the whole line.

The second one is remove `#` token, but add `CLOSURE_IDENTIFIER` token (see [commit](https://github.com/vsrad/radeon-asm-tools/commit/3220981fc26a056cb028141a395cc43f70db37d4)).  In this case, it is not necessary to apply the lexer to the whole line.