### PR TITLE
Open in Editor: Tab groups handling [dev-stable]

### DIFF
--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -56,6 +56,14 @@ namespace VSRAD.Package.Options
         private BreakMode _breakMode;
         public BreakMode BreakMode { get => _breakMode; set => SetField(ref _breakMode, value); }
 
+        [DefaultValue(true)]
+        private bool _forceOppositeTab;
+        public bool ForceOppositeTab { get => _forceOppositeTab; set => SetField(ref _forceOppositeTab, value); }
+
+        [DefaultValue(false)]
+        private bool _preserveActiveDoc;
+        public bool PreserveActiveDoc { get => _preserveActiveDoc; set => SetField(ref _preserveActiveDoc, value); }
+
         public DebuggerOptions() { }
         public DebuggerOptions(List<Watch> watches) => Watches = watches;
 

--- a/VSRAD.Package/ProjectSystem/ActionLauncher.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLauncher.cs
@@ -120,7 +120,7 @@ namespace VSRAD.Package.ProjectSystem
                 _projectSources.SaveProjectState();
 
                 var env = new ActionEnvironment(general.LocalWorkDir, general.RemoteWorkDir, transients.Watches);
-                var runner = new ActionRunner(_channel, _serviceProvider, env);
+                var runner = new ActionRunner(_channel, _serviceProvider, env, _project);
                 var runResult = await runner.RunAsync(action.Name, action.Steps, _project.Options.Profile.General.ContinueActionExecOnError).ConfigureAwait(false);
                 var actionError = await _actionLogger.LogActionWithWarningsAsync(runResult).ConfigureAwait(false);
                 return new ActionExecution(actionError, transients, runResult);

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -8,6 +8,7 @@ using VSRAD.DebugServer;
 using VSRAD.DebugServer.IPC.Commands;
 using VSRAD.DebugServer.IPC.Responses;
 using VSRAD.Package.Options;
+using VSRAD.Package.ProjectSystem;
 using VSRAD.Package.Utils;
 using Task = System.Threading.Tasks.Task;
 
@@ -19,12 +20,14 @@ namespace VSRAD.Package.Server
         private readonly SVsServiceProvider _serviceProvider;
         private readonly Dictionary<string, DateTime> _initialTimestamps = new Dictionary<string, DateTime>();
         private readonly ActionEnvironment _environment;
+        private readonly IProject _project;
 
-        public ActionRunner(ICommunicationChannel channel, SVsServiceProvider serviceProvider, ActionEnvironment environment)
+        public ActionRunner(ICommunicationChannel channel, SVsServiceProvider serviceProvider, ActionEnvironment environment, IProject project)
         {
             _channel = channel;
             _serviceProvider = serviceProvider;
             _environment = environment;
+            _project = project;
         }
 
         public DateTime GetInitialFileTimestamp(string file) =>
@@ -173,7 +176,8 @@ namespace VSRAD.Package.Server
         private async Task<StepResult> DoOpenInEditorAsync(OpenInEditorStep step)
         {
             await VSPackage.TaskFactory.SwitchToMainThreadAsync();
-            VsEditor.OpenFileInEditor(_serviceProvider, step.Path, step.LineMarker);
+            VsEditor.OpenFileInEditor(_serviceProvider, step.Path, step.LineMarker,
+                _project.Options.DebuggerOptions.ForceOppositeTab, _project.Options.DebuggerOptions.PreserveActiveDoc);
             return new StepResult(true, "", "");
         }
 

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -124,6 +124,14 @@
                         </ComboBox.ItemTemplate>
                     </ComboBox>
                 </StackPanel>
+                <StackPanel Orientation="Horizontal" Height="25">
+                    <CheckBox Content="Open in Editor: Force new document to be opened in the opposite tab" VerticalAlignment="Center" Padding="4,0,0,0"
+                                IsChecked="{Binding Options.DebuggerOptions.ForceOppositeTab, UpdateSourceTrigger=PropertyChanged}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Height="25">
+                    <CheckBox Content="Open in Editor: Preserve active document" VerticalAlignment="Center" Padding="4,0,0,0"
+                                IsChecked="{Binding Options.DebuggerOptions.PreserveActiveDoc, UpdateSourceTrigger=PropertyChanged}"/>
+                </StackPanel>
                 <Expander Header="Visualizer Appearance" Margin="0,8,0,0">
                     <StackPanel Margin="0,6,0,0">
                         <StackPanel Orientation="Horizontal" Height="25">

--- a/VSRAD.Package/Utils/VsEditor.cs
+++ b/VSRAD.Package/Utils/VsEditor.cs
@@ -1,10 +1,13 @@
 ﻿using EnvDTE;
 using Microsoft;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.IO;
+using System.Reflection;
 
 namespace VSRAD.Package.Utils
 {
@@ -46,25 +49,34 @@ namespace VSRAD.Package.Utils
             return markers;
         }
 
-        public static void OpenFileInEditor(SVsServiceProvider serviceProvider, string path, string lineMarker)
+        private static readonly Type _sVsWindowManagerType = Type.GetType("Microsoft.Internal.VisualStudio.Shell.Interop.SVsWindowManager, Microsoft.VisualStudio.Platform.WindowManagement");
+        private static readonly Type _viewManagerType = Type.GetType("Microsoft.VisualStudio.PlatformUI.Shell.ViewManager, Microsoft.VisualStudio.Shell.ViewManager");
+        private static readonly Type _viewDockOperationsType = Type.GetType("Microsoft.VisualStudio.PlatformUI.Shell.DockOperations, Microsoft.VisualStudio.Shell.ViewManager");
+
+        public static void OpenFileInEditor(SVsServiceProvider serviceProvider, string path, string lineMarker, bool forceOppositeTab, bool preserveActiveDoc)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             try
             {
-                var dte = serviceProvider.GetService(typeof(DTE)) as DTE;
-                Assumes.Present(dte);
-                dte.ItemOperations.OpenFile(path);
+                var windowManager = serviceProvider.GetService(_sVsWindowManagerType);
+                Assumes.Present(windowManager);
+                // Using GetType() because _sVsWindowManagerType is just an interface; ActiveDocumentFrame is present only in the actual implementation class
+                dynamic originalDocumentFrame = windowManager.GetType().GetProperty("ActiveDocumentFrame", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(windowManager);
 
-                if (string.IsNullOrEmpty(lineMarker))
-                    return;
+                var vsUIShellOpenDocument = serviceProvider.GetService(typeof(SVsUIShellOpenDocument)) as IVsUIShellOpenDocument;
+                Assumes.Present(vsUIShellOpenDocument);
+                ErrorHandler.ThrowOnFailure(vsUIShellOpenDocument.OpenDocumentViaProject(path, Guid.Empty, out _, out _, out _, out var newDocumentFrame));
 
-                var lineNumber = GetMarkedLineNumber(path, lineMarker);
+                if (!string.IsNullOrEmpty(lineMarker))
+                    SetCaretAtLineMarker(newDocumentFrame, lineMarker);
 
-                var textManager = serviceProvider.GetService(typeof(SVsTextManager)) as IVsTextManager2;
-                Assumes.Present(textManager);
+                if (forceOppositeTab && originalDocumentFrame != null && originalDocumentFrame != newDocumentFrame)
+                    MoveToOppositeTab(newDocumentFrame, originalDocumentFrame, preserveActiveDoc);
 
-                textManager.GetActiveView2(1, null, (uint)_VIEWFRAMETYPE.vftCodeWindow, out var activeView);
-                activeView.SetCaretPos(lineNumber, 0);
+                if (preserveActiveDoc)
+                    ErrorHandler.ThrowOnFailure(newDocumentFrame.ShowNoActivate());
+                else
+                    ErrorHandler.ThrowOnFailure(newDocumentFrame.Show());
             }
             catch (Exception e)
             {
@@ -72,16 +84,88 @@ namespace VSRAD.Package.Utils
             }
         }
 
-        private static int GetMarkedLineNumber(string file, string lineMarker)
+        private static void MoveToOppositeTab(IVsWindowFrame newDocumentFrame, dynamic originalDocumentFrame, bool preserveActiveDoc)
         {
-            var lineNumber = 0;
-            foreach (var line in File.ReadLines(file))
+            dynamic newDocumentFrameView = ((dynamic)newDocumentFrame).FrameView;
+            dynamic newDocumentTabGroup = newDocumentFrameView.Parent;
+
+            // if the document is in the same tab group as the original active document, move it
+            if (originalDocumentFrame.FrameView.Parent == newDocumentTabGroup)
             {
-                if (line == lineMarker)
-                    return lineNumber;
-                ++lineNumber;
+                // If there's only one existing tab group, create a new one
+                var tabGroups = (IList)newDocumentTabGroup.Parent.VisibleChildren;
+                if (tabGroups.Count == 1)
+                {
+                    var viewManager = _viewManagerType.GetProperty("Instance").GetValue(null);
+                    var createDocumentGroup = _viewManagerType.GetMethod("CreateDocumentGroup", BindingFlags.NonPublic | BindingFlags.Instance);
+                    createDocumentGroup.Invoke(viewManager, new[] { newDocumentFrameView, 0 });
+                }
+
+                // Choose the tab group the document should be assigned to
+                int tabGroupIndex = tabGroups.IndexOf(newDocumentTabGroup);
+                dynamic newTabGroup;
+                if (tabGroupIndex + 1 < tabGroups.Count)
+                    newTabGroup = tabGroups[tabGroupIndex + 1];
+                else
+                    newTabGroup = tabGroups[tabGroupIndex - 1];
+
+                // Remove the document from the tab group it was assigned to
+                newDocumentFrameView.Detach();
+
+                // Assign the document to the new tab group
+                _viewDockOperationsType.GetMethod("Dock").Invoke(null, new[] { newTabGroup, newDocumentFrameView, 0 });
+
+                if (preserveActiveDoc)
+                {
+                    // There's a race condition in Visual Studio 2019 which makes the new document frame steal focus from the original document
+                    // _after_ we exit from OpenFileInEditor, caused by WindowFrame using the FrameworkElement.Loaded event to move focus into itself.
+                    // The hack below listens to this event and restores focus to the original document frame.
+                    // This happens only when performing docking operations. To reproduce the bug:
+                    // 1. Create an action that opens a file in the editor, enable forceOppositeTab and preserveActiveDoc.
+                    // 2. Open a different source file in the editor, which becomes the active (or "original") document. There should be a single tab group in the editor at this point.
+                    // 3. Run the action once. A tab group will be created on the right with the new document.
+                    // 4. Move the new document to the left tab group and switch to the original document's tab. There should be a single tab group in the editor at this point.
+                    // 5. Run the action again. A tab group will be created on the right and the new document will receive focus despite preserveActiveDoc.
+                    // Repeat steps 4-5 if you can't reproduce it at first try.
+                    var innerContentProperty = newDocumentFrame.GetType().GetProperty("InnerContent", BindingFlags.NonPublic | BindingFlags.Instance);
+                    var newFrameContent = (System.Windows.FrameworkElement)innerContentProperty.GetValue(newDocumentFrame);
+                    var originalFrameContent = (System.Windows.FrameworkElement)innerContentProperty.GetValue(originalDocumentFrame);
+                    void NewDocumentFrameLoaded(object sender, System.Windows.RoutedEventArgs e)
+                    {
+                        newFrameContent.Loaded -= NewDocumentFrameLoaded;
+                        var originalFrameRoot = System.Windows.PresentationSource.FromVisual(originalFrameContent).RootVisual;
+                        System.Windows.Input.FocusManager.SetFocusedElement(originalFrameRoot, null);
+                        System.Windows.Input.Keyboard.Focus((System.Windows.IInputElement)originalFrameRoot);
+                        Microsoft.VisualStudio.PlatformUI.FocusHelper.MoveFocusInto(originalFrameContent);
+                    }
+                    newFrameContent.Loaded += NewDocumentFrameLoaded;
+                }
             }
-            return 0;
+            // Otherwise, make the document active in its tab group without changing the global active document
+            else
+            {
+                newDocumentTabGroup.SelectedElement = newDocumentFrameView;
+            }
+        }
+
+        private static void SetCaretAtLineMarker(IVsWindowFrame documentFrame, string lineMarker)
+        {
+            var vsTextView = VsShellUtilities.GetTextView(documentFrame);
+            ErrorHandler.ThrowOnFailure(vsTextView.GetBuffer(out var vsTextLines));
+            ErrorHandler.ThrowOnFailure(vsTextLines.GetLineCount(out var numLines));
+            for (int i = 0; i < numLines; ++i)
+            {
+                ErrorHandler.ThrowOnFailure(vsTextLines.GetLengthOfLine(i, out var lineLength));
+                if (lineLength != lineMarker.Length)
+                    continue;
+
+                ErrorHandler.ThrowOnFailure(vsTextLines.GetLineText(i, 0, i, lineLength, out var line));
+                if (line != lineMarker)
+                    continue;
+
+                ErrorHandler.ThrowOnFailure(vsTextView.SetCaretPos(i, 0));
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR modifies the behavior of Open in Editor step.

Added two new settings to the Options Window:

* **Open in Editor: Force new document to be opened in the opposite tab**: if checked, new document will always be opened in the separate vertical tab group from current active document, in existing, if possible, or in new, if there is only one tab.
* **Open in Editor: Preserve active document**: if checked, Open in Editor step would not change the active document. Otherwise, opened document will become active.