### PR TITLE
Debugger plugin fixes

### DIFF
--- a/VSRAD.Package/Commands/AddToWatchesCommand.cs
+++ b/VSRAD.Package/Commands/AddToWatchesCommand.cs
@@ -36,7 +36,8 @@ namespace VSRAD.Package.Commands
 
         private void HandleCustomSlice(uint start, uint step, uint count, string watchName)
         {
-            var arrayRangeWatch = ArrayRange.FormatCustomSlice(watchName, (int)start, (int)step, (int)count);
+            var arrayRangeWatch = ArrayRange.FormatCustomSlice(watchName, (int)start, (int)step, (int)count,
+                _toolIntegration.ProjectOptions.VisualizerOptions.MatchBracketsOnAddToWatches);
             foreach (var watch in arrayRangeWatch)
                 _toolIntegration.AddWatchFromEditor(watch);
         }

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -56,12 +56,14 @@ namespace VSRAD.Package.Options
         private BreakMode _breakMode;
         public BreakMode BreakMode { get => _breakMode; set => SetField(ref _breakMode, value); }
 
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         [DefaultValue(true)]
-        private bool _forceOppositeTab;
+        private bool _forceOppositeTab = true;
         public bool ForceOppositeTab { get => _forceOppositeTab; set => SetField(ref _forceOppositeTab, value); }
-
-        [DefaultValue(false)]
-        private bool _preserveActiveDoc;
+        
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(true)]
+        private bool _preserveActiveDoc = true;
         public bool PreserveActiveDoc { get => _preserveActiveDoc; set => SetField(ref _preserveActiveDoc, value); }
 
         public DebuggerOptions() { }

--- a/VSRAD.Package/Utils/ArrayRange.cs
+++ b/VSRAD.Package/Utils/ArrayRange.cs
@@ -39,13 +39,13 @@ namespace VSRAD.Package.Utils
             return result;
         }
 
-        public static string[] FormatCustomSlice(string name, int start, int step, int count)
+        public static string[] FormatCustomSlice(string name, int start, int step, int count, bool matchBrackets)
         {
             var numericMatch = _numericIndexPattern.Match(name);
             var symbolMatch = _symbolIndexPattern.Match(name);
 
             var result = new string[count];
-            if (numericMatch.Success || (!numericMatch.Success && !symbolMatch.Success))
+            if ((numericMatch.Success || (!numericMatch.Success && !symbolMatch.Success)) || !matchBrackets)
             {
                 for (int i = 0; i < count; i++)
                     result[i] = $"{name}[{start + (i * step)}]";

--- a/VSRAD.Package/Utils/BreakModeConverter.cs
+++ b/VSRAD.Package/Utils/BreakModeConverter.cs
@@ -4,8 +4,8 @@ namespace VSRAD.Package.Utils
 {
     class BreakModeConverter
     {
-        static public readonly string[] BreakModeOptions = new[] {  "Single active breakpoint, round-robin",
-                                                                    "Single active breakpoint, rerun same line",
+        static public readonly string[] BreakModeOptions = new[] {  "Round-robin, single active breakpoint",
+                                                                    "Rerun line, single active breakpoint",
                                                                     "Multiple active breakpoints" };
 
         static public readonly string[] ShortBreakModeOptions = new[] { "Round-robin", "Rerun line", "Multiple" };


### PR DESCRIPTION
This PR provides a few fixes that related to the last changes in the Debugger plugin.

* Added support for optional brackets matching when using custom slices for watch adding.
* Fixed break mode descriptions for better matching with short versions.
* Fixed default values setting for `ForceOppositeTab` and `PreserveActiveDoc` properties.