### PR TITLE
Default settings tweaks

### DIFF
--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -168,7 +168,7 @@ To switch to manual grid size selection, right-click on the space next to the Gr
         private void AddWatch(string watchName)
         {
             _table.RemoveNewWatchRow();
-            _table.AppendVariableRow(new Watch(watchName, VariableType.Hex, isAVGPR: false));
+            _table.AppendVariableRow(new Watch(watchName, VariableType.Int, isAVGPR: false));
             _table.PrepareNewWatchRow();
             _context.Options.DebuggerOptions.Watches.Clear();
             _context.Options.DebuggerOptions.Watches.AddRange(_table.GetCurrentWatchState());

--- a/VSRAD.Package/VSRAD.Package.tt
+++ b/VSRAD.Package/VSRAD.Package.tt
@@ -261,8 +261,8 @@
 
   <KeyBindings>
     <KeyBinding guid="guidCmdSetAddToWatches" id="AddSelectionToWatchesCommandId" key1="E" key2="A" mod1="Control" mod2="Control" editor="guidVSStd97" />
-    <KeyBinding guid="guidCmdSetActionsMenu" id="DisassembleCommandId" key1="E" key2="D" mod1="Control" mod2="Control" editor="guidVSStd97" />
-    <KeyBinding guid="guidCmdSetActionsMenu" id="ProfileCommandId" key1="E" key2="S" mod1="Control" mod2="Control" editor="guidVSStd97" />
+    <KeyBinding guid="guidCmdSetActionsMenu" id="DisassembleCommandId" key1="D" mod1="Alt" editor="guidVSStd97" />
+    <KeyBinding guid="guidCmdSetActionsMenu" id="ProfileCommandId" key1="W" mod1="Alt" editor="guidVSStd97" />
   </KeyBindings>
 
   <CommandPlacements>

--- a/VSRAD.Package/VSRAD.Package.tt
+++ b/VSRAD.Package/VSRAD.Package.tt
@@ -260,9 +260,9 @@
   </Commands>
 
   <KeyBindings>
-    <KeyBinding guid="guidCmdSetAddToWatches" id="AddSelectionToWatchesCommandId" key1="A" mod1="Alt" editor="guidVSStd97" />
-    <KeyBinding guid="guidCmdSetActionsMenu" id="DisassembleCommandId" key1="D" mod1="Alt" editor="guidVSStd97" />
-    <KeyBinding guid="guidCmdSetActionsMenu" id="ProfileCommandId" key1="W" mod1="Alt" editor="guidVSStd97" />
+    <KeyBinding guid="guidCmdSetAddToWatches" id="AddSelectionToWatchesCommandId" key1="E" key2="A" mod1="Control" mod2="Control" editor="guidVSStd97" />
+    <KeyBinding guid="guidCmdSetActionsMenu" id="DisassembleCommandId" key1="E" key2="D" mod1="Control" mod2="Control" editor="guidVSStd97" />
+    <KeyBinding guid="guidCmdSetActionsMenu" id="ProfileCommandId" key1="E" key2="S" mod1="Control" mod2="Control" editor="guidVSStd97" />
   </KeyBindings>
 
   <CommandPlacements>


### PR DESCRIPTION
This PR changes default values for watch type and shortcut for `Add to watches` command.

* `Add to watches`: `Alt+A` -> `Ctrl+E,A`
* Default watch type changed from `HEX` to `INT`