### PR TITLE
Move document to opposite tab fix

### DIFF
--- a/VSRAD.Package/Utils/VsEditor.cs
+++ b/VSRAD.Package/Utils/VsEditor.cs
@@ -140,6 +140,8 @@ namespace VSRAD.Package.Utils
                     }
                     newFrameContent.Loaded += NewDocumentFrameLoaded;
                 }
+                
+                newTabGroup.SelectedElement = newDocumentFrameView;
             }
             // Otherwise, make the document active in its tab group without changing the global active document
             else


### PR DESCRIPTION
This PR provides small fix for the Open in Editor feature.

Steps to reproduce:

1. Check both `Open in editor: ...` options.
2. Create 2 separate tab groups, set focus to the first one.
3. Run action with `Open in editor` step (the file should not be opened in any tab before this).

As a result, the file will be opened in the second tab, but it will be hidden because active document from this tab will remain same.