### PR TITLE
Fix tokenization of preprocessor keyword

### DIFF
--- a/VSRAD.Syntax/Core/Lexer/Asm2Lexer.cs
+++ b/VSRAD.Syntax/Core/Lexer/Asm2Lexer.cs
@@ -97,7 +97,6 @@ namespace VSRAD.Syntax.Core.Lexer
             { RadAsm2Lexer.SEMI, RadAsmTokenType.Semi },
             { RadAsm2Lexer.COLON, RadAsmTokenType.Colon },
             { RadAsm2Lexer.QUEST, RadAsmTokenType.Structural },
-            { RadAsm2Lexer.SHARP, RadAsmTokenType.Structural },
             { RadAsm2Lexer.LPAREN, RadAsmTokenType.Lparen },
             { RadAsm2Lexer.RPAREN, RadAsmTokenType.Rparen },
             { RadAsm2Lexer.LSQUAREBRACKET, RadAsmTokenType.LsquareBracket },
@@ -107,6 +106,7 @@ namespace VSRAD.Syntax.Core.Lexer
 
             { RadAsm2Lexer.CONSTANT, RadAsmTokenType.Number },
             { RadAsm2Lexer.STRING_LITERAL, RadAsmTokenType.String },
+            { RadAsm2Lexer.CLOSURE_IDENTIFIER, RadAsmTokenType.Identifier },
             { RadAsm2Lexer.IDENTIFIER, RadAsmTokenType.Identifier },
 
             { RadAsm2Lexer.LINE_COMMENT, RadAsmTokenType.Comment },

--- a/VSRAD.Syntax/Core/Parser/Asm2Parser.cs
+++ b/VSRAD.Syntax/Core/Parser/Asm2Parser.cs
@@ -193,6 +193,14 @@ namespace VSRAD.Syntax.Core.Parser
                             currentBlock.AddToken(variableDefinition);
                         }
                     }
+                    else if (token.Type == RadAsm2Lexer.CLOSURE_IDENTIFIER)
+                    {
+                        var tokenText = token.GetText(version).Substring(1); // remove first '#' symbol
+                        if (!TryAddReference(tokenText, token, currentBlock, version, definitionContainer, cancellation))
+                        {
+                            referenceCandidates.AddLast((tokenText, token, currentBlock));
+                        }
+                    }
                     else if (token.Type == RadAsm2Lexer.IDENTIFIER)
                     {
                         var tokenText = token.GetText(version);

--- a/VSRAD.SyntaxParser/RadAsm2.g4
+++ b/VSRAD.SyntaxParser/RadAsm2.g4
@@ -146,7 +146,6 @@ COMMA      : ',' ;
 SEMI       : ';' ;
 COLON      : ':' ;
 QUEST      : '?' ;
-SHARP      : '#' ;
 LPAREN     : '(' ;
 RPAREN     : ')' ;
 LSQUAREBRACKET   : '[' ;
@@ -178,8 +177,17 @@ STRING_LITERAL
     : '"' .*? ('"'| EOF)
     ;
 
-IDENTIFIER
+fragment
+SYMBOL_IDENTIFIER
     : '.'? [a-zA-Z_] [a-zA-Z0-9_]*
+    ;
+
+CLOSURE_IDENTIFIER
+    : '#' SYMBOL_IDENTIFIER
+    ;
+
+IDENTIFIER
+    : SYMBOL_IDENTIFIER
     ;
 
 LINE_COMMENT
@@ -199,5 +207,5 @@ EOL
     ;
 
 UNKNOWN
-    : ~[ \t\r\n,:;#?()[\]{}=<>!&|~+\\-*%^/]+
+    : ~[ \t\r\n,:;?()[\]{}=<>!&|~+\\-*%^/]+
     ;


### PR DESCRIPTION
This PR fixes preprocessor keyword highlighting.

## Issue
Lexer result:
```
#i
^ CHARP
  ^ IDENTIFIER
```

After the preprocessor keyword is fully written (`#if`), tokenizer will apply changes (changed text: `if`) only to the _IDENTIFIER_ token, because text changes intersect only with this token, but not with CSHARP. 

After that, lexer result for the changed text will be:
```
#if
^ CHARP
  ^ IF keyword
```

## Solution
The solution is to remove `SHARP` (**#** symbol) token, but add `CLOSURE_IDENTIFIER` token. 
In this case lexer result will be:
```
#i
^ CLOSURE_IDENTIFIER
``` 

And after adding the letter `f`, tokenizer will apply the changes to the `CLOSURE_IDENTIFIER` token. And lexer result will be:
```
#if
^ PP_IF keyword
``` 