### PR TITLE
Rerun line behavior fix

### DIFF
--- a/VSRAD.Package/ProjectSystem/BreakpointTracker.cs
+++ b/VSRAD.Package/ProjectSystem/BreakpointTracker.cs
@@ -109,7 +109,8 @@ namespace VSRAD.Package.ProjectSystem
                     return (file, breakpointLines.ToArray());
                 case BreakMode.SingleRerun:
                     if (_breakTargets.TryGetValue(file, out var prevTarget))
-                        return (file, prevTarget);
+                        if (breakpointLines.Contains(prevTarget[0]))
+                            return (file, prevTarget);
 
                     return (file, new[] { breakpointLines[0] });
                 default:


### PR DESCRIPTION
This PR fixes the behavior of the breakpoint placing in the `Rerun Line` mode. Previously, the same line would be selected for `Continue` even if user deletes original breakpoint, now the next line (or last line in doc, if there is no more breakpoints) will be selected.