### PR TITLE
BreakLineGlyphTagger memory leak fix

### DIFF
--- a/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphTagger.cs
+++ b/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphTagger.cs
@@ -90,6 +90,7 @@ namespace VSRAD.Package.ProjectSystem.EditorExtensions
         private readonly ITextBuffer _buffer;
         private readonly ITextDocument _document;
         private readonly BreakLineGlyphTaggerProvider _provider;
+        private readonly ITextDocumentFactoryService _textDocumentFactoryService;
 
         private readonly List<TagSpan<BreakLineGlyphTag>> _tagSpans = new List<TagSpan<BreakLineGlyphTag>>();
 
@@ -99,7 +100,8 @@ namespace VSRAD.Package.ProjectSystem.EditorExtensions
             _buffer = buffer;
             _document = document;
             _provider = provider;
-            textDocumentFactoryService.TextDocumentDisposed += DocumentDisposed;
+            _textDocumentFactoryService = textDocumentFactoryService;
+            _textDocumentFactoryService.TextDocumentDisposed += DocumentDisposed;
             _provider.DebugExecutionCompleted += DebugExecutionCompleted;
         }
 
@@ -107,7 +109,10 @@ namespace VSRAD.Package.ProjectSystem.EditorExtensions
         private void DocumentDisposed(object sender, TextDocumentEventArgs e)
         {
             if (e.TextDocument == _document)
+            {
                 _provider.DebugExecutionCompleted -= DebugExecutionCompleted;
+                _textDocumentFactoryService.TextDocumentDisposed -= DocumentDisposed;
+            }
         }
 
         private void DebugExecutionCompleted(object sender, ExecutionCompletedEventArgs e)

--- a/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphTagger.cs
+++ b/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphTagger.cs
@@ -33,6 +33,14 @@ namespace VSRAD.Package.ProjectSystem.EditorExtensions
         // ExecutionCompleted event directly.
         internal event EventHandler<ExecutionCompletedEventArgs> DebugExecutionCompleted;
 
+        private readonly ITextDocumentFactoryService _textDocumentFactoryService;
+
+        [ImportingConstructor]
+        public BreakLineGlyphTaggerProvider(ITextDocumentFactoryService textDocumentFactoryService)
+        {
+            _textDocumentFactoryService = textDocumentFactoryService;
+        }
+
         public virtual void OnExecutionCompleted(ExecutionCompletedEventArgs execCompleted)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
@@ -69,7 +77,8 @@ namespace VSRAD.Package.ProjectSystem.EditorExtensions
         public ITagger<T> CreateTagger<T>(ITextView textView, ITextBuffer buffer) where T : ITag
         {
             if (buffer != null && buffer.Properties.TryGetProperty(typeof(ITextDocument), out ITextDocument document))
-                return buffer.Properties.GetOrCreateSingletonProperty(() => new BreakLineGlyphTagger(buffer, document, this) as ITagger<T>);
+                return buffer.Properties.GetOrCreateSingletonProperty(() => new BreakLineGlyphTagger(buffer, document, this,
+                    _textDocumentFactoryService) as ITagger<T>);
             return null;
         }
     }
@@ -80,14 +89,25 @@ namespace VSRAD.Package.ProjectSystem.EditorExtensions
 
         private readonly ITextBuffer _buffer;
         private readonly ITextDocument _document;
+        private readonly BreakLineGlyphTaggerProvider _provider;
 
         private readonly List<TagSpan<BreakLineGlyphTag>> _tagSpans = new List<TagSpan<BreakLineGlyphTag>>();
 
-        public BreakLineGlyphTagger(ITextBuffer buffer, ITextDocument document, BreakLineGlyphTaggerProvider provider)
+        public BreakLineGlyphTagger(ITextBuffer buffer, ITextDocument document, BreakLineGlyphTaggerProvider provider,
+            ITextDocumentFactoryService textDocumentFactoryService)
         {
             _buffer = buffer;
             _document = document;
-            provider.DebugExecutionCompleted += DebugExecutionCompleted;
+            _provider = provider;
+            textDocumentFactoryService.TextDocumentDisposed += DocumentDisposed;
+            _provider.DebugExecutionCompleted += DebugExecutionCompleted;
+        }
+
+        // Unsubscribe from DebugExecutionCompleted to prevent possible memory leaks
+        private void DocumentDisposed(object sender, TextDocumentEventArgs e)
+        {
+            if (e.TextDocument == _document)
+                _provider.DebugExecutionCompleted -= DebugExecutionCompleted;
         }
 
         private void DebugExecutionCompleted(object sender, ExecutionCompletedEventArgs e)


### PR DESCRIPTION
Resolves #228 

Steps to reproduce:

1. Insert breakpoint in `BreakGlyphTagger.cs:100`
2. Enable `Memory Usage` in the `Diagnostic Tools`.
3. Open project in the debug instance of VS.
4. Open first document, take the memory snapshot.
5. Open/Close document `N`-times.
6. Take the second memory snapshot.
7. Open diff between snapshots, filter objects by `VSRAD.Package` predicate.
8. Sort by `Count Diff.` column.
9. See the `+N` of `BreakGlyphTagger` objects (screenshot below).

![image](https://user-images.githubusercontent.com/39794543/132879194-a2272b56-01cf-4853-acfc-23466e8263ef.png)

Visual Studio seems to be cashing some of Tagger objects. However, this PR reduces number of Tagger instances from one per any opened document in the session to several instances, which have the roots inside the VS internal structures, according to memory profiler. So, I consider the possible memory leak as fixed.