### PR TITLE
Handle document renaming correctly

### DIFF
--- a/VSRAD.Syntax/Core/Document.cs
+++ b/VSRAD.Syntax/Core/Document.cs
@@ -38,7 +38,7 @@ namespace VSRAD.Syntax.Core
 
         private void FileActionOccurred(object sender, TextDocumentFileActionEventArgs e)
         {
-            if (e.FileActionType == FileActionTypes.DocumentRenamed)
+            if (e.FileActionType.HasFlag(FileActionTypes.DocumentRenamed))
             {
                 var oldPath = Path;
                 Path = e.FilePath;


### PR DESCRIPTION
[FileActionTypes](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.text.fileactiontypes?view=visualstudiosdk-2019) is flag enum. It's incorrect to compare `e.FileActionType` with `FileActionTypes.DocumentRenamed` because it may have a different value. 

For example, on `save as` the value is `FileActionTypes.DocumentRenamed | FileActionTypes.ContentSavedToDisk` so renaming will not be handled.