### PR TITLE
Save selected instruction set

### DIFF
--- a/VSRAD.Syntax/Helpers/CustomThreadHelper.cs
+++ b/VSRAD.Syntax/Helpers/CustomThreadHelper.cs
@@ -9,12 +9,23 @@ namespace VSRAD.Syntax.Helpers
         public static T RunOnMainThread<T>(Func<T> func) =>
             RunOnMainThread(func, CancellationToken.None);
 
+        public static void RunOnMainThread(Action func) =>
+            RunOnMainThread(func, CancellationToken.None);
+
         public static T RunOnMainThread<T>(Func<T> func, CancellationToken ct) =>
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
                 ThreadHelper.ThrowIfNotOnUIThread();
                 return func();
+            });
+
+        public static void RunOnMainThread(Action func, CancellationToken ct) =>
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
+                ThreadHelper.ThrowIfNotOnUIThread();
+                func();
             });
     }
 }

--- a/VSRAD.Syntax/Options/GeneralOptionProvider.cs
+++ b/VSRAD.Syntax/Options/GeneralOptionProvider.cs
@@ -31,6 +31,8 @@ namespace VSRAD.Syntax.Options
             Asm1FileExtensions = Constants.DefaultFileExtensionAsm1;
             Asm2FileExtensions = Constants.DefaultFileExtensionAsm2;
             InstructionsPaths = GetDefaultInstructionDirectoryPath();
+            Asm1InstructionSet = string.Empty;
+            Asm2InstructionSet = string.Empty;
             AutocompleteInstructions = false;
             AutocompleteFunctions = false;
             AutocompleteLabels = false;
@@ -48,6 +50,8 @@ namespace VSRAD.Syntax.Options
         public IReadOnlyList<string> Asm1FileExtensions;
         public IReadOnlyList<string> Asm2FileExtensions;
         public string InstructionsPaths;
+        public string Asm1InstructionSet;
+        public string Asm2InstructionSet;
         public bool AutocompleteInstructions;
         public bool AutocompleteFunctions;
         public bool AutocompleteLabels;

--- a/VSRAD.Syntax/Options/GeneralOptions.cs
+++ b/VSRAD.Syntax/Options/GeneralOptions.cs
@@ -78,7 +78,7 @@ namespace VSRAD.Syntax.Options
             set { var extensions = ConvertExtensionsFrom(value); if (ValidateExtensions(extensions)) _optionsProvider.Asm2FileExtensions = extensions; }
         }
 
-        [Category("Syntax instruction folder paths")]
+        [Category("Instructions")]
         [DisplayName("Instruction folder paths")]
         [Description("List of folder path separated by semicolon wit assembly instructions with .radasm file extension")]
         [Editor(typeof(FolderPathsEditor), typeof(System.Drawing.Design.UITypeEditor))]
@@ -86,6 +86,24 @@ namespace VSRAD.Syntax.Options
         {
             get { return _optionsProvider.InstructionsPaths; }
             set { _optionsProvider.InstructionsPaths = value; }
+        }
+
+        [Category("Instructions")]
+        [DisplayName("Asm1 selected set")]
+        [Browsable(false)]
+        public string Asm1InstructionSet
+        {
+            get { return _optionsProvider.Asm1InstructionSet; }
+            set { _optionsProvider.Asm1InstructionSet = value; }
+        }
+
+        [Category("Instructions")]
+        [DisplayName("Asm2 selected set")]
+        [Browsable(false)]
+        public string Asm2InstructionSet
+        {
+            get { return _optionsProvider.Asm2InstructionSet; }
+            set { _optionsProvider.Asm2InstructionSet = value; }
         }
 
         [Category("Autocompletion")]

--- a/VSRAD.Syntax/Options/Instructions/InstructionListManager.cs
+++ b/VSRAD.Syntax/Options/Instructions/InstructionListManager.cs
@@ -31,6 +31,7 @@ namespace VSRAD.Syntax.Options.Instructions
         private readonly List<IInstructionSet> _radAsm2InstructionSets;
         private readonly List<Instruction> _radAsm1Instructions;
         private readonly List<Instruction> _radAsm2Instructions;
+        private readonly GeneralOptions _options;
 
         private AsmType activeDocumentAsm;
         private IInstructionSet radAsm1SelectedSet;
@@ -51,6 +52,8 @@ namespace VSRAD.Syntax.Options.Instructions
             _radAsm1Instructions = new List<Instruction>();
             _radAsm2Instructions = new List<Instruction>();
             activeDocumentAsm = AsmType.Unknown;
+
+            _options = GeneralOptions.Instance;
         }
 
         private void InstructionsLoaded(IReadOnlyList<IInstructionSet> instructions)
@@ -71,8 +74,9 @@ namespace VSRAD.Syntax.Options.Instructions
 
             _radAsm1Instructions.AddRange(_radAsm1InstructionSets.SelectMany(s => s.Select(i => i)));
             _radAsm2Instructions.AddRange(_radAsm2InstructionSets.SelectMany(s => s.Select(i => i)));
-            radAsm1SelectedSet = null;
-            radAsm2SelectedSet = null;
+
+            radAsm1SelectedSet = SelectInstructionSet(_radAsm1InstructionSets, _options.Asm1InstructionSet);
+            radAsm2SelectedSet = SelectInstructionSet(_radAsm2InstructionSets, _options.Asm2InstructionSet);
 
             AsmTypeChanged?.Invoke();
             InstructionsUpdated?.Invoke(this, AsmType.RadAsmCode);
@@ -127,6 +131,13 @@ namespace VSRAD.Syntax.Options.Instructions
                 }
             }
 
+            switch (activeDocumentAsm)
+            {
+                case AsmType.RadAsm: _options.Asm1InstructionSet = selected ?? string.Empty; break;
+                case AsmType.RadAsm2: _options.Asm2InstructionSet = selected ?? string.Empty; break;
+            }
+            _options.Save();
+
             InstructionsUpdated?.Invoke(this, activeDocumentAsm);
         }
 
@@ -158,5 +169,8 @@ namespace VSRAD.Syntax.Options.Instructions
                 default: return null;
             }
         }
+
+        private static IInstructionSet SelectInstructionSet(IEnumerable<IInstructionSet> sets, string name) =>
+            sets.FirstOrDefault(s => s.SetName.Equals(name, System.StringComparison.OrdinalIgnoreCase));
     }
 }


### PR DESCRIPTION
## ⚠️ Note
Before reviewing this pull request, #243 must be merged into dev-stable.

## Description
This PR provides automatic saving of the selected instruction set. 
The next time the Visual Studio is launched, the instruction set that was selected in the previous session will be automatically selected. 

The selected instruction set is different for `asm1` and `asm2`.