### PR TITLE
Fix function argument highlighting

### DIFF
--- a/VSRAD.Syntax/SyntaxHighlighter/Classifier.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/Classifier.cs
@@ -40,8 +40,15 @@ namespace VSRAD.Syntax.SyntaxHighlighter
             var analysisResult = _analysisResult;
             if (analysisResult == null || analysisResult.Snapshot != span.Snapshot) return classificationSpans;
 
-            var block = analysisResult.GetBlock(span.Start);
+            var block = analysisResult.GetBlock(span.End);
             if (block.Type == BlockType.Comment) return classificationSpans;
+            if (block.Type == BlockType.Function)
+            {
+                var funcBlock = (FunctionBlock)block;
+                var funcToken = funcBlock.Name;
+                var funcClassificationSpan = new ClassificationSpan(funcToken.Span, _tokenClassification[funcToken.Type]);
+                classificationSpans.Add(funcClassificationSpan);
+            }
 
             foreach (var scopeToken in block.Tokens)
             {

--- a/VSRAD.Syntax/SyntaxHighlighter/Classifier.cs
+++ b/VSRAD.Syntax/SyntaxHighlighter/Classifier.cs
@@ -40,7 +40,8 @@ namespace VSRAD.Syntax.SyntaxHighlighter
             var analysisResult = _analysisResult;
             if (analysisResult == null || analysisResult.Snapshot != span.Snapshot) return classificationSpans;
 
-            var block = analysisResult.GetBlock(span.End);
+            var point = span.End - 1; // span is right exclusive
+            var block = analysisResult.GetBlock(point);
             if (block.Type == BlockType.Comment) return classificationSpans;
             if (block.Type == BlockType.Function)
             {


### PR DESCRIPTION
This PR fixes function argument highlighting.
In this example `arg1` and `arg2` function parameters were not highlighted. 

```
.macro some_macro arg1, arg2
     .set value, \arg1
.endm
```