### PR TITLE
Combine instruction completions

### DIFF
--- a/VSRAD.Syntax/IntelliSense/Completion/Providers/InstructionCompletionProvider.cs
+++ b/VSRAD.Syntax/IntelliSense/Completion/Providers/InstructionCompletionProvider.cs
@@ -65,17 +65,26 @@ namespace VSRAD.Syntax.IntelliSense.Completion.Providers
             {
                 _asm1InstructionCompletions.Clear();
                 _asm1InstructionCompletions.AddRange(
-                    sender.GetSelectedSetInstructions(AsmType.RadAsm)
-                          .Select(i => new MultipleCompletionItem(i.Text, i.Navigations, Icon)));
+                    GetInstructionCompletions(sender, AsmType.RadAsm));
             }
 
             if ((asmType & AsmType.RadAsm2) != 0)
             {
                 _asm2InstructionCompletions.Clear();
                 _asm2InstructionCompletions.AddRange(
-                    sender.GetSelectedSetInstructions(AsmType.RadAsm2)
-                          .Select(i => new MultipleCompletionItem(i.Text, i.Navigations, Icon)));
+                    GetInstructionCompletions(sender, AsmType.RadAsm2));
             }
         }
+
+        private static IEnumerable<MultipleCompletionItem> GetInstructionCompletions(IInstructionListManager manager, AsmType asmType) =>
+            manager.GetSelectedSetInstructions(asmType)
+              .GroupBy(i => i.Text)
+              .Select(g =>
+              {
+                  var instructionName = g.Key;
+                  var navigationList = g.SelectMany(i => i.Navigations).ToList();
+
+                  return new MultipleCompletionItem(instructionName, navigationList, Icon);
+              });
     }
 }


### PR DESCRIPTION
This pull request fixes multiple instances of instructions in the autocompletion list.

For example, if all instruction sets are selected (`instruction set selector -> All`).
Then completion list contained multiple **identical instructions** from different _Instruction Sets_.
![image](https://user-images.githubusercontent.com/40007198/126367728-5f83906d-0e36-46b7-861c-e957ce4c12fa.png)

This pull request fixes this issue:
![image](https://user-images.githubusercontent.com/40007198/126368500-ddc3122b-d0cb-4f10-aa3a-036f938b0b99.png)
