### PR TITLE
CopyFile step fixes

### DIFF
--- a/VSRAD.Package/Options/Actions.cs
+++ b/VSRAD.Package/Options/Actions.cs
@@ -39,7 +39,7 @@ namespace VSRAD.Package.Options
     [JsonConverter(typeof(StringEnumConverter))]
     public enum ActionIfNotModified
     {
-        Copy, DoNotCopy, Fail
+        DoNotCopy, Copy, Fail
     }
 
     public static class ActionExtensions

--- a/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
@@ -163,8 +163,8 @@
                             <Label Content="If not Modified:" VerticalContentAlignment="Center" Padding="4,0" Height="22" Grid.Row="3" Grid.Column="0"/>
                             <ComboBox VerticalContentAlignment="Center" Height="22" Grid.Row="3" Grid.Column="1"
                                       SelectedIndex="{Binding IfNotModified, Converter={StaticResource IfNotModifiedConverter}, Mode=TwoWay}">
-                                <ComboBoxItem Content="Copy"/>
                                 <ComboBoxItem Content="Do Not Copy"/>
+                                <ComboBoxItem Content="Copy"/>
                                 <ComboBoxItem Content="Fail"/>
                             </ComboBox>
 

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
@@ -26,7 +26,8 @@ namespace VSRAD.Package.ProjectSystem.Profiles
                     foreach (var step in action["Steps"])
                     {
                         if (step["Type"].ToString() != "CopyFile") continue;
-                        ((JObject)step).Add("IfNotModified", (bool)step["CheckTimestamp"] ? "Fail" : "DoNotCopy");
+                        var checkTimestamp = ((JObject)step).ContainsKey("CheckTimestamp") && (bool)step["CheckTimestamp"];
+                        ((JObject)step).Add("IfNotModified", checkTimestamp ? "Fail" : "DoNotCopy");
                     }
                 }
             }

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
@@ -18,6 +18,18 @@ namespace VSRAD.Package.ProjectSystem.Profiles
         public static Dictionary<string, ProfileOptions> ImportObsolete(string path)
         {
             var json = JObject.Parse(File.ReadAllText(path));
+            // convert copy file steps to new format
+            foreach (var profile in (JObject)json["Profiles"])
+            {
+                foreach (var action in profile.Value["Actions"])
+                {
+                    foreach (var step in action["Steps"])
+                    {
+                        if (step["Type"].ToString() != "CopyFile") continue;
+                        ((JObject)step).Add("IfNotModified", (bool)step["CheckTimestamp"] ? "Fail" : "DoNotCopy");
+                    }
+                }
+            }
             return json["Profiles"].ToObject<Dictionary<string, ProfileOptions>>();
         }
 

--- a/VSRAD.PackageTests/ProjectSystem/Profiles/Fixtures/ConfigsTest.vcxproj.conf.json
+++ b/VSRAD.PackageTests/ProjectSystem/Profiles/Fixtures/ConfigsTest.vcxproj.conf.json
@@ -128,7 +128,7 @@
               "WatchesFile": {
                 "Location": "Remote",
                 "Path": "src/dbg/valid_watches",
-                "CheckTimestamp": true
+                "CheckTimestamp": false
               },
               "DispatchParamsFile": {
                 "Location": "Remote",
@@ -309,7 +309,7 @@
               "WatchesFile": {
                 "Location": "Remote",
                 "Path": "src/dbg/valid_watches",
-                "CheckTimestamp": true
+                "CheckTimestamp": false
               },
               "DispatchParamsFile": {
                 "Location": "Remote",

--- a/VSRAD.PackageTests/ProjectSystem/Profiles/ObsoleteFormatProfileImportTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Profiles/ObsoleteFormatProfileImportTests.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
+﻿using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using VSRAD.Package.DebugVisualizer;
 using VSRAD.Package.Options;
-using VSRAD.Package.ProjectSystem.Profiles;
 using Xunit;
 
 namespace VSRAD.PackageTests.ProjectSystem.Profiles
@@ -86,7 +80,7 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             Assert.Equal(new CopyFileStep
             {
                 Direction = FileCopyDirection.LocalToRemote,
-                CheckTimestamp = false,
+                IfNotModified = ActionIfNotModified.DoNotCopy,
                 SourcePath = "$(RadActiveSourceFullPath)",
                 TargetPath = "src/$(RadActiveSourceFile)"
             }, action.Steps[0]);
@@ -112,11 +106,11 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
 
             Assert.Equal(StepEnvironment.Remote, readDebugData.WatchesFile.Location);
             Assert.Equal("src/dbg/valid_watches", readDebugData.WatchesFile.Path);
-            Assert.True(readDebugData.OutputFile.CheckTimestamp);
+            Assert.False(readDebugData.WatchesFile.CheckTimestamp);
 
             Assert.Equal(StepEnvironment.Remote, readDebugData.DispatchParamsFile.Location);
             Assert.Equal("src/dbg/dispatch_params", readDebugData.DispatchParamsFile.Path);
-            Assert.True(readDebugData.OutputFile.CheckTimestamp);
+            Assert.True(readDebugData.DispatchParamsFile.CheckTimestamp);
         }
 
         [Theory]
@@ -136,7 +130,7 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             Assert.Equal(new CopyFileStep
             {
                 Direction = FileCopyDirection.LocalToRemote,
-                CheckTimestamp = false,
+                IfNotModified = ActionIfNotModified.DoNotCopy,
                 SourcePath = "$(RadActiveSourceFullPath)",
                 TargetPath = "$(RadRemoteWorkDir)/src/$(RadActiveSourceFile)"
             }, action.Steps[0]);
@@ -153,7 +147,7 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             Assert.Equal(new CopyFileStep
             {
                 Direction = FileCopyDirection.RemoteToLocal,
-                CheckTimestamp = true,
+                IfNotModified = ActionIfNotModified.Fail,
                 SourcePath = "src/pp/pp_result",
                 TargetPath = "pp_result_local"
             }, action.Steps[2]);
@@ -181,7 +175,7 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             Assert.Equal(new CopyFileStep
             {
                 Direction = FileCopyDirection.LocalToRemote,
-                CheckTimestamp = false,
+                IfNotModified = ActionIfNotModified.DoNotCopy,
                 SourcePath = "$(RadActiveSourceFullPath)",
                 TargetPath = "src/$(RadActiveSourceFile)"
             }, action.Steps[0]);
@@ -198,7 +192,7 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             Assert.Equal(new CopyFileStep
             {
                 Direction = FileCopyDirection.RemoteToLocal,
-                CheckTimestamp = false,
+                IfNotModified = ActionIfNotModified.DoNotCopy,
                 SourcePath = "src/dsm/dsm_src.s",
                 TargetPath = "dsm_src_local.s"
             }, action.Steps[2]);
@@ -225,7 +219,7 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             Assert.Equal(new CopyFileStep
             {
                 Direction = FileCopyDirection.LocalToRemote,
-                CheckTimestamp = false,
+                IfNotModified = ActionIfNotModified.DoNotCopy,
                 SourcePath = "$(RadActiveSourceFullPath)",
                 TargetPath = "src/$(RadActiveSourceFile)"
             }, action.Steps[0]);
@@ -242,7 +236,7 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             Assert.Equal(new CopyFileStep
             {
                 Direction = FileCopyDirection.RemoteToLocal,
-                CheckTimestamp = false,
+                IfNotModified = ActionIfNotModified.DoNotCopy,
                 SourcePath = "src/prf/prf_out",
                 TargetPath = "prf_out_local"
             }, action.Steps[2]);


### PR DESCRIPTION
This PR:

* Adds compatibility between #259 and #254 : now the `IfNotModified` property is correctly handled during the obsolete config import.
* Makes `Do Not Copy` default option for `IfNotModified` property.
* Updates tests from #254 to match #259 configs format.