### PR TITLE
Options refactoring

### DIFF
--- a/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
@@ -1,5 +1,5 @@
 ﻿using VSRAD.Syntax.FunctionList.Commands;
-using static VSRAD.Syntax.Options.GeneralOptionPage;
+using VSRAD.Syntax.Options;
 using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
@@ -10,7 +10,6 @@ using System.Windows.Input;
 using Task = System.Threading.Tasks.Task;
 using System.Threading;
 using System.Linq;
-using VSRAD.Syntax.Options;
 
 namespace VSRAD.Syntax.FunctionList
 {

--- a/VSRAD.Syntax/FunctionList/Helper.cs
+++ b/VSRAD.Syntax/FunctionList/Helper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using static VSRAD.Syntax.Options.GeneralOptionPage;
+using VSRAD.Syntax.Options;
 
 namespace VSRAD.Syntax.FunctionList
 {

--- a/VSRAD.Syntax/Options/BaseOptionModel.cs
+++ b/VSRAD.Syntax/Options/BaseOptionModel.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.VisualStudio.Settings;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.Settings;
+using Microsoft.VisualStudio.Threading;
+using Task = System.Threading.Tasks.Task;
+
+namespace VSRAD.Syntax.Options
+{
+    public abstract class BaseOptionModel<T> where T : BaseOptionModel<T>, new()
+    {
+        private static readonly AsyncLazy<T> _liveModel = new AsyncLazy<T>(CreateAsync, ThreadHelper.JoinableTaskFactory);
+        protected static readonly AsyncLazy<ShellSettingsManager> _settingsManager = new AsyncLazy<ShellSettingsManager>(GetSettingsManagerAsync, ThreadHelper.JoinableTaskFactory);
+
+        protected BaseOptionModel()
+        { }
+
+        public static T Instance
+        {
+            get
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+                return ThreadHelper.JoinableTaskFactory.Run(GetInstanceAsync);
+            }
+        }
+
+        public static Task<T> GetInstanceAsync() => _liveModel.GetValueAsync();
+
+        public static async Task<T> CreateAsync()
+        {
+            var instance = new T();
+            await instance.LoadAsync();
+            return instance;
+        }
+
+        protected virtual string CollectionName { get; } = typeof(T).FullName;
+
+        public virtual void Load()
+        {
+            ThreadHelper.JoinableTaskFactory.Run(LoadAsync);
+        }
+
+        public virtual async Task LoadAsync()
+        {
+            var manager = await _settingsManager.GetValueAsync();
+            var settingsStore = manager.GetReadOnlySettingsStore(SettingsScope.UserSettings);
+
+            if (!settingsStore.CollectionExists(CollectionName))
+            {
+                return;
+            }
+
+            foreach (PropertyInfo property in GetOptionProperties())
+            {
+                try
+                {
+                    string serializedProp = settingsStore.GetString(CollectionName, property.Name);
+                    object value = DeserializeValue(serializedProp, property.PropertyType);
+                    property.SetValue(this, value);
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.Write(ex);
+                }
+            }
+        }
+
+        public virtual void Save()
+        {
+            ThreadHelper.JoinableTaskFactory.Run(SaveAsync);
+        }
+
+        public virtual async Task SaveAsync()
+        {
+            ShellSettingsManager manager = await _settingsManager.GetValueAsync();
+            WritableSettingsStore settingsStore = manager.GetWritableSettingsStore(SettingsScope.UserSettings);
+
+            if (!settingsStore.CollectionExists(CollectionName))
+            {
+                settingsStore.CreateCollection(CollectionName);
+            }
+
+            foreach (PropertyInfo property in GetOptionProperties())
+            {
+                string output = SerializeValue(property.GetValue(this));
+                settingsStore.SetString(CollectionName, property.Name, output);
+            }
+
+            T liveModel = await GetInstanceAsync();
+
+            if (this != liveModel)
+            {
+                await liveModel.LoadAsync();
+            }
+        }
+
+        protected virtual string SerializeValue(object value)
+        {
+            using (var stream = new MemoryStream())
+            {
+                var formatter = new BinaryFormatter();
+                formatter.Serialize(stream, value);
+                stream.Flush();
+                return Convert.ToBase64String(stream.ToArray());
+            }
+        }
+
+        protected virtual object DeserializeValue(string value, Type type)
+        {
+            byte[] b = Convert.FromBase64String(value);
+
+            using (var stream = new MemoryStream(b))
+            {
+                var formatter = new BinaryFormatter();
+                return formatter.Deserialize(stream);
+            }
+        }
+
+        private static async Task<ShellSettingsManager> GetSettingsManagerAsync()
+        {
+            var svc = await AsyncServiceProvider.GlobalProvider.GetServiceAsync(typeof(SVsSettingsManager)) as IVsSettingsManager;
+
+            Assumes.Present(svc);
+            return new ShellSettingsManager(svc);
+        }
+
+        private IEnumerable<PropertyInfo> GetOptionProperties()
+        {
+            return GetType()
+                .GetProperties()
+                .Where(p => p.PropertyType.IsSerializable && p.PropertyType.IsPublic);
+        }
+    }
+}

--- a/VSRAD.Syntax/Options/BaseOptionPage.cs
+++ b/VSRAD.Syntax/Options/BaseOptionPage.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.VisualStudio.Shell;
+
+namespace VSRAD.Syntax.Options
+{
+    public class BaseOptionPage<T> : DialogPage where T : BaseOptionModel<T>, new()
+    {
+        private readonly BaseOptionModel<GeneralOptions> _model;
+
+        public BaseOptionPage()
+        {
+            _model = GeneralOptions.Instance;
+        }
+
+        public override object AutomationObject => _model;
+
+        public override void LoadSettingsFromStorage() => _model.Load();
+
+        public override void SaveSettingsToStorage() => _model.Save();
+    }
+}

--- a/VSRAD.Syntax/Options/GeneralOptionPage.cs
+++ b/VSRAD.Syntax/Options/GeneralOptionPage.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using VSRAD.Syntax.Helpers;
 
 namespace VSRAD.Syntax.Options
@@ -15,10 +14,9 @@ namespace VSRAD.Syntax.Options
 
         protected override void OnApply(PageApplyEventArgs e)
         {
-            base.OnApply(e);
-
             try
             {
+                base.OnApply(e);
                 _optionsEventProvider.OptionsUpdatedInvoke();
             }
             catch (Exception ex)

--- a/VSRAD.Syntax/Options/GeneralOptionPage.cs
+++ b/VSRAD.Syntax/Options/GeneralOptionPage.cs
@@ -26,17 +26,5 @@ namespace VSRAD.Syntax.Options
                 Error.ShowWarning(ex);
             }
         }
-
-        public enum SortState
-        {
-            [Description("by line number")]
-            ByLine = 1,
-            [Description("by line number descending")]
-            ByLineDescending = 2,
-            [Description("by name")]
-            ByName = 3,
-            [Description("by name descending")]
-            ByNameDescending = 4,
-        }
     }
 }

--- a/VSRAD.Syntax/Options/GeneralOptionPage.cs
+++ b/VSRAD.Syntax/Options/GeneralOptionPage.cs
@@ -1,216 +1,30 @@
-﻿using Microsoft.VisualStudio.Settings;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Settings;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.ComponentModel;
-using System.ComponentModel.Composition;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Text.RegularExpressions;
 using VSRAD.Syntax.Helpers;
-using VSRAD.Syntax.Options.Instructions;
-using DisplayNameAttribute = System.ComponentModel.DisplayNameAttribute;
-using Task = System.Threading.Tasks.Task;
 
 namespace VSRAD.Syntax.Options
 {
-    [Export(typeof(OptionsProvider))]
-    public class OptionsProvider
+    public class GeneralOptionPage : BaseOptionPage<GeneralOptions>
     {
-        public OptionsProvider()
-        {
-            SortOptions = GeneralOptionPage.SortState.ByName;
-            Autoscroll = true;
-            IsEnabledIndentGuides = false;
-            IndentGuideThickness = 0.9;
-            IndentGuideDashSize = 3.0;
-            IndentGuideSpaceSize = 2.9;
-            IndentGuideOffsetX = 3.2;
-            IndentGuideOffsetY = 2.0;
-            Asm1FileExtensions = Constants.DefaultFileExtensionAsm1;
-            Asm2FileExtensions = Constants.DefaultFileExtensionAsm2;
-            InstructionsPaths = GetDefaultInstructionDirectoryPath();
-            AutocompleteInstructions = false;
-            AutocompleteFunctions = false;
-            AutocompleteLabels = false;
-            AutocompleteVariables = false;
-    }
-
-        public GeneralOptionPage.SortState SortOptions;
-        public bool Autoscroll;
-        public bool IsEnabledIndentGuides;
-        public double IndentGuideThickness;
-        public double IndentGuideDashSize;
-        public double IndentGuideSpaceSize;
-        public double IndentGuideOffsetY;
-        public double IndentGuideOffsetX;
-        public IReadOnlyList<string> Asm1FileExtensions;
-        public IReadOnlyList<string> Asm2FileExtensions;
-        public string InstructionsPaths;
-        public bool AutocompleteInstructions;
-        public bool AutocompleteFunctions;
-        public bool AutocompleteLabels;
-        public bool AutocompleteVariables;
-
-        public delegate void OptionsUpdate(OptionsProvider sender);
-        public event OptionsUpdate OptionsUpdated;
-
-        public void OptionsUpdatedInvoke() =>
-            OptionsUpdated?.Invoke(this);
-
-        public static string GetDefaultInstructionDirectoryPath()
-        {
-            var assemblyFolder = new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath;
-            return Path.GetDirectoryName(assemblyFolder);
-        }
-    }
-
-    public class GeneralOptionPage : DialogPage
-    {
-        private const string InstructionCollectionPath = "VSRADInstructionCollectionPath";
-        private static readonly Regex fileExtensionRegular = new Regex(@"^\.\w+$");
         private readonly OptionsProvider _optionsEventProvider;
 
-        public GeneralOptionPage(): base()
+        public GeneralOptionPage() : base()
         {
             _optionsEventProvider = Package.Instance.GetMEFComponent<OptionsProvider>();
         }
 
-        [Category("Function list")]
-        [DisplayName("Function list default sort option")]
-        [Description("Set default sort option for Function List")]
-        public SortState SortOptions
+        protected override void OnApply(PageApplyEventArgs e)
         {
-            get { return _optionsEventProvider.SortOptions; }
-            set { _optionsEventProvider.SortOptions = value; }
-        }
+            base.OnApply(e);
 
-        [Category("Function list")]
-        [DisplayName("Autoscroll function list")]
-        [Description("Scroll to current function in the function list automatically")]
-        public bool Autoscroll
-        {
-            get { return _optionsEventProvider.Autoscroll; }
-            set { _optionsEventProvider.Autoscroll = value; }
-        }
-
-        [Category("Syntax highlight")]
-        [DisplayName("Indent guide lines")]
-        [Description("Enable/disable indent guide lines")]
-        public bool IsEnabledIndentGuides
-        {
-            get { return _optionsEventProvider.IsEnabledIndentGuides; }
-            set { _optionsEventProvider.IsEnabledIndentGuides = value; }
-        }
-
-#if DEBUG
-        [Category("Syntax highlight")]
-        [DisplayName("Indent guide line thikness")]
-        public double IndentGuideThikness
-        {
-            get { return _optionsEventProvider.IndentGuideThickness; }
-            set { _optionsEventProvider.IndentGuideThickness = value; }
-        }
-
-        [Category("Syntax highlight")]
-        [DisplayName("Indent guide dash size")]
-        public double IndentGuideDashSize
-        {
-            get { return _optionsEventProvider.IndentGuideDashSize; }
-            set { _optionsEventProvider.IndentGuideDashSize = value; }
-        }
-
-        [Category("Syntax highlight")]
-        [DisplayName("Indent guide space size")]
-        [Description("Space size between indent lines")]
-        public double IndentGuideSpaceSize
-        {
-            get { return _optionsEventProvider.IndentGuideSpaceSize; }
-            set { _optionsEventProvider.IndentGuideSpaceSize = value; }
-        }
-
-        [Category("Syntax highlight")]
-        [DisplayName("Indent guide line offset X")]
-        public double IndentGuideOffsetX
-        {
-            get { return _optionsEventProvider.IndentGuideOffsetX; }
-            set { _optionsEventProvider.IndentGuideOffsetX = value; }
-        }
-
-        [Category("Syntax highlight")]
-        [DisplayName("Indent guide line offset Y")]
-        public double IndentGuideOffsetY
-        {
-            get { return _optionsEventProvider.IndentGuideOffsetY; }
-            set { _optionsEventProvider.IndentGuideOffsetY = value; }
-        }
-#endif
-
-        [Category("Syntax file extensions")]
-        [DisplayName("Asm1 file extensions")]
-        [Description("List of file extensions for the asm1 syntax")]
-        public string Asm1FileExtensions
-        {
-            get { return ConvertExtensionsTo(_optionsEventProvider.Asm1FileExtensions); }
-            set { var extensions = ConvertExtensionsFrom(value); if (ValidateExtensions(extensions)) _optionsEventProvider.Asm1FileExtensions = extensions; }
-        }
-
-        [Category("Syntax file extensions")]
-        [DisplayName("Asm2 file extensions")]
-        [Description("List of file extensions for the asm2 syntax")]
-        public string Asm2FileExtensions
-        {
-            get { return ConvertExtensionsTo(_optionsEventProvider.Asm2FileExtensions); }
-            set { var extensions = ConvertExtensionsFrom(value); if (ValidateExtensions(extensions)) _optionsEventProvider.Asm2FileExtensions = extensions; }
-        }
-
-        [Category("Syntax instruction folder paths")]
-        [DisplayName("Instruction folder paths")]
-        [Description("List of folder path separated by semicolon wit assembly instructions with .radasm file extension")]
-        [Editor(typeof(FolderPathsEditor), typeof(System.Drawing.Design.UITypeEditor))]
-        public string InstructionsPaths
-        {
-            get { return _optionsEventProvider.InstructionsPaths; }
-            set { _optionsEventProvider.InstructionsPaths = value; }
-        }
-
-        [Category("Autocompletion")]
-        [DisplayName("Instruction autocompletion")]
-        [Description("Autocomplete instructions")]
-        public bool AutocompleteInstructions
-        {
-            get { return _optionsEventProvider.AutocompleteInstructions; }
-            set { _optionsEventProvider.AutocompleteInstructions = value; }
-        }
-
-        [Category("Autocompletion")]
-        [DisplayName("Function autocompletion")]
-        [Description("Autocomplete function name")]
-        public bool AutocompleteFunctions
-        {
-            get { return _optionsEventProvider.AutocompleteFunctions; }
-            set { _optionsEventProvider.AutocompleteFunctions = value; }
-        }
-
-        [Category("Autocompletion")]
-        [DisplayName("Label autocompletion")]
-        [Description("Autocomplete labels")]
-        public bool AutocompleteLabels
-        {
-            get { return _optionsEventProvider.AutocompleteLabels; }
-            set { _optionsEventProvider.AutocompleteLabels = value; }
-        }
-
-        [Category("Autocompletion")]
-        [DisplayName("Variable autocompletion")]
-        [Description("Autocomplete global variables, local variables, function arguments")]
-        public bool AutocompleteVariables
-        {
-            get { return _optionsEventProvider.AutocompleteVariables; }
-            set { _optionsEventProvider.AutocompleteVariables = value; }
+            try
+            {
+                _optionsEventProvider.OptionsUpdatedInvoke();
+            }
+            catch (Exception ex)
+            {
+                Error.ShowWarning(ex);
+            }
         }
 
         public enum SortState
@@ -223,79 +37,6 @@ namespace VSRAD.Syntax.Options
             ByName = 3,
             [Description("by name descending")]
             ByNameDescending = 4,
-        }
-
-        public Task InitializeAsync()
-        {
-            // make sure this managers initialized before initial option event
-            _ = Package.Instance.GetMEFComponent<ContentTypeManager>();
-            _ = Package.Instance.GetMEFComponent<IInstructionListManager>();
-
-            _optionsEventProvider.OptionsUpdatedInvoke();
-            return Task.CompletedTask;
-        }
-
-        // hack to avoid installation errors when reinstalling the extension
-        public override void LoadSettingsFromStorage()
-        {
-            base.LoadSettingsFromStorage();
-            var settingsManager = new ShellSettingsManager(ServiceProvider.GlobalProvider);
-            var userSettingsStore = settingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
-
-            InstructionsPaths = userSettingsStore.CollectionExists(InstructionCollectionPath)
-                ? userSettingsStore.GetString(InstructionCollectionPath, nameof(InstructionsPaths))
-                : OptionsProvider.GetDefaultInstructionDirectoryPath();
-        }
-
-        public override void SaveSettingsToStorage()
-        {
-            base.SaveSettingsToStorage();
-            var settingsManager = new ShellSettingsManager(ServiceProvider.GlobalProvider);
-            var userSettingsStore = settingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
-
-            if (InstructionsPaths != OptionsProvider.GetDefaultInstructionDirectoryPath())
-            {
-                if (!userSettingsStore.CollectionExists(InstructionCollectionPath))
-                    userSettingsStore.CreateCollection(InstructionCollectionPath);
-
-                userSettingsStore.SetString(InstructionCollectionPath, nameof(InstructionsPaths), InstructionsPaths);
-            }
-        }
-
-        protected override void OnApply(PageApplyEventArgs e)
-        {
-            try
-            {
-                base.OnApply(e);
-                _optionsEventProvider.OptionsUpdatedInvoke();
-            }
-            catch(Exception ex)
-            {
-                Error.ShowWarning(ex);
-            }
-        }
-
-        private static List<string> ConvertExtensionsFrom(string str) =>
-            str.Split(';').Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
-
-        private static string ConvertExtensionsTo(IReadOnlyList<string> extensions) =>
-            string.Join(";", extensions.ToArray());
-        
-        private static bool ValidateExtensions(List<string> extensions)
-        {
-            var sb = new StringBuilder();
-            foreach (var ext in extensions)
-            {
-                if (!fileExtensionRegular.IsMatch(ext))
-                    sb.AppendLine($"Invalid file extension format \"{ext}\"");
-            }
-            if (sb.Length != 0)
-            {
-                sb.AppendLine();
-                sb.AppendLine("Format example: .asm");
-                return false;
-            }
-            return true;
         }
     }
 }

--- a/VSRAD.Syntax/Options/GeneralOptionPage.cs
+++ b/VSRAD.Syntax/Options/GeneralOptionPage.cs
@@ -7,7 +7,7 @@ namespace VSRAD.Syntax.Options
     {
         private readonly OptionsProvider _optionsEventProvider;
 
-        public GeneralOptionPage() : base()
+        public GeneralOptionPage()
         {
             _optionsEventProvider = Package.Instance.GetMEFComponent<OptionsProvider>();
         }

--- a/VSRAD.Syntax/Options/GeneralOptionProvider.cs
+++ b/VSRAD.Syntax/Options/GeneralOptionProvider.cs
@@ -20,7 +20,7 @@ namespace VSRAD.Syntax.Options
     {
         public OptionsProvider()
         {
-            SortOptions = GeneralOptionPage.SortState.ByName;
+            SortOptions = SortState.ByName;
             Autoscroll = true;
             IsEnabledIndentGuides = false;
             IndentGuideThickness = 0.9;
@@ -37,7 +37,7 @@ namespace VSRAD.Syntax.Options
             AutocompleteVariables = false;
         }
 
-        public GeneralOptionPage.SortState SortOptions;
+        public SortState SortOptions;
         public bool Autoscroll;
         public bool IsEnabledIndentGuides;
         public double IndentGuideThickness;

--- a/VSRAD.Syntax/Options/GeneralOptionProvider.cs
+++ b/VSRAD.Syntax/Options/GeneralOptionProvider.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.VisualStudio.Shell;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Reflection;
+using VSRAD.Syntax.Options.Instructions;
+using Task = System.Threading.Tasks.Task;
+
+namespace VSRAD.Syntax.Options
+{
+    public interface IOptions
+    {
+        Task LoadAsync();
+    }
+
+    [Export(typeof(OptionsProvider))]
+    [Export(typeof(IOptions))]
+    public class OptionsProvider : IOptions
+    {
+        public OptionsProvider()
+        {
+            SortOptions = GeneralOptionPage.SortState.ByName;
+            Autoscroll = true;
+            IsEnabledIndentGuides = false;
+            IndentGuideThickness = 0.9;
+            IndentGuideDashSize = 3.0;
+            IndentGuideSpaceSize = 2.9;
+            IndentGuideOffsetX = 3.2;
+            IndentGuideOffsetY = 2.0;
+            Asm1FileExtensions = Constants.DefaultFileExtensionAsm1;
+            Asm2FileExtensions = Constants.DefaultFileExtensionAsm2;
+            InstructionsPaths = GetDefaultInstructionDirectoryPath();
+            AutocompleteInstructions = false;
+            AutocompleteFunctions = false;
+            AutocompleteLabels = false;
+            AutocompleteVariables = false;
+        }
+
+        public GeneralOptionPage.SortState SortOptions;
+        public bool Autoscroll;
+        public bool IsEnabledIndentGuides;
+        public double IndentGuideThickness;
+        public double IndentGuideDashSize;
+        public double IndentGuideSpaceSize;
+        public double IndentGuideOffsetY;
+        public double IndentGuideOffsetX;
+        public IReadOnlyList<string> Asm1FileExtensions;
+        public IReadOnlyList<string> Asm2FileExtensions;
+        public string InstructionsPaths;
+        public bool AutocompleteInstructions;
+        public bool AutocompleteFunctions;
+        public bool AutocompleteLabels;
+        public bool AutocompleteVariables;
+
+        public delegate void OptionsUpdate(OptionsProvider sender);
+        public event OptionsUpdate OptionsUpdated;
+
+        public void OptionsUpdatedInvoke() =>
+            OptionsUpdated?.Invoke(this);
+
+        public static string GetDefaultInstructionDirectoryPath()
+        {
+            var assemblyFolder = new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath;
+            return Path.GetDirectoryName(assemblyFolder);
+        }
+
+        public async Task LoadAsync()
+        {
+            var model = await GeneralOptions.GetInstanceAsync();
+
+            // make sure this managers initialized before initial option event
+            _ = Package.Instance.GetMEFComponent<ContentTypeManager>();
+            _ = Package.Instance.GetMEFComponent<IInstructionListManager>();
+
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            OptionsUpdatedInvoke();
+        }
+    }
+}

--- a/VSRAD.Syntax/Options/GeneralOptions.cs
+++ b/VSRAD.Syntax/Options/GeneralOptions.cs
@@ -1,0 +1,173 @@
+﻿using System.Linq;
+using System.Text;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using static VSRAD.Syntax.Options.GeneralOptionPage;
+using Microsoft.VisualStudio.Settings;
+using System;
+using Task = System.Threading.Tasks.Task;
+
+namespace VSRAD.Syntax.Options
+{
+    public class GeneralOptions : BaseOptionModel<GeneralOptions>
+    {
+        private const string InstructionCollectionName = "RadeonAsmInstructionCollection";
+        private static readonly Regex fileExtensionRegular = new Regex(@"^\.\w+$");
+        private readonly OptionsProvider _optionsProvider;
+
+        public GeneralOptions()
+        {
+            _optionsProvider = Package.Instance.GetMEFComponent<OptionsProvider>();
+        }
+
+        #region Options
+        [Category("Function list")]
+        [DisplayName("Function list default sort option")]
+        [Description("Set default sort option for Function List")]
+        public SortState SortOptions
+        {
+            get { return _optionsProvider.SortOptions; }
+            set { _optionsProvider.SortOptions = value; }
+        }
+
+        [Category("Function list")]
+        [DisplayName("Autoscroll function list")]
+        [Description("Scroll to current function in the function list automatically")]
+        public bool Autoscroll
+        {
+            get { return _optionsProvider.Autoscroll; }
+            set { _optionsProvider.Autoscroll = value; }
+        }
+
+        [Category("Syntax highlight")]
+        [DisplayName("Indent guide lines")]
+        [Description("Enable/disable indent guide lines")]
+        public bool IsEnabledIndentGuides
+        {
+            get { return _optionsProvider.IsEnabledIndentGuides; }
+            set { _optionsProvider.IsEnabledIndentGuides = value; }
+        }
+
+        [Category("Syntax file extensions")]
+        [DisplayName("Asm1 file extensions")]
+        [Description("List of file extensions for the asm1 syntax")]
+        public string Asm1FileExtensions
+        {
+            get { return ConvertExtensionsTo(_optionsProvider.Asm1FileExtensions); }
+            set { var extensions = ConvertExtensionsFrom(value); if (ValidateExtensions(extensions)) _optionsProvider.Asm1FileExtensions = extensions; }
+        }
+
+        [Category("Syntax file extensions")]
+        [DisplayName("Asm2 file extensions")]
+        [Description("List of file extensions for the asm2 syntax")]
+        public string Asm2FileExtensions
+        {
+            get { return ConvertExtensionsTo(_optionsProvider.Asm2FileExtensions); }
+            set { var extensions = ConvertExtensionsFrom(value); if (ValidateExtensions(extensions)) _optionsProvider.Asm2FileExtensions = extensions; }
+        }
+
+        [Category("Syntax instruction folder paths")]
+        [DisplayName("Instruction folder paths")]
+        [Description("List of folder path separated by semicolon wit assembly instructions with .radasm file extension")]
+        [Editor(typeof(FolderPathsEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string InstructionsPaths
+        {
+            get { return _optionsProvider.InstructionsPaths; }
+            set { _optionsProvider.InstructionsPaths = value; }
+        }
+
+        [Category("Autocompletion")]
+        [DisplayName("Instruction autocompletion")]
+        [Description("Autocomplete instructions")]
+        public bool AutocompleteInstructions
+        {
+            get { return _optionsProvider.AutocompleteInstructions; }
+            set { _optionsProvider.AutocompleteInstructions = value; }
+        }
+
+        [Category("Autocompletion")]
+        [DisplayName("Function autocompletion")]
+        [Description("Autocomplete function name")]
+        public bool AutocompleteFunctions
+        {
+            get { return _optionsProvider.AutocompleteFunctions; }
+            set { _optionsProvider.AutocompleteFunctions = value; }
+        }
+
+        [Category("Autocompletion")]
+        [DisplayName("Label autocompletion")]
+        [Description("Autocomplete labels")]
+        public bool AutocompleteLabels
+        {
+            get { return _optionsProvider.AutocompleteLabels; }
+            set { _optionsProvider.AutocompleteLabels = value; }
+        }
+
+        [Category("Autocompletion")]
+        [DisplayName("Variable autocompletion")]
+        [Description("Autocomplete global variables, local variables, function arguments")]
+        public bool AutocompleteVariables
+        {
+            get { return _optionsProvider.AutocompleteVariables; }
+            set { _optionsProvider.AutocompleteVariables = value; }
+        }
+        #endregion
+
+        public override async Task LoadAsync()
+        {
+            await base.LoadAsync();
+
+            var settingsManager = await _settingsManager.GetValueAsync();
+            var userSettingsStore = settingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
+
+            if (!userSettingsStore.CollectionExists(InstructionCollectionName))
+                return;
+
+            InstructionsPaths = userSettingsStore.PropertyExists(InstructionCollectionName, nameof(InstructionsPaths))
+                ? userSettingsStore.GetString(InstructionCollectionName, nameof(InstructionsPaths))
+                : OptionsProvider.GetDefaultInstructionDirectoryPath();
+        }
+
+        public override async Task SaveAsync()
+        {
+            await base.SaveAsync();
+
+            var settingsManager = await _settingsManager.GetValueAsync();
+            var userSettingsStore = settingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
+
+            if (!userSettingsStore.CollectionExists(InstructionCollectionName))
+                userSettingsStore.CreateCollection(InstructionCollectionName);
+
+            if (!InstructionsPaths.Equals(
+                OptionsProvider.GetDefaultInstructionDirectoryPath(),
+                StringComparison.OrdinalIgnoreCase))
+            {
+                userSettingsStore.SetString(InstructionCollectionName, nameof(InstructionsPaths), InstructionsPaths);
+            }
+        }
+
+        private static List<string> ConvertExtensionsFrom(string str) =>
+            str.Split(';').Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+
+        private static string ConvertExtensionsTo(IReadOnlyList<string> extensions) =>
+            string.Join(";", extensions.ToArray());
+
+        private static bool ValidateExtensions(List<string> extensions)
+        {
+            var sb = new StringBuilder();
+            foreach (var ext in extensions)
+            {
+                if (!fileExtensionRegular.IsMatch(ext))
+                    sb.AppendLine($"Invalid file extension format \"{ext}\"");
+            }
+            if (sb.Length != 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("Format example: .asm");
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/VSRAD.Syntax/Options/GeneralOptions.cs
+++ b/VSRAD.Syntax/Options/GeneralOptions.cs
@@ -12,13 +12,13 @@ namespace VSRAD.Syntax.Options
     public enum SortState
     {
         [Description("by line number")]
-        ByLine = 1,
+        ByLine,
         [Description("by line number descending")]
-        ByLineDescending = 2,
+        ByLineDescending,
         [Description("by name")]
-        ByName = 3,
+        ByName,
         [Description("by name descending")]
-        ByNameDescending = 4,
+        ByNameDescending,
     }
 
     public class GeneralOptions : BaseOptionModel<GeneralOptions>

--- a/VSRAD.Syntax/Options/GeneralOptions.cs
+++ b/VSRAD.Syntax/Options/GeneralOptions.cs
@@ -3,13 +3,24 @@ using System.Text;
 using System.ComponentModel;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using static VSRAD.Syntax.Options.GeneralOptionPage;
 using Microsoft.VisualStudio.Settings;
 using System;
 using Task = System.Threading.Tasks.Task;
 
 namespace VSRAD.Syntax.Options
 {
+    public enum SortState
+    {
+        [Description("by line number")]
+        ByLine = 1,
+        [Description("by line number descending")]
+        ByLineDescending = 2,
+        [Description("by name")]
+        ByName = 3,
+        [Description("by name descending")]
+        ByNameDescending = 4,
+    }
+
     public class GeneralOptions : BaseOptionModel<GeneralOptions>
     {
         private const string InstructionCollectionName = "RadeonAsmInstructionCollection";

--- a/VSRAD.Syntax/Options/GeneralOptions.cs
+++ b/VSRAD.Syntax/Options/GeneralOptions.cs
@@ -89,7 +89,7 @@ namespace VSRAD.Syntax.Options
         }
 
         [Category("Autocompletion")]
-        [DisplayName("Instruction autocompletion")]
+        [DisplayName("Instruction auto-completion")]
         [Description("Autocomplete instructions")]
         public bool AutocompleteInstructions
         {
@@ -98,7 +98,7 @@ namespace VSRAD.Syntax.Options
         }
 
         [Category("Autocompletion")]
-        [DisplayName("Function autocompletion")]
+        [DisplayName("Function auto-completion")]
         [Description("Autocomplete function name")]
         public bool AutocompleteFunctions
         {
@@ -107,7 +107,7 @@ namespace VSRAD.Syntax.Options
         }
 
         [Category("Autocompletion")]
-        [DisplayName("Label autocompletion")]
+        [DisplayName("Label auto-completion")]
         [Description("Autocomplete labels")]
         public bool AutocompleteLabels
         {
@@ -116,7 +116,7 @@ namespace VSRAD.Syntax.Options
         }
 
         [Category("Autocompletion")]
-        [DisplayName("Variable autocompletion")]
+        [DisplayName("Variable auto-completion")]
         [Description("Autocomplete global variables, local variables, function arguments")]
         public bool AutocompleteVariables
         {

--- a/VSRAD.Syntax/Options/GeneralOptions.cs
+++ b/VSRAD.Syntax/Options/GeneralOptions.cs
@@ -24,7 +24,7 @@ namespace VSRAD.Syntax.Options
     public class GeneralOptions : BaseOptionModel<GeneralOptions>
     {
         private const string InstructionCollectionName = "RadeonAsmInstructionCollection";
-        private static readonly Regex fileExtensionRegular = new Regex(@"^\.\w+$");
+        private static readonly Regex _fileExtensionRegular = new Regex(@"^\.\w+$");
         private readonly OptionsProvider _optionsProvider;
 
         public GeneralOptions()
@@ -38,8 +38,8 @@ namespace VSRAD.Syntax.Options
         [Description("Set default sort option for Function List")]
         public SortState SortOptions
         {
-            get { return _optionsProvider.SortOptions; }
-            set { _optionsProvider.SortOptions = value; }
+            get => _optionsProvider.SortOptions;
+            set => _optionsProvider.SortOptions = value;
         }
 
         [Category("Function list")]
@@ -47,8 +47,8 @@ namespace VSRAD.Syntax.Options
         [Description("Scroll to current function in the function list automatically")]
         public bool Autoscroll
         {
-            get { return _optionsProvider.Autoscroll; }
-            set { _optionsProvider.Autoscroll = value; }
+            get => _optionsProvider.Autoscroll;
+            set => _optionsProvider.Autoscroll = value;
         }
 
         [Category("Syntax highlight")]
@@ -56,8 +56,8 @@ namespace VSRAD.Syntax.Options
         [Description("Enable/disable indent guide lines")]
         public bool IsEnabledIndentGuides
         {
-            get { return _optionsProvider.IsEnabledIndentGuides; }
-            set { _optionsProvider.IsEnabledIndentGuides = value; }
+            get => _optionsProvider.IsEnabledIndentGuides;
+            set => _optionsProvider.IsEnabledIndentGuides = value;
         }
 
         [Category("Syntax file extensions")]
@@ -65,7 +65,7 @@ namespace VSRAD.Syntax.Options
         [Description("List of file extensions for the asm1 syntax")]
         public string Asm1FileExtensions
         {
-            get { return ConvertExtensionsTo(_optionsProvider.Asm1FileExtensions); }
+            get => ConvertExtensionsTo(_optionsProvider.Asm1FileExtensions);
             set { var extensions = ConvertExtensionsFrom(value); if (ValidateExtensions(extensions)) _optionsProvider.Asm1FileExtensions = extensions; }
         }
 
@@ -74,7 +74,7 @@ namespace VSRAD.Syntax.Options
         [Description("List of file extensions for the asm2 syntax")]
         public string Asm2FileExtensions
         {
-            get { return ConvertExtensionsTo(_optionsProvider.Asm2FileExtensions); }
+            get => ConvertExtensionsTo(_optionsProvider.Asm2FileExtensions);
             set { var extensions = ConvertExtensionsFrom(value); if (ValidateExtensions(extensions)) _optionsProvider.Asm2FileExtensions = extensions; }
         }
 
@@ -84,8 +84,8 @@ namespace VSRAD.Syntax.Options
         [Editor(typeof(FolderPathsEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string InstructionsPaths
         {
-            get { return _optionsProvider.InstructionsPaths; }
-            set { _optionsProvider.InstructionsPaths = value; }
+            get => _optionsProvider.InstructionsPaths;
+            set => _optionsProvider.InstructionsPaths = value;
         }
 
         [Category("Autocompletion")]
@@ -93,8 +93,8 @@ namespace VSRAD.Syntax.Options
         [Description("Autocomplete instructions")]
         public bool AutocompleteInstructions
         {
-            get { return _optionsProvider.AutocompleteInstructions; }
-            set { _optionsProvider.AutocompleteInstructions = value; }
+            get => _optionsProvider.AutocompleteInstructions;
+            set => _optionsProvider.AutocompleteInstructions = value;
         }
 
         [Category("Autocompletion")]
@@ -102,8 +102,8 @@ namespace VSRAD.Syntax.Options
         [Description("Autocomplete function name")]
         public bool AutocompleteFunctions
         {
-            get { return _optionsProvider.AutocompleteFunctions; }
-            set { _optionsProvider.AutocompleteFunctions = value; }
+            get => _optionsProvider.AutocompleteFunctions;
+            set => _optionsProvider.AutocompleteFunctions = value;
         }
 
         [Category("Autocompletion")]
@@ -111,8 +111,8 @@ namespace VSRAD.Syntax.Options
         [Description("Autocomplete labels")]
         public bool AutocompleteLabels
         {
-            get { return _optionsProvider.AutocompleteLabels; }
-            set { _optionsProvider.AutocompleteLabels = value; }
+            get => _optionsProvider.AutocompleteLabels;
+            set => _optionsProvider.AutocompleteLabels = value;
         }
 
         [Category("Autocompletion")]
@@ -120,8 +120,8 @@ namespace VSRAD.Syntax.Options
         [Description("Autocomplete global variables, local variables, function arguments")]
         public bool AutocompleteVariables
         {
-            get { return _optionsProvider.AutocompleteVariables; }
-            set { _optionsProvider.AutocompleteVariables = value; }
+            get => _optionsProvider.AutocompleteVariables;
+            set => _optionsProvider.AutocompleteVariables = value;
         }
         #endregion
 
@@ -129,7 +129,7 @@ namespace VSRAD.Syntax.Options
         {
             await base.LoadAsync();
 
-            var settingsManager = await _settingsManager.GetValueAsync();
+            var settingsManager = await SettingsManager.GetValueAsync();
             var userSettingsStore = settingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
 
             if (!userSettingsStore.CollectionExists(InstructionCollectionName))
@@ -144,7 +144,7 @@ namespace VSRAD.Syntax.Options
         {
             await base.SaveAsync();
 
-            var settingsManager = await _settingsManager.GetValueAsync();
+            var settingsManager = await SettingsManager.GetValueAsync();
             var userSettingsStore = settingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
 
             if (!userSettingsStore.CollectionExists(InstructionCollectionName))
@@ -158,27 +158,27 @@ namespace VSRAD.Syntax.Options
             }
         }
 
-        private static List<string> ConvertExtensionsFrom(string str) =>
+        private static IReadOnlyList<string> ConvertExtensionsFrom(string str) =>
             str.Split(';').Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
 
-        private static string ConvertExtensionsTo(IReadOnlyList<string> extensions) =>
+        private static string ConvertExtensionsTo(IEnumerable<string> extensions) =>
             string.Join(";", extensions.ToArray());
 
-        private static bool ValidateExtensions(List<string> extensions)
+        private static bool ValidateExtensions(IEnumerable<string> extensions)
         {
             var sb = new StringBuilder();
             foreach (var ext in extensions)
             {
-                if (!fileExtensionRegular.IsMatch(ext))
+                if (!_fileExtensionRegular.IsMatch(ext))
                     sb.AppendLine($"Invalid file extension format \"{ext}\"");
             }
-            if (sb.Length != 0)
-            {
-                sb.AppendLine();
-                sb.AppendLine("Format example: .asm");
-                return false;
-            }
-            return true;
+
+            if (sb.Length == 0)
+                return true;
+
+            sb.AppendLine();
+            sb.AppendLine("Format example: .asm");
+            return false;
         }
     }
 }

--- a/VSRAD.Syntax/Package.cs
+++ b/VSRAD.Syntax/Package.cs
@@ -37,7 +37,9 @@ namespace VSRAD.Syntax
             _componentModel = await GetServiceAsync(typeof(SComponentModel)) as IComponentModel;
             var commandService = await GetServiceAsync((typeof(IMenuCommandService))) as OleMenuCommandService;
 
-            await ((GeneralOptionPage)GetDialogPage(typeof(GeneralOptionPage))).InitializeAsync();
+            var options = GetMEFComponent<IOptions>();
+            await options.LoadAsync();
+
             await NavigationListCommand.InitializeAsync(this);
 
             FunctionListCommand.Initialize(this, commandService);

--- a/VSRAD.Syntax/VSRAD.Syntax.csproj
+++ b/VSRAD.Syntax/VSRAD.Syntax.csproj
@@ -155,6 +155,12 @@
     <Compile Include="IntelliSense\Navigation\NavigationTokenServiceResult.cs" />
     <Compile Include="Options\ContentTypeManager.cs" />
     <Compile Include="Options\FolderPathsEditor.cs" />
+    <Compile Include="Options\BaseOptionPage.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="Options\BaseOptionModel.cs" />
+    <Compile Include="Options\GeneralOptions.cs" />
+    <Compile Include="Options\GeneralOptionProvider.cs" />
     <Compile Include="Options\Instructions\InstructionListLoader.cs" />
     <Compile Include="Options\Instructions\Instruction.cs" />
     <Compile Include="Options\Instructions\InstructionListManager.cs" />
@@ -162,7 +168,9 @@
     <Compile Include="Options\Instructions\InstructionSetSelector.cs" />
     <Compile Include="Package.cs" />
     <Compile Include="Constants.cs" />
-    <Compile Include="Options\GeneralOptionPage.cs" />
+    <Compile Include="Options\GeneralOptionPage.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="IntelliSense\Navigation\NavigationTokenService.cs" />
     <Compile Include="IntelliSense\Peek\PeekableItem.cs" />
     <Compile Include="IntelliSense\Peek\PeekableItemSource.cs" />


### PR DESCRIPTION
This PR doesn't fix anything, but it cleans up the options module.
The options have been split into two components:
- Option Page
- Option Model

The first is responsible for presenting options on the dialog page.
The second is responsible for saving and loading options from the Visual Studio registry.
This makes the options more expandable.

This PR may also slightly speed up the extension loading.