### PR TITLE
Debug server capabilities check [stable]

### DIFF
--- a/VSRAD.DebugServer/Dispatcher.cs
+++ b/VSRAD.DebugServer/Dispatcher.cs
@@ -17,6 +17,7 @@ namespace VSRAD.DebugServer
             PutDirectoryCommand pd => new PutDirectoryHandler(pd).RunAsync(),
             ListFilesCommand lf => new ListFilesHandler(lf).RunAsync(),
             GetFilesCommand gf => new GetFilesHandler(gf).RunAsync(),
+            GetServerCapabilitiesCommand _ => new GetServerCapabilitiesHandler().RunAsync(),
             Deploy d => new DeployHandler(d, clientLog).RunAsync(),
             ListEnvironmentVariables lev => new ListEnvironmentVariablesHandler(lev).RunAsync(),
             _ => throw new ArgumentException($"Unknown command type {command.GetType()}"),

--- a/VSRAD.DebugServer/Handlers/GetServerCapabilitiesHandler.cs
+++ b/VSRAD.DebugServer/Handlers/GetServerCapabilitiesHandler.cs
@@ -1,0 +1,20 @@
+﻿using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using VSRAD.DebugServer.IPC;
+using VSRAD.DebugServer.IPC.Responses;
+
+namespace VSRAD.DebugServer.Handlers
+{
+    public sealed class GetServerCapabilitiesHandler : IHandler
+    {
+        public Task<IResponse> RunAsync()
+        {
+            var info = new CapabilityInfo(
+                version: typeof(CapabilityInfo).Assembly.GetName().Version.ToString(3),
+                platform: RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ServerPlatform.Windows : ServerPlatform.Linux,
+                capabilities: CapabilityInfo.LatestServerCapabilities
+            );
+            return Task.FromResult<IResponse>(new GetServerCapabilitiesResponse { Info = info });
+        }
+    }
+}

--- a/VSRAD.DebugServer/Handlers/ListFilesHandler.cs
+++ b/VSRAD.DebugServer/Handlers/ListFilesHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using VSRAD.DebugServer.IPC.Commands;
 using VSRAD.DebugServer.IPC.Responses;
 using VSRAD.DebugServer.SharedUtils;
@@ -17,8 +16,7 @@ namespace VSRAD.DebugServer.Handlers
 
         public Task<IResponse> RunAsync()
         {
-            var path = Path.Combine(_command.WorkDir, _command.Path);
-            var files = FileMetadata.GetMetadataForPath(path, _command.IncludeSubdirectories);
+            var files = FileMetadata.GetMetadataForPath(_command.Path, _command.IncludeSubdirectories);
             return Task.FromResult<IResponse>(new ListFilesResponse { Files = files.ToArray() });
         }
     }

--- a/VSRAD.DebugServer/Handlers/PutDirectoryHandler.cs
+++ b/VSRAD.DebugServer/Handlers/PutDirectoryHandler.cs
@@ -18,9 +18,7 @@ namespace VSRAD.DebugServer.Handlers
 
         public async Task<IResponse> RunAsync()
         {
-            var fullPath = Path.Combine(_command.WorkDir, _command.Path);
-
-            if (File.Exists(fullPath))
+            if (File.Exists(_command.Path))
                 return new PutDirectoryResponse { Status = PutDirectoryStatus.TargetPathIsFile };
 
             bool retryOnce = true;
@@ -28,7 +26,7 @@ namespace VSRAD.DebugServer.Handlers
             {
                 try
                 {
-                    PackedFile.UnpackFiles(fullPath, _command.Files, _command.PreserveTimestamps);
+                    PackedFile.UnpackFiles(_command.Path, _command.Files, _command.PreserveTimestamps);
                     return new PutDirectoryResponse { Status = PutDirectoryStatus.Successful };
                 }
                 catch (UnauthorizedAccessException)

--- a/VSRAD.DebugServer/IPC/Capabilities.cs
+++ b/VSRAD.DebugServer/IPC/Capabilities.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace VSRAD.DebugServer.IPC
+{
+#pragma warning disable CA1028 // Using byte for enum storage because it's used for binary serialization
+    public enum ServerCapability : byte
+    {
+        Base = 0
+    }
+
+    public enum ServerPlatform : byte
+    {
+        Windows = 0,
+        Linux = 1
+    }
+#pragma warning restore CA1028
+
+    public sealed class CapabilityInfo
+    {
+        public string Version { get; }
+        public ServerPlatform Platform { get; }
+        public HashSet<ServerCapability> Capabilities { get; }
+
+        public static readonly HashSet<ServerCapability> LatestServerCapabilities = new HashSet<ServerCapability>(new[]
+        {
+            ServerCapability.Base
+        });
+
+        public CapabilityInfo(string version, ServerPlatform platform, HashSet<ServerCapability> capabilities)
+        {
+            Version = version;
+            Platform = platform;
+            Capabilities = capabilities;
+        }
+
+        public bool IsUpToDate()
+        {
+            return Capabilities.SetEquals(LatestServerCapabilities);
+        }
+
+        public override string ToString() => string.Join(Environment.NewLine, new[]
+        {
+            $"Version = {Version}",
+            $"Platform = {Platform}",
+            $"Capabilities = {string.Join(", ", Capabilities)}"
+        });
+
+        public static CapabilityInfo Deserialize(IPCReader reader)
+        {
+            var version = reader.ReadString();
+            var platform = (ServerPlatform)reader.ReadByte();
+            var capabilityCount = reader.Read7BitEncodedInt();
+            var capabilities = new HashSet<ServerCapability>();
+            for (int i = 0; i < capabilityCount; ++i)
+                capabilities.Add((ServerCapability)reader.ReadByte());
+            return new CapabilityInfo(version, platform, capabilities);
+        }
+
+        public void Serialize(IPCWriter writer)
+        {
+            writer.Write(Version);
+            writer.Write((byte)Platform);
+            writer.Write7BitEncodedInt(Capabilities.Count);
+            foreach (var cap in Capabilities)
+                writer.Write((byte)cap);
+        }
+    }
+}

--- a/VSRAD.DebugServer/IPC/Commands.cs
+++ b/VSRAD.DebugServer/IPC/Commands.cs
@@ -228,8 +228,6 @@ namespace VSRAD.DebugServer.IPC.Commands
 
         public string Path { get; set; }
 
-        public string WorkDir { get; set; }
-
         public bool PreserveTimestamps { get; set; }
 
         public override string ToString() => string.Join(Environment.NewLine, new[]
@@ -237,7 +235,6 @@ namespace VSRAD.DebugServer.IPC.Commands
             "PutDirectoryCommand",
             $"Files = <{Files.Length} files>",
             $"Path = {Path}",
-            $"WorkDir = {WorkDir}",
             $"PreserveTimestamps = {PreserveTimestamps}"
         });
 
@@ -245,7 +242,6 @@ namespace VSRAD.DebugServer.IPC.Commands
         {
             Files = reader.ReadLengthPrefixedFileArray(),
             Path = reader.ReadString(),
-            WorkDir = reader.ReadString(),
             PreserveTimestamps = reader.ReadBoolean()
         };
 
@@ -253,7 +249,6 @@ namespace VSRAD.DebugServer.IPC.Commands
         {
             writer.WriteLengthPrefixedFileArray(Files);
             writer.Write(Path);
-            writer.Write(WorkDir);
             writer.Write(PreserveTimestamps);
         }
     }
@@ -262,28 +257,23 @@ namespace VSRAD.DebugServer.IPC.Commands
     {
         public string Path { get; set; }
 
-        public string WorkDir { get; set; }
-
         public bool IncludeSubdirectories { get; set; }
 
         public override string ToString() => string.Join(Environment.NewLine, new[] {
             "ListFilesCommand",
             $"Path = {Path}",
-            $"WorkDir = {WorkDir}",
             $"IncludeSubdirectories = {IncludeSubdirectories}"
         });
 
         public static ListFilesCommand Deserialize(IPCReader reader) => new ListFilesCommand
         {
             Path = reader.ReadString(),
-            WorkDir = reader.ReadString(),
             IncludeSubdirectories = reader.ReadBoolean()
         };
 
         public void Serialize(IPCWriter writer)
         {
             writer.Write(Path);
-            writer.Write(WorkDir);
             writer.Write(IncludeSubdirectories);
         }
     }
@@ -292,29 +282,29 @@ namespace VSRAD.DebugServer.IPC.Commands
     {
         public bool UseCompression { get; set; }
 
-        public string[] Paths { get; set; }
+        public string RootPath { get; set; }
 
-        public string[] RootPath { get; set; }
+        public string[] Paths { get; set; }
 
         public override string ToString() => string.Join(Environment.NewLine, new[] {
             "GetFilesCommand",
             $"UseCompression = {UseCompression}",
-            $"Paths = {string.Join(", ", Paths)}",
-            $"WorkDir = {string.Join(", ", RootPath)}"
+            $"RootPath = {RootPath}",
+            $"Paths = {string.Join(", ", Paths)}"
         });
 
         public static GetFilesCommand Deserialize(IPCReader reader) => new GetFilesCommand
         {
             UseCompression = reader.ReadBoolean(),
-            Paths = reader.ReadLengthPrefixedStringArray(),
-            RootPath = reader.ReadLengthPrefixedStringArray()
+            RootPath = reader.ReadString(),
+            Paths = reader.ReadLengthPrefixedStringArray()
         };
 
         public void Serialize(IPCWriter writer)
         {
             writer.Write(UseCompression);
+            writer.Write(RootPath);
             writer.WriteLengthPrefixedArray(Paths);
-            writer.WriteLengthPrefixedArray(RootPath);
         }
     }
 

--- a/VSRAD.DebugServer/IPC/Commands.cs
+++ b/VSRAD.DebugServer/IPC/Commands.cs
@@ -17,6 +17,7 @@ namespace VSRAD.DebugServer.IPC.Commands
         PutDirectory = 6,
         ListFiles = 7,
         GetFiles = 8,
+        GetServerCapabilities = 9,
 
         CompressedCommand = 0xFF
     }
@@ -46,6 +47,7 @@ namespace VSRAD.DebugServer.IPC.Commands
                 case CommandType.PutDirectory: return PutDirectoryCommand.Deserialize(reader);
                 case CommandType.ListFiles: return ListFilesCommand.Deserialize(reader);
                 case CommandType.GetFiles: return GetFilesCommand.Deserialize(reader);
+                case CommandType.GetServerCapabilities: return GetServerCapabilitiesCommand.Deserialize(reader);
 
                 case CommandType.CompressedCommand: return CompressedCommand.Deserialize(reader);
             }
@@ -66,6 +68,7 @@ namespace VSRAD.DebugServer.IPC.Commands
                 case PutDirectoryCommand _: type = CommandType.PutDirectory; break;
                 case ListFilesCommand _: type = CommandType.ListFiles; break;
                 case GetFilesCommand _: type = CommandType.GetFiles; break;
+                case GetServerCapabilitiesCommand _: type = CommandType.GetServerCapabilities; break;
 
                 case CompressedCommand _: type = CommandType.CompressedCommand; break;
                 default: throw new ArgumentException($"Unable to serialize {command.GetType()}");
@@ -313,6 +316,15 @@ namespace VSRAD.DebugServer.IPC.Commands
             writer.WriteLengthPrefixedArray(Paths);
             writer.WriteLengthPrefixedArray(RootPath);
         }
+    }
+
+    public sealed class GetServerCapabilitiesCommand : ICommand
+    {
+        public override string ToString() => "GetServerCapabilitiesCommand";
+
+        public static GetServerCapabilitiesCommand Deserialize(IPCReader _) => new GetServerCapabilitiesCommand();
+
+        public void Serialize(IPCWriter _) { }
     }
 
     public sealed class CompressedCommand : ICommand

--- a/VSRAD.DebugServer/IPC/Commands.cs
+++ b/VSRAD.DebugServer/IPC/Commands.cs
@@ -197,7 +197,7 @@ namespace VSRAD.DebugServer.IPC.Commands
 
         public string Path { get; set; }
 
-        public string WorkDir { get; set; }
+        public string WorkDir { get; set; } = "";
 
         public override string ToString() => string.Join(Environment.NewLine, new[]
         {

--- a/VSRAD.DebugServer/IPC/Responses.cs
+++ b/VSRAD.DebugServer/IPC/Responses.cs
@@ -17,6 +17,7 @@ namespace VSRAD.DebugServer.IPC.Responses
         PutDirectory = 5,
         ListFiles = 6,
         GetFiles = 7,
+        GetServerCapabilities = 8,
 
         CompressedResponse = 0xFF
     }
@@ -42,6 +43,7 @@ namespace VSRAD.DebugServer.IPC.Responses
                 case ResponseType.PutDirectory: return PutDirectoryResponse.Deserialize(reader);
                 case ResponseType.ListFiles: return ListFilesResponse.Deserialize(reader);
                 case ResponseType.GetFiles: return GetFilesResponse.Deserialize(reader);
+                case ResponseType.GetServerCapabilities: return GetServerCapabilitiesResponse.Deserialize(reader);
 
                 case ResponseType.CompressedResponse: return CompressedResponse.Deserialize(reader);
             }
@@ -61,6 +63,7 @@ namespace VSRAD.DebugServer.IPC.Responses
                 case PutDirectoryResponse _: type = ResponseType.PutDirectory; break;
                 case ListFilesResponse _: type = ResponseType.ListFiles; break;
                 case GetFilesResponse _: type = ResponseType.GetFiles; break;
+                case GetServerCapabilitiesResponse _: type = ResponseType.GetServerCapabilities; break;
 
                 case CompressedResponse _: type = ResponseType.CompressedResponse; break;
                 default: throw new ArgumentException($"Unable to serialize {response.GetType()}");
@@ -288,6 +291,24 @@ namespace VSRAD.DebugServer.IPC.Responses
 
         public void Serialize(IPCWriter writer) =>
             writer.WriteLengthPrefixedDict(Variables);
+    }
+
+    public sealed class GetServerCapabilitiesResponse : IResponse
+    {
+        public CapabilityInfo Info { get; set; }
+
+        public override string ToString() => string.Join(Environment.NewLine, new[]
+        {
+            "GetServerCapabilitiesResponse",
+            Info.ToString()
+        });
+
+        public static GetServerCapabilitiesResponse Deserialize(IPCReader reader) => new GetServerCapabilitiesResponse
+        {
+            Info = CapabilityInfo.Deserialize(reader)
+        };
+
+        public void Serialize(IPCWriter writer) => Info.Serialize(writer);
     }
 
     public sealed class CompressedResponse : IResponse

--- a/VSRAD.DebugServerTests/Handlers/GetFilesHandlerTest.cs
+++ b/VSRAD.DebugServerTests/Handlers/GetFilesHandlerTest.cs
@@ -29,7 +29,7 @@ namespace VSRAD.DebugServerTests.Handlers
             {
                 UseCompression = false,
                 Paths = new[] { "k/s", "h/b/w", "empty/" },
-                RootPath = new[] { tmpPath }
+                RootPath = tmpPath
             });
 
             Assert.Equal(GetFilesStatus.Successful, response.Status);
@@ -61,7 +61,7 @@ namespace VSRAD.DebugServerTests.Handlers
             {
                 UseCompression = true,
                 Paths = new[] { "test" },
-                RootPath = new[] { tmpPath }
+                RootPath = tmpPath
             });
             Assert.Equal(GetFilesStatus.FileNotFound, response.Status);
 
@@ -72,7 +72,7 @@ namespace VSRAD.DebugServerTests.Handlers
             {
                 UseCompression = true,
                 Paths = new[] { "test" },
-                RootPath = new[] { tmpPath }
+                RootPath = tmpPath
             });
             Assert.Equal(GetFilesStatus.FileNotFound, response.Status);
         }

--- a/VSRAD.DebugServerTests/Handlers/ListFilesHandlerTest.cs
+++ b/VSRAD.DebugServerTests/Handlers/ListFilesHandlerTest.cs
@@ -19,8 +19,7 @@ namespace VSRAD.DebugServerTests.Handlers
 
             var response = await Helper.DispatchCommandAsync<ListFilesCommand, ListFilesResponse>(new ListFilesCommand
             {
-                Path = Path.GetFileName(tmpPath),
-                WorkDir = Path.GetDirectoryName(tmpPath),
+                Path = tmpPath,
                 IncludeSubdirectories = true
             });
 
@@ -53,7 +52,6 @@ namespace VSRAD.DebugServerTests.Handlers
             var response = await Helper.DispatchCommandAsync<ListFilesCommand, ListFilesResponse>(new ListFilesCommand
             {
                 Path = tmpPath,
-                WorkDir = "",
                 IncludeSubdirectories = true
             });
 
@@ -93,7 +91,6 @@ namespace VSRAD.DebugServerTests.Handlers
             var response = await Helper.DispatchCommandAsync<ListFilesCommand, ListFilesResponse>(new ListFilesCommand
             {
                 Path = tmpPath + "\\",
-                WorkDir = "",
                 IncludeSubdirectories = false
             });
 
@@ -112,8 +109,7 @@ namespace VSRAD.DebugServerTests.Handlers
 
             var response = await Helper.DispatchCommandAsync<ListFilesCommand, ListFilesResponse>(new ListFilesCommand
             {
-                Path = Path.GetFileName(tmpPath),
-                WorkDir = Path.GetDirectoryName(tmpPath),
+                Path = tmpPath,
                 IncludeSubdirectories = true
             });
 

--- a/VSRAD.DebugServerTests/Handlers/PutDirectoryHandlerTest.cs
+++ b/VSRAD.DebugServerTests/Handlers/PutDirectoryHandlerTest.cs
@@ -26,8 +26,7 @@ namespace VSRAD.DebugServerTests.Handlers
             var response = await Helper.DispatchCommandAsync<PutDirectoryCommand, PutDirectoryResponse>(new PutDirectoryCommand
             {
                 Files = files,
-                Path = Path.GetFileName(tmpPath),
-                WorkDir = Path.GetDirectoryName(tmpPath),
+                Path = tmpPath,
                 PreserveTimestamps = true
             });
 
@@ -60,8 +59,7 @@ namespace VSRAD.DebugServerTests.Handlers
             var response = await Helper.DispatchCommandAsync<PutDirectoryCommand, PutDirectoryResponse>(new PutDirectoryCommand
             {
                 Files = Array.Empty<PackedFile>(),
-                Path = Path.GetFileName(tmpPath),
-                WorkDir = Path.GetDirectoryName(tmpPath)
+                Path = tmpPath
             });
 
             Assert.Equal(PutDirectoryStatus.TargetPathIsFile, response.Status);
@@ -83,8 +81,7 @@ namespace VSRAD.DebugServerTests.Handlers
             var response = await Helper.DispatchCommandAsync<PutDirectoryCommand, PutDirectoryResponse>(new PutDirectoryCommand
             {
                 Files = files,
-                Path = tmpPath,
-                WorkDir = ""
+                Path = tmpPath
             });
 
             Assert.Equal(PutDirectoryStatus.PermissionDenied, response.Status);

--- a/VSRAD.Package/Errors.cs
+++ b/VSRAD.Package/Errors.cs
@@ -26,6 +26,11 @@ namespace VSRAD.Package
         public static bool operator !=(Error left, Error right) => !(left == right);
     }
 
+    public class UserException : Exception
+    {
+        public UserException(string message) : base(message) { }
+    }
+
     public static class Errors
     {
         public static void Show(Error error) =>
@@ -45,7 +50,10 @@ namespace VSRAD.Package
             // Cancelled operations are usually triggered by the user or are accompanied by a more descriptive message.
             if (e is OperationCanceledException) return;
 
-            ShowCritical(e.Message + "\r\n\r\n" + e.StackTrace, title: "An unexpected error occurred in RAD Debugger");
+            if (typeof(UserException).IsAssignableFrom(e.GetType())) // Caused by user input/environment, intended to bubble up
+                ShowCritical(e.Message);
+            else // Caused by a bug: make diagnosing it easier by printing the stacktrace
+                ShowCritical(e.Message + "\r\n\r\n" + e.StackTrace, title: "An unexpected error occurred in RAD Debugger");
         }
 
         public static void RunAsyncWithErrorHandling(this JoinableTaskFactory taskFactory, Func<Task> method, Action exceptionCallbackOnMainThread = null) =>

--- a/VSRAD.Package/Options/Actions.cs
+++ b/VSRAD.Package/Options/Actions.cs
@@ -4,8 +4,10 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using VSRAD.DebugServer.IPC;
 using VSRAD.Package.ProjectSystem.Macros;
 using VSRAD.Package.Utils;
 using static VSRAD.Package.Options.ActionExtensions;
@@ -19,9 +21,63 @@ namespace VSRAD.Package.Options
     // it satisfies the contract (the same hash code is returned for objects that are equal)
     // and prevents errors when an object is mutated (e.g. in profile editor's WPF controls, https://stackoverflow.com/q/15365905)
 
+    public sealed class ActionEvaluationEnvironment
+    {
+        public string LocalWorkDir { get; }
+        public string RemoteWorkDir { get; }
+        public bool RunActionsLocally { get; }
+        public CapabilityInfo ServerCapabilities { get; }
+        public IEnumerable<ActionProfileOptions> Actions { get; }
+
+        public ActionEvaluationEnvironment(string localWorkDir, string remoteWorkDir, bool runActionsLocally, CapabilityInfo serverCapabilities, IEnumerable<ActionProfileOptions> actions)
+        {
+            LocalWorkDir = localWorkDir;
+            RemoteWorkDir = remoteWorkDir;
+            RunActionsLocally = runActionsLocally;
+            ServerCapabilities = serverCapabilities;
+            Actions = actions;
+        }
+
+        public bool TryResolveFullPath(string path, StepEnvironment location, out string fullPath, out string error)
+        {
+            try
+            {
+                if (location == StepEnvironment.Remote)
+                {
+                    if (ServerCapabilities.Platform == ServerPlatform.Windows)
+                    {
+                        fullPath = Path.Combine(RemoteWorkDir, path);
+                    }
+                    else
+                    {
+                        if (RemoteWorkDir.Length == 0 || path.StartsWith('/'))
+                            fullPath = path;
+                        else if (RemoteWorkDir.EndsWith('/'))
+                            fullPath = RemoteWorkDir + path;
+                        else
+                            fullPath = RemoteWorkDir + '/' + path;
+                    }
+                }
+                else
+                {
+                    fullPath = Path.Combine(LocalWorkDir, path);
+                }
+                error = "";
+                return true;
+            }
+            catch (ArgumentException e) when (e.Message == "Illegal characters in path.")
+            {
+                var workDir = location == StepEnvironment.Remote ? RemoteWorkDir : LocalWorkDir;
+                error = $"Path contains illegal characters: \"{path}\"\r\nWorking directory: \"{workDir}\"";
+                fullPath = null;
+                return false;
+            }
+        }
+    }
+
     public interface IActionStep : INotifyPropertyChanged
     {
-        Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ProfileOptions profile, string sourceAction);
+        Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ActionEvaluationEnvironment env, string sourceAction);
     }
 
     [JsonConverter(typeof(StringEnumConverter))]
@@ -97,7 +153,7 @@ namespace VSRAD.Package.Options
 
         public override int GetHashCode() => 1;
 
-        public async Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ProfileOptions profile, string sourceAction)
+        public async Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ActionEvaluationEnvironment env, string sourceAction)
         {
             if (string.IsNullOrWhiteSpace(SourcePath))
                 return EvaluationError(sourceAction, "Copy File", "No source path specified");
@@ -116,7 +172,14 @@ namespace VSRAD.Package.Options
             if (string.IsNullOrWhiteSpace(evaluatedTargetPath))
                 return EvaluationError(sourceAction, "Copy File", $"The specified target path (\"{TargetPath}\") evaluates to an empty string");
 
-            var direction = profile.General.RunActionsLocally ? FileCopyDirection.LocalToLocal : Direction;
+            var direction = env.RunActionsLocally ? FileCopyDirection.LocalToLocal : Direction;
+
+            var sourceLocation = direction == FileCopyDirection.RemoteToLocal ? StepEnvironment.Remote : StepEnvironment.Local;
+            var targetLocation = direction == FileCopyDirection.LocalToRemote ? StepEnvironment.Remote : StepEnvironment.Local;
+            if (!env.TryResolveFullPath(evaluatedSourcePath, sourceLocation, out evaluatedSourcePath, out var errorMessage))
+                return EvaluationError(sourceAction, "Copy File", errorMessage);
+            if (!env.TryResolveFullPath(evaluatedTargetPath, targetLocation, out evaluatedTargetPath, out errorMessage))
+                return EvaluationError(sourceAction, "Copy File", errorMessage);
 
             return new CopyFileStep
             {
@@ -175,7 +238,7 @@ namespace VSRAD.Package.Options
 
         public override int GetHashCode() => 3;
 
-        public async Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ProfileOptions profile, string sourceAction)
+        public async Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ActionEvaluationEnvironment env, string sourceAction)
         {
             if (string.IsNullOrWhiteSpace(Executable))
                 return EvaluationError(sourceAction, "Execute", "No executable specified");
@@ -193,7 +256,15 @@ namespace VSRAD.Package.Options
             if (string.IsNullOrWhiteSpace(evaluatedExecutable))
                 return EvaluationError(sourceAction, "Execute", $"The specified executable (\"{Executable}\") evaluates to an empty string");
 
-            var environment = profile.General.RunActionsLocally ? StepEnvironment.Local : Environment;
+            var environment = env.RunActionsLocally ? StepEnvironment.Local : Environment;
+
+            if (string.IsNullOrWhiteSpace(evaluatedWorkdir))
+            {
+                if (environment == StepEnvironment.Remote)
+                    evaluatedWorkdir = env.RemoteWorkDir;
+                else
+                    evaluatedWorkdir = env.LocalWorkDir;
+            }
 
             return new ExecuteStep
             {
@@ -226,7 +297,7 @@ namespace VSRAD.Package.Options
 
         public override int GetHashCode() => 5;
 
-        public async Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ProfileOptions profile, string sourceAction)
+        public async Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ActionEvaluationEnvironment env, string sourceAction)
         {
             if (string.IsNullOrWhiteSpace(Path))
                 return EvaluationError(sourceAction, "Open in Editor", "No file path specified");
@@ -264,13 +335,13 @@ namespace VSRAD.Package.Options
 
         public override int GetHashCode() => 7;
 
-        public Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ProfileOptions profile, string sourceAction)
+        public Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ActionEvaluationEnvironment env, string sourceAction)
         {
             var traversed = new List<string>() { sourceAction };
-            return EvaluateAsync(evaluator, profile, traversed);
+            return EvaluateAsync(evaluator, env, traversed);
         }
 
-        public async Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ProfileOptions profile, List<string> actionsTraversed)
+        public async Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ActionEvaluationEnvironment env, List<string> actionsTraversed)
         {
             if (string.IsNullOrWhiteSpace(Name))
             {
@@ -285,7 +356,7 @@ namespace VSRAD.Package.Options
                 return EvaluationError(actionsTraversed[0], "Run Action", "Encountered a circular dependency: " + t);
             }
 
-            var action = profile.Actions.FirstOrDefault(a => a.Name == Name);
+            var action = env.Actions.FirstOrDefault(a => a.Name == Name);
             if (action == null)
             {
                 var message = "Action \"" + Name + "\" is not found";
@@ -302,13 +373,13 @@ namespace VSRAD.Package.Options
                 IActionStep evaluated;
                 if (step is RunActionStep runAction)
                 {
-                    var evalResult = await runAction.EvaluateAsync(evaluator, profile, actionsTraversed);
+                    var evalResult = await runAction.EvaluateAsync(evaluator, env, actionsTraversed);
                     if (!evalResult.TryGetResult(out evaluated, out var error))
                         return error;
                 }
                 else
                 {
-                    var evalResult = await step.EvaluateAsync(evaluator, profile, actionsTraversed[0]);
+                    var evalResult = await step.EvaluateAsync(evaluator, env, actionsTraversed[0]);
                     if (!evalResult.TryGetResult(out evaluated, out _))
                     {
                         var message = "Action \"" + Name + "\" is misconfigured";
@@ -355,13 +426,11 @@ namespace VSRAD.Package.Options
             OutputOffset = outputOffset;
         }
 
-        public async Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ProfileOptions profile, string sourceAction)
+        public async Task<Result<IActionStep>> EvaluateAsync(IMacroEvaluator evaluator, ActionEvaluationEnvironment env, string sourceAction)
         {
             var outputResult = await OutputFile.EvaluateAsync(evaluator);
             if (!outputResult.TryGetResult(out var outputFile, out var error))
                 return EvaluationError(sourceAction, "Read Debug Data", error.Message);
-            if (string.IsNullOrEmpty(outputFile.Path))
-                return EvaluationError(sourceAction, "Read Debug Data", "Debug data path is not specified");
 
             var watchesResult = await WatchesFile.EvaluateAsync(evaluator);
             if (!watchesResult.TryGetResult(out var watchesFile, out error))
@@ -371,11 +440,34 @@ namespace VSRAD.Package.Options
             if (!dispatchParamsResult.TryGetResult(out var dispatchParamsFile, out error))
                 return EvaluationError(sourceAction, "Read Debug Data", error.Message);
 
-            if (profile.General.RunActionsLocally)
+            if (env.RunActionsLocally)
             {
                 outputFile.Location = StepEnvironment.Local;
                 watchesFile.Location = StepEnvironment.Local;
                 dispatchParamsFile.Location = StepEnvironment.Local;
+            }
+
+            if (string.IsNullOrEmpty(outputFile.Path))
+            {
+                return EvaluationError(sourceAction, "Read Debug Data", "Debug data path is not specified");
+            }
+            else
+            {
+                if (!env.TryResolveFullPath(outputFile.Path, outputFile.Location, out var outputFullPath, out var errorMessage))
+                    return EvaluationError(sourceAction, "Read Debug Data", errorMessage);
+                outputFile.Path = outputFullPath;
+            }
+            if (!string.IsNullOrEmpty(watchesFile.Path))
+            {
+                if (!env.TryResolveFullPath(watchesFile.Path, watchesFile.Location, out var watchesFullPath, out var errorMessage))
+                    return EvaluationError(sourceAction, "Read Debug Data", errorMessage);
+                watchesFile.Path = watchesFullPath;
+            }
+            if (!string.IsNullOrEmpty(dispatchParamsFile.Path))
+            {
+                if (!env.TryResolveFullPath(dispatchParamsFile.Path, dispatchParamsFile.Location, out var dispatchParamsFullPath, out var errorMessage))
+                    return EvaluationError(sourceAction, "Read Debug Data", errorMessage);
+                dispatchParamsFile.Path = dispatchParamsFullPath;
             }
 
             return new ReadDebugDataStep(outputOffset: OutputOffset, binaryOutput: BinaryOutput,

--- a/VSRAD.Package/Options/ProfileOptions.cs
+++ b/VSRAD.Package/Options/ProfileOptions.cs
@@ -76,12 +76,12 @@ namespace VSRAD.Package.Options
         [JsonProperty(ItemConverterType = typeof(ActionStepJsonConverter))]
         public ObservableCollection<IActionStep> Steps { get; } = new ObservableCollection<IActionStep>();
 
-        public async Task<Result<ActionProfileOptions>> EvaluateAsync(IMacroEvaluator evaluator, ProfileOptions profile)
+        public async Task<Result<ActionProfileOptions>> EvaluateAsync(IMacroEvaluator evaluator, ActionEvaluationEnvironment env)
         {
             var evaluated = new ActionProfileOptions { Name = Name };
             foreach (var step in Steps)
             {
-                if ((await step.EvaluateAsync(evaluator, profile, Name)).TryGetResult(out var evaluatedStep, out var error))
+                if ((await step.EvaluateAsync(evaluator, env, Name)).TryGetResult(out var evaluatedStep, out var error))
                     evaluated.Steps.Add(evaluatedStep);
                 else
                     return error;
@@ -145,30 +145,5 @@ namespace VSRAD.Package.Options
         public override int GetHashCode() => (RemoteMachine, Port).GetHashCode();
         public static bool operator ==(ServerConnectionOptions left, ServerConnectionOptions right) => left.Equals(right);
         public static bool operator !=(ServerConnectionOptions left, ServerConnectionOptions right) => !(left == right);
-    }
-
-    public readonly struct ActionEnvironment : IEquatable<ActionEnvironment>
-    {
-        public string LocalWorkDir { get; }
-        public string RemoteWorkDir { get; }
-        public ReadOnlyCollection<string> Watches { get; }
-
-        public ActionEnvironment(string localWorkDir, string remoteWorkDir) :
-            this(localWorkDir, remoteWorkDir, new ReadOnlyCollection<string>(Array.Empty<string>()))
-        {
-        }
-
-        public ActionEnvironment(string localWorkDir, string remoteWorkDir, ReadOnlyCollection<string> watches)
-        {
-            LocalWorkDir = localWorkDir;
-            RemoteWorkDir = remoteWorkDir;
-            Watches = watches;
-        }
-
-        public bool Equals(ActionEnvironment o) => LocalWorkDir == o.LocalWorkDir && RemoteWorkDir == o.RemoteWorkDir;
-        public override bool Equals(object o) => o is ActionEnvironment env && Equals(env);
-        public override int GetHashCode() => (LocalWorkDir, RemoteWorkDir).GetHashCode();
-        public static bool operator ==(ActionEnvironment left, ActionEnvironment right) => left.Equals(right);
-        public static bool operator !=(ActionEnvironment left, ActionEnvironment right) => !(left == right);
     }
 }

--- a/VSRAD.Package/ProjectSystem/ActionLauncher.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLauncher.cs
@@ -106,6 +106,9 @@ namespace VSRAD.Package.ProjectSystem
                 var remoteEnvironment = _project.Options.Profile.General.RunActionsLocally
                     ? null
                     : new AsyncLazy<IReadOnlyDictionary<string, string>>(_channel.GetRemoteEnvironmentAsync, VSPackage.TaskFactory);
+                var serverCapabilities = _project.Options.Profile.General.RunActionsLocally
+                    ? null
+                    : await _channel.GetServerCapabilityInfoAsync();
 
                 var evaluator = new MacroEvaluator(projectProperties, transients, remoteEnvironment, _project.Options.DebuggerOptions, _project.Options.Profile);
 
@@ -114,7 +117,7 @@ namespace VSRAD.Package.ProjectSystem
                     return new ActionExecution(evalError);
 
                 var actionEvalEnv = new ActionEvaluationEnvironment(general.LocalWorkDir, general.RemoteWorkDir, general.RunActionsLocally,
-                    _channel.ServerCapabilities, _project.Options.Profile.Actions);
+                    serverCapabilities, _project.Options.Profile.Actions);
                 var actionEvalResult = await action.EvaluateAsync(evaluator, actionEvalEnv);
                 if (!actionEvalResult.TryGetResult(out action, out evalError))
                     return new ActionExecution(evalError);

--- a/VSRAD.Package/ProjectSystem/ActionLauncher.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLauncher.cs
@@ -125,7 +125,7 @@ namespace VSRAD.Package.ProjectSystem
                 await VSPackage.TaskFactory.SwitchToMainThreadAsync();
                 _projectSources.SaveProjectState();
 
-                var runner = new ActionRunner(_channel, _serviceProvider, transients.Watches);
+                var runner = new ActionRunner(_channel, _serviceProvider, transients.Watches, _project);
                 var runResult = await runner.RunAsync(action.Name, action.Steps, _project.Options.Profile.General.ContinueActionExecOnError).ConfigureAwait(false);
                 var actionError = await _actionLogger.LogActionWithWarningsAsync(runResult).ConfigureAwait(false);
                 return new ActionExecution(actionError, transients, runResult);

--- a/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
+++ b/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
@@ -124,7 +124,7 @@ namespace VSRAD.Package.ProjectSystem
             Assumes.Present(textManager);
 
             textManager.GetActiveView2(0, null, (uint)_VIEWFRAMETYPE.vftCodeWindow, out var activeView);
-            return activeView ?? throw new InvalidOperationException(NoFilesOpenError);
+            return activeView ?? throw new UserException(NoFilesOpenError);
         }
 
         private static IWpfTextView GetTextViewFromVsTextView(IVsTextView view)

--- a/VSRAD.Package/ProjectSystem/Macros/DirtyProfileMacroEditor.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/DirtyProfileMacroEditor.cs
@@ -35,7 +35,10 @@ namespace VSRAD.Package.ProjectSystem.Macros
             var transients = GetMacroTransients();
             var evaluator = new MacroEvaluator(ProjectProperties, transients, RemoteEnvironment, _project.Options.DebuggerOptions, _dirtyProfile);
 
-            return await step.EvaluateAsync(evaluator, _dirtyProfile, sourceAction);
+            var actionEvalEnv = new ActionEvaluationEnvironment("", "", _dirtyProfile.General.RunActionsLocally,
+                new DebugServer.IPC.CapabilityInfo(default, default, default), _dirtyProfile.Actions);
+
+            return await step.EvaluateAsync(evaluator, actionEvalEnv, sourceAction);
         }
 
         public async Task EditObjectPropertyAsync(object target, string propertyName)

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
@@ -102,8 +102,6 @@ namespace VSRAD.Package.ProjectSystem.Macros
         Task<Result<string>> EvaluateAsync(string src);
     }
 
-    public sealed class MacroEvaluationException : Exception { public MacroEvaluationException(string message) : base(message) { } }
-
     public sealed class MacroEvaluator : IMacroEvaluator
     {
         private static readonly Regex _macroRegex = new Regex(@"\$(ENVR?)?\(([^()]+)\)", RegexOptions.Compiled);

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -77,7 +77,7 @@ namespace VSRAD.Package.Server
             // List all source files
             if (step.Direction == FileCopyDirection.RemoteToLocal)
             {
-                var command = new ListFilesCommand { Path = step.SourcePath };
+                var command = new ListFilesCommand { Path = step.SourcePath, IncludeSubdirectories = step.IncludeSubdirectories };
                 var response = await _channel.SendWithReplyAsync<ListFilesResponse>(command);
                 sourceFiles = response.Files;
             }
@@ -93,7 +93,7 @@ namespace VSRAD.Package.Server
             // List all target files
             if (step.Direction == FileCopyDirection.LocalToRemote)
             {
-                var command = new ListFilesCommand { Path = step.TargetPath };
+                var command = new ListFilesCommand { Path = step.TargetPath, IncludeSubdirectories = step.IncludeSubdirectories };
                 var response = await _channel.SendWithReplyAsync<ListFilesResponse>(command);
                 targetFiles = response.Files;
             }

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -427,7 +427,7 @@ namespace VSRAD.Package.Server
             }
         }
 
-        private bool ReadLocalFile(string fullPath, out byte[] data, out string error, int byteOffset = 0)
+        private static bool ReadLocalFile(string fullPath, out byte[] data, out string error, int byteOffset = 0)
         {
             try
             {
@@ -490,7 +490,7 @@ namespace VSRAD.Package.Server
             }
         }
 
-        private DateTime GetLocalFileLastWriteTimeUtc(string path)
+        private static DateTime GetLocalFileLastWriteTimeUtc(string path)
         {
             try
             {
@@ -502,7 +502,7 @@ namespace VSRAD.Package.Server
             }
         }
 
-        private bool TryGetLocalMetadata(string localPath, bool includeSubdirectories, out IList<FileMetadata> metadata, out string error)
+        private static bool TryGetLocalMetadata(string localPath, bool includeSubdirectories, out IList<FileMetadata> metadata, out string error)
         {
             try
             {

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -21,12 +21,14 @@ namespace VSRAD.Package.Server
         private readonly SVsServiceProvider _serviceProvider;
         private readonly Dictionary<string, DateTime> _initialTimestamps = new Dictionary<string, DateTime>();
         private readonly ReadOnlyCollection<string> _debugWatches;
+        private readonly IProject _project;
 
-        public ActionRunner(ICommunicationChannel channel, SVsServiceProvider serviceProvider, ReadOnlyCollection<string> debugWatches)
+        public ActionRunner(ICommunicationChannel channel, SVsServiceProvider serviceProvider, ReadOnlyCollection<string> debugWatches, IProject project)
         {
             _channel = channel;
             _serviceProvider = serviceProvider;
             _debugWatches = debugWatches;
+            _project = project;
         }
 
         public DateTime GetInitialFileTimestamp(string file) =>

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -19,15 +20,13 @@ namespace VSRAD.Package.Server
         private readonly ICommunicationChannel _channel;
         private readonly SVsServiceProvider _serviceProvider;
         private readonly Dictionary<string, DateTime> _initialTimestamps = new Dictionary<string, DateTime>();
-        private readonly ActionEnvironment _environment;
-        private readonly IProject _project;
+        private readonly ReadOnlyCollection<string> _debugWatches;
 
-        public ActionRunner(ICommunicationChannel channel, SVsServiceProvider serviceProvider, ActionEnvironment environment, IProject project)
+        public ActionRunner(ICommunicationChannel channel, SVsServiceProvider serviceProvider, ReadOnlyCollection<string> debugWatches)
         {
             _channel = channel;
             _serviceProvider = serviceProvider;
-            _environment = environment;
-            _project = project;
+            _debugWatches = debugWatches;
         }
 
         public DateTime GetInitialFileTimestamp(string file) =>
@@ -75,37 +74,35 @@ namespace VSRAD.Package.Server
         private async Task<StepResult> DoCopyFileAsync(CopyFileStep step)
         {
             IList<FileMetadata> sourceFiles, targetFiles;
+            // List all source files
             if (step.Direction == FileCopyDirection.RemoteToLocal)
             {
-                var command = new ListFilesCommand { Path = step.SourcePath, WorkDir = _environment.RemoteWorkDir,
-                    IncludeSubdirectories = step.IncludeSubdirectories };
+                var command = new ListFilesCommand { Path = step.SourcePath };
                 var response = await _channel.SendWithReplyAsync<ListFilesResponse>(command);
                 sourceFiles = response.Files;
             }
             else
             {
-                if (!TryGetMetadataForLocalPath(step.SourcePath, step.IncludeSubdirectories, out sourceFiles, out var error))
+                if (!TryGetLocalMetadata(step.SourcePath, step.IncludeSubdirectories, out sourceFiles, out var error))
                     return new StepResult(false, error, "");
             }
             if (sourceFiles.Count == 0)
             {
-                var cwd = step.Direction == FileCopyDirection.RemoteToLocal ? _environment.RemoteWorkDir : _environment.LocalWorkDir;
-                return new StepResult(false, $"Path \"{step.SourcePath}\" does not exist\r\nWorking directory: \"{cwd}\"", "");
+                return new StepResult(false, $"Path \"{step.SourcePath}\" does not exist", "");
             }
+            // List all target files
             if (step.Direction == FileCopyDirection.LocalToRemote)
             {
-                var command = new ListFilesCommand { Path = step.TargetPath, WorkDir = _environment.RemoteWorkDir,
-                    IncludeSubdirectories = step.IncludeSubdirectories };
+                var command = new ListFilesCommand { Path = step.TargetPath };
                 var response = await _channel.SendWithReplyAsync<ListFilesResponse>(command);
                 targetFiles = response.Files;
             }
             else
             {
-                if (!TryGetMetadataForLocalPath(step.TargetPath, step.IncludeSubdirectories, out targetFiles, out var error))
+                if (!TryGetLocalMetadata(step.TargetPath, step.IncludeSubdirectories, out targetFiles, out var error))
                     return new StepResult(false, error, "");
             }
-
-            /* Copying a single file */
+            // Copying one file?
             if (sourceFiles.Count == 1 && !sourceFiles[0].IsDirectory)
             {
                 if (targetFiles.Count > 0 && targetFiles[0].IsDirectory)
@@ -122,13 +119,13 @@ namespace VSRAD.Package.Server
 
                 return await DoCopySingleFileAsync(step);
             }
-            /* Copying a directory */
+            // Copying a directory?
             return await DoCopyDirectoryAsync(step, sourceFiles, targetFiles);
         }
 
         private async Task<StepResult> DoCopyDirectoryAsync(CopyFileStep step, IList<FileMetadata> sourceFiles, IList<FileMetadata> targetFiles)
         {
-            /* Retrieve source files */
+            // Retrieve source files
             var files = new List<PackedFile>();
             bool SourceIdenticalToTarget(FileMetadata src)
             {
@@ -149,7 +146,7 @@ namespace VSRAD.Package.Server
             {
                 if (step.Direction == FileCopyDirection.RemoteToLocal)
                 {
-                    var command = new GetFilesCommand { RootPath = new[] { _environment.RemoteWorkDir, step.SourcePath }, Paths = filesToGet.ToArray(), UseCompression = step.UseCompression };
+                    var command = new GetFilesCommand { RootPath = step.SourcePath, Paths = filesToGet.ToArray(), UseCompression = step.UseCompression };
                     var response = await _channel.SendWithReplyAsync<GetFilesResponse>(command);
 
                     if (response.Status != GetFilesStatus.Successful)
@@ -159,30 +156,24 @@ namespace VSRAD.Package.Server
                 }
                 else
                 {
-                    var rootPath = Path.Combine(_environment.LocalWorkDir, step.SourcePath);
-                    files.AddRange(PackedFile.PackFiles(rootPath, filesToGet));
+                    files.AddRange(PackedFile.PackFiles(step.SourcePath, filesToGet));
                 }
             }
-            /* Include empty directories */
+            // Include empty directories
             foreach (var src in sourceFiles)
             {
                 // ./ indicates the root directory
                 if (src.IsDirectory && src.RelativePath != "./" && !(step.IfNotModified == ActionIfNotModified.DoNotCopy && SourceIdenticalToTarget(src)))
                     files.Add(new PackedFile(Array.Empty<byte>(), src.RelativePath, src.LastWriteTimeUtc));
             }
-            /* Write source files and directories to the target directory */
+            // Write source files and directories to the target directory
             if (files.Count == 0)
+            {
                 return new StepResult(true, "", "No files were copied. Sizes and modification times are identical on the source and target sides.\r\n");
-
+            }
             if (step.Direction == FileCopyDirection.LocalToRemote)
             {
-                ICommand command = new PutDirectoryCommand
-                {
-                    Files = files.ToArray(),
-                    Path = step.TargetPath,
-                    WorkDir = _environment.RemoteWorkDir,
-                    PreserveTimestamps = step.PreserveTimestamps
-                };
+                ICommand command = new PutDirectoryCommand { Files = files.ToArray(), Path = step.TargetPath, PreserveTimestamps = step.PreserveTimestamps };
                 if (step.UseCompression)
                     command = new CompressedCommand(command);
                 var response = await _channel.SendWithReplyAsync<PutDirectoryResponse>(command);
@@ -196,14 +187,12 @@ namespace VSRAD.Package.Server
             }
             else
             {
-                if (!TryGetFullLocalPath(step.TargetPath, out var fullPath, out var error))
-                    return new StepResult(false, error, "");
-                if (File.Exists(fullPath))
-                    return new StepResult(false, $"Directory \"{step.SourcePath}\" could not be copied to the local machine: the target path is a file.", "");
+                if (File.Exists(step.TargetPath))
+                    return new StepResult(false, $"Directory \"{step.TargetPath}\" could not be copied to the local machine: the target path is a file.", "");
 
                 try
                 {
-                    PackedFile.UnpackFiles(fullPath, files, step.PreserveTimestamps);
+                    PackedFile.UnpackFiles(step.TargetPath, files, step.PreserveTimestamps);
                 }
                 catch (UnauthorizedAccessException)
                 {
@@ -211,7 +200,7 @@ namespace VSRAD.Package.Server
                 }
                 catch (IOException)
                 {
-                    return new StepResult(false, $"Directory \"{step.SourcePath}\" could not be copied to the local machine", "");
+                    return new StepResult(false, $"Directory \"{step.TargetPath}\" could not be copied to the local machine", "");
                 }
             }
 
@@ -224,7 +213,7 @@ namespace VSRAD.Package.Server
             /* Read source file */
             if (step.Direction == FileCopyDirection.RemoteToLocal)
             {
-                var command = new FetchResultRange { FilePath = new[] { _environment.RemoteWorkDir, step.SourcePath } };
+                var command = new FetchResultRange { FilePath = new[] { step.SourcePath } };
                 var response = await _channel.SendWithReplyAsync<ResultRangeFetched>(command);
                 if (response.Status == FetchStatus.FileNotFound)
                     return new StepResult(false, $"File is not found on the remote machine at {step.SourcePath}", "");
@@ -237,7 +226,7 @@ namespace VSRAD.Package.Server
             /* Write target file */
             if (step.Direction == FileCopyDirection.LocalToRemote)
             {
-                ICommand command = new PutFileCommand { Data = sourceContents, Path = step.TargetPath, WorkDir = _environment.RemoteWorkDir };
+                ICommand command = new PutFileCommand { Data = sourceContents, Path = step.TargetPath };
                 if (step.UseCompression)
                     command = new CompressedCommand(command);
                 var response = await _channel.SendWithReplyAsync<PutFileResponse>(command);
@@ -249,13 +238,10 @@ namespace VSRAD.Package.Server
             }
             else
             {
-                if (!TryGetFullLocalPath(step.TargetPath, out var localPath, out var error))
-                    return new StepResult(false, error, "");
-
                 try
                 {
-                    Directory.CreateDirectory(Path.GetDirectoryName(localPath));
-                    File.WriteAllBytes(localPath, sourceContents);
+                    Directory.CreateDirectory(Path.GetDirectoryName(step.TargetPath));
+                    File.WriteAllBytes(step.TargetPath, sourceContents);
                 }
                 catch (UnauthorizedAccessException)
                 {
@@ -268,15 +254,11 @@ namespace VSRAD.Package.Server
 
         private async Task<StepResult> DoExecuteAsync(ExecuteStep step)
         {
-            var workDir = step.WorkingDirectory;
-            if (string.IsNullOrEmpty(workDir))
-                workDir = step.Environment == StepEnvironment.Local ? _environment.LocalWorkDir : _environment.RemoteWorkDir;
-
             var command = new Execute
             {
                 Executable = step.Executable,
                 Arguments = step.Arguments,
-                WorkingDirectory = workDir,
+                WorkingDirectory = step.WorkingDirectory,
                 RunAsAdministrator = step.RunAsAdmin,
                 WaitForCompletion = step.WaitForCompletion,
                 ExecutionTimeoutSecs = step.TimeoutSecs
@@ -330,7 +312,7 @@ namespace VSRAD.Package.Server
 
         private async Task<(StepResult, BreakState)> DoReadDebugDataAsync(ReadDebugDataStep step)
         {
-            var watches = _environment.Watches;
+            var watches = _debugWatches;
             BreakStateDispatchParameters dispatchParams = null;
 
             if (!string.IsNullOrEmpty(step.WatchesFile.Path))
@@ -356,8 +338,8 @@ namespace VSRAD.Package.Server
                     return (new StepResult(false, error.Message, ""), null);
             }
             {
-                var path = step.OutputFile.Path;
-                var initOutputTimestamp = GetInitialFileTimestamp(path);
+                var outputPath = step.OutputFile.Path;
+                var initOutputTimestamp = GetInitialFileTimestamp(outputPath);
 
                 int GetOutputDwordCount(int fileByteCount, out string warning)
                 {
@@ -372,7 +354,7 @@ namespace VSRAD.Package.Server
 
                     if (fileDwordCount < dispatchDwordCount)
                     {
-                        warning = $"Output file ({path}) is smaller than expected.\r\n\r\n" +
+                        warning = $"Output file ({outputPath}) is smaller than expected.\r\n\r\n" +
                             $"Grid size as specified in the dispatch parameters file is ({dispatchParams.GridSizeX}, {dispatchParams.GridSizeY}, {dispatchParams.GridSizeZ}), " +
                             $"which corresponds to {totalLaneCount} lanes. With {laneDataSize} DWORDs per lane, the output file is expected to contain at least " +
                             $"{dispatchDwordCount} DWORDs, but it only contains {fileDwordCount} DWORDs.";
@@ -387,34 +369,32 @@ namespace VSRAD.Package.Server
 
                 if (step.OutputFile.IsRemote())
                 {
-                    var fullPath = new[] { _environment.RemoteWorkDir, path };
-                    var response = await _channel.SendWithReplyAsync<MetadataFetched>(new FetchMetadata { FilePath = fullPath, BinaryOutput = step.BinaryOutput });
+                    var response = await _channel.SendWithReplyAsync<MetadataFetched>(new FetchMetadata { FilePath = new[] { outputPath }, BinaryOutput = step.BinaryOutput });
 
                     if (response.Status == FetchStatus.FileNotFound)
-                        return (new StepResult(false, $"Output file ({path}) could not be found.", ""), null);
+                        return (new StepResult(false, $"Output file ({outputPath}) could not be found.", ""), null);
                     if (step.OutputFile.CheckTimestamp && response.Timestamp == initOutputTimestamp)
-                        return (new StepResult(false, $"Output file ({path}) was not modified. Data may be stale.", ""), null);
+                        return (new StepResult(false, $"Output file ({outputPath}) was not modified. Data may be stale.", ""), null);
 
                     var offset = step.BinaryOutput ? step.OutputOffset : step.OutputOffset * 4;
                     var dataByteCount = Math.Max(0, response.ByteCount - offset);
                     var dataDwordCount = GetOutputDwordCount(dataByteCount, out stepWarning);
-                    outputFile = new BreakStateOutputFile(fullPath, step.BinaryOutput, step.OutputOffset, response.Timestamp, dataDwordCount);
+                    outputFile = new BreakStateOutputFile(outputPath, step.BinaryOutput, step.OutputOffset, response.Timestamp, dataDwordCount);
                 }
                 else
                 {
-                    var fullPath = new[] { _environment.LocalWorkDir, path };
-                    var timestamp = GetLocalFileLastWriteTimeUtc(path);
+                    var timestamp = GetLocalFileLastWriteTimeUtc(outputPath);
                     if (step.OutputFile.CheckTimestamp && timestamp == initOutputTimestamp)
-                        return (new StepResult(false, $"Output file ({path}) was not modified. Data may be stale.", ""), null);
+                        return (new StepResult(false, $"Output file ({outputPath}) was not modified. Data may be stale.", ""), null);
 
                     var readOffset = step.BinaryOutput ? step.OutputOffset : 0;
-                    if (!ReadLocalFile(path, out localOutputData, out var readError, readOffset))
+                    if (!ReadLocalFile(outputPath, out localOutputData, out var readError, readOffset))
                         return (new StepResult(false, "Output file could not be opened. " + readError, ""), null);
                     if (!step.BinaryOutput)
                         localOutputData = await TextDebuggerOutputParser.ReadTextOutputAsync(new MemoryStream(localOutputData), step.OutputOffset);
 
                     var dataDwordCount = GetOutputDwordCount(localOutputData.Length, out stepWarning);
-                    outputFile = new BreakStateOutputFile(fullPath, step.BinaryOutput, offset: 0, timestamp, dataDwordCount);
+                    outputFile = new BreakStateOutputFile(outputPath, step.BinaryOutput, offset: 0, timestamp, dataDwordCount);
                 }
 
                 var data = new BreakStateData(watches, outputFile, localOutputData);
@@ -428,7 +408,7 @@ namespace VSRAD.Package.Server
             if (isRemote)
             {
                 var response = await _channel.SendWithReplyAsync<ResultRangeFetched>(
-                    new FetchResultRange { FilePath = new[] { _environment.RemoteWorkDir, path } });
+                    new FetchResultRange { FilePath = new[] { path } });
 
                 if (response.Status == FetchStatus.FileNotFound)
                     return new Error($"{type} file ({path}) could not be found.");
@@ -447,13 +427,8 @@ namespace VSRAD.Package.Server
             }
         }
 
-        private bool ReadLocalFile(string path, out byte[] data, out string error, int byteOffset = 0)
+        private bool ReadLocalFile(string fullPath, out byte[] data, out string error, int byteOffset = 0)
         {
-            if (!TryGetFullLocalPath(path, out var fullPath, out error))
-            {
-                data = null;
-                return false;
-            }
             try
             {
                 using (var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read, 8192, FileOptions.SequentialScan))
@@ -476,11 +451,11 @@ namespace VSRAD.Package.Server
             }
             catch (IOException e) when (e is FileNotFoundException || e is DirectoryNotFoundException)
             {
-                error = $"File {path} is not found on the local machine";
+                error = $"File {fullPath} is not found on the local machine";
             }
             catch (UnauthorizedAccessException)
             {
-                error = $"Access to path {path} on the local machine is denied";
+                error = $"Access to path {fullPath} on the local machine is denied";
             }
             data = null;
             return false;
@@ -494,7 +469,7 @@ namespace VSRAD.Package.Server
                 {
                     if (copyFile.Direction == FileCopyDirection.RemoteToLocal)
                         _initialTimestamps[copyFile.SourcePath] = (await _channel.SendWithReplyAsync<MetadataFetched>(
-                            new FetchMetadata { FilePath = new[] { _environment.RemoteWorkDir, copyFile.SourcePath } })).Timestamp;
+                            new FetchMetadata { FilePath = new[] { copyFile.SourcePath } })).Timestamp;
                     else
                         _initialTimestamps[copyFile.SourcePath] = GetLocalFileLastWriteTimeUtc(copyFile.SourcePath);
                 }
@@ -507,7 +482,7 @@ namespace VSRAD.Package.Server
                             continue;
                         if (file.IsRemote())
                             _initialTimestamps[file.Path] = (await _channel.SendWithReplyAsync<MetadataFetched>(
-                                new FetchMetadata { FilePath = new[] { _environment.RemoteWorkDir, file.Path } })).Timestamp;
+                                new FetchMetadata { FilePath = new[] { file.Path } })).Timestamp;
                         else
                             _initialTimestamps[file.Path] = GetLocalFileLastWriteTimeUtc(file.Path);
                     }
@@ -515,12 +490,11 @@ namespace VSRAD.Package.Server
             }
         }
 
-        private DateTime GetLocalFileLastWriteTimeUtc(string file)
+        private DateTime GetLocalFileLastWriteTimeUtc(string path)
         {
             try
             {
-                var localPath = Path.Combine(_environment.LocalWorkDir, file);
-                return File.GetLastWriteTimeUtc(localPath);
+                return File.GetLastWriteTimeUtc(path);
             }
             catch
             {
@@ -528,16 +502,11 @@ namespace VSRAD.Package.Server
             }
         }
 
-        private bool TryGetMetadataForLocalPath(string path, bool includeSubdirectories, out IList<FileMetadata> metadata, out string error)
+        private bool TryGetLocalMetadata(string localPath, bool includeSubdirectories, out IList<FileMetadata> metadata, out string error)
         {
-            if (!TryGetFullLocalPath(path, out var localPath, out error))
-            {
-                metadata = null;
-                return false;
-            }
-
             try
             {
+                error = "";
                 metadata = FileMetadata.GetMetadataForPath(localPath, includeSubdirectories);
                 return true;
             }
@@ -551,22 +520,6 @@ namespace VSRAD.Package.Server
             {
                 error = $"Unable to open directory or its contents: \"{localPath}\"";
                 metadata = null;
-                return false;
-            }
-        }
-
-        private bool TryGetFullLocalPath(string path, out string fullPath, out string error)
-        {
-            try
-            {
-                error = "";
-                fullPath = Path.Combine(_environment.LocalWorkDir, path);
-                return true;
-            }
-            catch (ArgumentException e) when (e.Message == "Illegal characters in path.")
-            {
-                error = $"Local path contains illegal characters: \"{path}\"\r\nWorking directory: \"{_environment.LocalWorkDir}\"";
-                fullPath = null;
                 return false;
             }
         }

--- a/VSRAD.Package/Server/BreakStateData.cs
+++ b/VSRAD.Package/Server/BreakStateData.cs
@@ -213,7 +213,7 @@ namespace VSRAD.Package.Server
             var response = await channel.SendWithReplyAsync<DebugServer.IPC.Responses.ResultRangeFetched>(
                 new DebugServer.IPC.Commands.FetchResultRange
                 {
-                    FilePath = _outputFile.Path,
+                    FilePath = new[] { _outputFile.Path },
                     BinaryOutput = _outputFile.BinaryOutput,
                     ByteOffset = requestedByteOffset,
                     ByteCount = requestedByteCount,

--- a/VSRAD.Package/Server/BreakStateOutputFile.cs
+++ b/VSRAD.Package/Server/BreakStateOutputFile.cs
@@ -6,13 +6,13 @@ namespace VSRAD.Package.Server
     public readonly struct BreakStateOutputFile
 #pragma warning restore CA1815 // Override equals and operator equals on value types
     {
-        public string[] Path { get; }
+        public string Path { get; }
         public bool BinaryOutput { get; }
         public int Offset { get; }
         public DateTime Timestamp { get; }
         public int DwordCount { get; }
 
-        public BreakStateOutputFile(string[] path, bool binaryOutput, int offset, DateTime timestamp, int dwordCount)
+        public BreakStateOutputFile(string path, bool binaryOutput, int offset, DateTime timestamp, int dwordCount)
         {
             Path = path;
             BinaryOutput = binaryOutput;

--- a/VSRAD.Package/Server/CommunicationChannel.cs
+++ b/VSRAD.Package/Server/CommunicationChannel.cs
@@ -23,11 +23,11 @@ namespace VSRAD.Package.Server
 
         ClientState ConnectionState { get; }
 
-        DebugServer.IPC.CapabilityInfo ServerCapabilities { get; }
-
         Task<T> SendWithReplyAsync<T>(ICommand command) where T : IResponse;
 
         Task<IReadOnlyDictionary<string, string>> GetRemoteEnvironmentAsync();
+
+        Task<DebugServer.IPC.CapabilityInfo> GetServerCapabilityInfoAsync();
 
         void ForceDisconnect();
     }
@@ -144,6 +144,13 @@ namespace VSRAD.Package.Server
                 _remoteEnvironment = environment.Variables;
             }
             return _remoteEnvironment;
+        }
+
+        public async Task<DebugServer.IPC.CapabilityInfo> GetServerCapabilityInfoAsync()
+        {
+            if (ConnectionState != ClientState.Connected)
+                await EstablishServerConnectionAsync();
+            return ServerCapabilities;
         }
 
         public void ForceDisconnect()

--- a/VSRAD.Package/Server/CommunicationChannel.cs
+++ b/VSRAD.Package/Server/CommunicationChannel.cs
@@ -32,14 +32,14 @@ namespace VSRAD.Package.Server
         void ForceDisconnect();
     }
 
-    public sealed class ConnectionRefusedException : System.IO.IOException
+    public sealed class ConnectionRefusedException : UserException
     {
         public ConnectionRefusedException(ServerConnectionOptions connection) :
-            base($"Unable to establish connection to a debug server at {connection}")
+            base($"Unable to establish connection to the debug server at host {connection}")
         { }
     }
 
-    public sealed class UnsupportedServerVersionException : System.IO.IOException
+    public sealed class UnsupportedServerVersionException : UserException
     {
         public UnsupportedServerVersionException(ServerConnectionOptions connection) :
             base($"The debug server on host {connection} is out of date and missing critical features. Please update it to the latest available version.")
@@ -127,7 +127,7 @@ namespace VSRAD.Package.Server
                 {
                     ForceDisconnect();
                     await _outputWindowWriter.PrintMessageAsync($"Could not reconnect to {ConnectionOptions}").ConfigureAwait(false);
-                    throw new Exception($"Connection to {ConnectionOptions} has been terminated: {e.Message}");
+                    throw;
                 }
             }
             finally

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -42,7 +42,7 @@
                                                 <ComboBox ItemsSource="{Binding ProfileNames}" SelectedItem="{Binding Options.ActiveProfile, Mode=TwoWay}"
                                                           Width="156" Height="24" Margin="4,0,0,4"/>
                                                 <Button Content="Edit" Style="{StaticResource ProfileButton}" Height="24" Padding="6,0" Margin="4,0,0,4"/>
-                                                <Label Content="{Binding ConnectionInfo}" Margin="4,0,0,4"/>
+                                                <Label Content="{Binding ConnectionInfo}" ToolTip="{Binding ServerInfo}" Margin="4,0,0,4"/>
                                                 <Button Content="{Binding DisconnectLabel}" Command="{Binding DisconnectCommand}" Height="24" Padding="6,0" Margin="4,0,0,4"
                                                         Visibility="{Binding DisconnectButtonVisible, Mode=OneWay}"/>
                                             </WrapPanel>

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
@@ -36,13 +36,13 @@ namespace VSRAD.Package.ToolWindows
 
             public ICommand DisconnectCommand { get; }
 
-            private readonly ICommunicationChannel _channel;
+            private readonly CommunicationChannel _channel;
 
             public Context(ProjectOptions options, ICommunicationChannel channel)
             {
                 Options = options;
                 Options.PropertyChanged += OptionsChanged;
-                _channel = channel;
+                _channel = (CommunicationChannel)channel;
                 _channel.ConnectionStateChanged += ConnectionStateChanged;
                 DisconnectCommand = new WpfDelegateCommand((_) => _channel.ForceDisconnect(), isEnabled: _channel.ConnectionState == ClientState.Connected);
             }

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml.cs
@@ -22,6 +22,9 @@ namespace VSRAD.Package.ToolWindows
             public string ConnectionInfo =>
                 Options.Profile?.General?.RunActionsLocally == true ? "Local" : _channel.ConnectionOptions.ToString();
 
+            public string ServerInfo =>
+                _channel.ServerCapabilities?.ToString() ?? "";
+
             public Visibility DisconnectButtonVisible =>
                 Options.Profile?.General?.RunActionsLocally == true ? Visibility.Hidden : Visibility.Visible;
 
@@ -56,6 +59,7 @@ namespace VSRAD.Package.ToolWindows
             private void ConnectionStateChanged()
             {
                 RaisePropertyChanged(nameof(ConnectionInfo));
+                RaisePropertyChanged(nameof(ServerInfo));
                 RaisePropertyChanged(nameof(DisconnectLabel));
                 RaisePropertyChanged(nameof(DisconnectButtonVisible));
                 ((WpfDelegateCommand)DisconnectCommand).IsEnabled = _channel.ConnectionState == ClientState.Connected;

--- a/VSRAD.Package/Utils/StringExtensions.cs
+++ b/VSRAD.Package/Utils/StringExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace VSRAD.Package.Utils
+{
+    public static class StringExtensions
+    {
+        public static bool StartsWith(this string str, char c)
+        {
+            return str.Length > 0 && str[0] == c;
+        }
+
+        public static bool EndsWith(this string str, char c)
+        {
+            return str.Length > 0 && str[str.Length - 1] == c;
+        }
+    }
+}

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -106,6 +106,9 @@
     <Compile Include="..\VSRAD.BuildTools\IPCBuildResult.cs">
       <Link>BuildTools\IPCBuildResult.cs</Link>
     </Compile>
+    <Compile Include="..\VSRAD.DebugServer\IPC\Capabilities.cs">
+      <Link>Server\IPC\Capabilities.cs</Link>
+    </Compile>
     <Compile Include="..\VSRAD.DebugServer\IPC\Commands.cs">
       <Link>Server\IPC\Commands.cs</Link>
     </Compile>

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -258,6 +258,7 @@
     <Compile Include="Utils\CollectionExtensions.cs" />
     <Compile Include="Utils\MruCollection.cs" />
     <Compile Include="Utils\OleCommandText.cs" />
+    <Compile Include="Utils\StringExtensions.cs" />
     <Compile Include="Utils\VsEditor.cs" />
     <Compile Include="Utils\VsStatusBarWriter.cs" />
     <Compile Include="Utils\WpfConverters.cs" />

--- a/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
@@ -16,7 +16,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             byte[] systemBytes = new byte[system.Length * 4];
             Buffer.BlockCopy(system, 0, systemBytes, 0, systemBytes.Length);
             var data = new BreakStateData(new ReadOnlyCollection<string>(new List<string>()),
-                new BreakStateOutputFile(Array.Empty<string>(), false, 0, default, dwordCount: system.Length), systemBytes);
+                new BreakStateOutputFile("", false, 0, default, dwordCount: system.Length), systemBytes);
             _ = data.ChangeGroupWithWarningsAsync(null, groupIndex: groupIndex, groupSize: groupSize, waveSize: waveSize, nGroups: 0).Result;
             var view = data.GetSystem();
             Assert.NotNull(view);

--- a/VSRAD.PackageTests/MockCommunicationChannel.cs
+++ b/VSRAD.PackageTests/MockCommunicationChannel.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using VSRAD.DebugServer.IPC;
 using VSRAD.DebugServer.IPC.Commands;
 using VSRAD.DebugServer.IPC.Responses;
 using VSRAD.Package.Server;
@@ -28,9 +29,12 @@ namespace VSRAD.PackageTests
 
         public void RaiseConnectionStateChanged() => _mock.Raise((m) => m.ConnectionStateChanged += null);
 
-        public MockCommunicationChannel()
+        public MockCommunicationChannel(ServerPlatform platform = ServerPlatform.Windows)
         {
             _mock = new Mock<ICommunicationChannel>();
+            _mock
+                .SetupGet(c => c.ServerCapabilities)
+                .Returns(new CapabilityInfo("", platform, CapabilityInfo.LatestServerCapabilities));
             _mock
                 .Setup((c) => c.SendWithReplyAsync<ExecutionCompleted>(It.IsAny<Execute>()))
                 .Returns<ICommand>((c) => Task.FromResult((ExecutionCompleted)HandleCommand(c)));

--- a/VSRAD.PackageTests/MockCommunicationChannel.cs
+++ b/VSRAD.PackageTests/MockCommunicationChannel.cs
@@ -33,8 +33,8 @@ namespace VSRAD.PackageTests
         {
             _mock = new Mock<ICommunicationChannel>();
             _mock
-                .SetupGet(c => c.ServerCapabilities)
-                .Returns(new CapabilityInfo("", platform, CapabilityInfo.LatestServerCapabilities));
+                .Setup(c => c.GetServerCapabilityInfoAsync())
+                .ReturnsAsync(new CapabilityInfo("", platform, CapabilityInfo.LatestServerCapabilities));
             _mock
                 .Setup((c) => c.SendWithReplyAsync<ExecutionCompleted>(It.IsAny<Execute>()))
                 .Returns<ICommand>((c) => Task.FromResult((ExecutionCompleted)HandleCommand(c)));

--- a/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
@@ -60,7 +60,7 @@ namespace VSRAD.PackageTests.ProjectSystem
             var serviceProvider = new Mock<SVsServiceProvider>();
             serviceProvider.Setup(p => p.GetService(typeof(SVsStatusbar))).Returns(new Mock<IVsStatusbar>().Object);
 
-            var channel = new MockCommunicationChannel();
+            var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
             var sourceManager = new Mock<IProjectSourceManager>();
             var actionLauncher = new ActionLauncher(project, new Mock<IActionLogger>().Object, channel.Object, sourceManager.Object,
                 codeEditor.Object, breakpointTracker.Object, serviceProvider.Object);
@@ -69,7 +69,7 @@ namespace VSRAD.PackageTests.ProjectSystem
             /* Set up server responses */
 
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.FileNotFound }, (FetchMetadata timestampFetch) =>
-                Assert.Equal(new[] { "/periphery/votw", "output-path" }, timestampFetch.FilePath));
+                Assert.Equal(new[] { "/periphery/votw/output-path" }, timestampFetch.FilePath));
             channel.ThenRespond(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0 }, (Execute execute) =>
             {
                 Assert.Equal("ohmu", execute.Executable);

--- a/VSRAD.PackageTests/Server/ActionRunnerTests.cs
+++ b/VSRAD.PackageTests/Server/ActionRunnerTests.cs
@@ -24,19 +24,19 @@ namespace VSRAD.PackageTests.Server
         [Fact]
         public async Task SucessfulRunTestAsync()
         {
-            var channel = new MockCommunicationChannel();
+            var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
             var steps = new List<IActionStep>
             {
                 new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "autotween" },
-                new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, IfNotModified = ActionIfNotModified.Fail, SourcePath = "tweened.tvpp", TargetPath = Path.GetTempFileName() }
+                new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, IfNotModified = ActionIfNotModified.Fail, SourcePath = "/home/mizu/machete/tweened.tvpp", TargetPath = Path.GetTempFileName() }
             };
             var localTempFile = Path.GetRandomFileName();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/home/mizu/machete"), _project);
+            var runner = new ActionRunner(channel.Object, null, null);
 
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.FromBinary(100) }, (FetchMetadata command) =>
             {
                 // init timestamp fetch
-                Assert.Equal(new[] { "/home/mizu/machete", "tweened.tvpp" }, command.FilePath);
+                Assert.Equal(new[] { "/home/mizu/machete/tweened.tvpp" }, command.FilePath);
             });
             channel.ThenRespond(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0, Stdout = "", Stderr = "" });
             channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata(".", 1, DateTime.FromBinary(101)) } });
@@ -57,8 +57,8 @@ namespace VSRAD.PackageTests.Server
         [Fact]
         public async Task CopyFileRLRemoteErrorTestAsync()
         {
-            var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/home/mizu/machete"), _project);
+            var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
+            var runner = new ActionRunner(channel.Object, null, null);
             var steps = new List<IActionStep>
             {
                 new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, IfNotModified = ActionIfNotModified.Fail, SourcePath = "/home/mizu/machete/key3_49", TargetPath = Path.GetRandomFileName() },
@@ -70,7 +70,7 @@ namespace VSRAD.PackageTests.Server
             var result = await runner.RunAsync("HTMT", steps, false);
             Assert.False(result.Successful);
             Assert.False(result.StepResults[0].Successful);
-            Assert.Equal("Path \"/home/mizu/machete/key3_49\" does not exist\r\nWorking directory: \"/home/mizu/machete\"", result.StepResults[0].Warning);
+            Assert.Equal("Path \"/home/mizu/machete/key3_49\" does not exist", result.StepResults[0].Warning);
 
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.FromBinary(100) }); // init timestamp fetch
             channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata(".", 1, DateTime.FromBinary(100)) } });
@@ -83,14 +83,14 @@ namespace VSRAD.PackageTests.Server
         [Fact]
         public async Task CopyFileRLMissingParentDirectoryTestAsync()
         {
-            var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/home/mizu/machete"), _project);
+            var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
+            var runner = new ActionRunner(channel.Object, null, null);
 
             var parentDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Assert.False(Directory.Exists(parentDir));
 
             var file = Path.Combine(parentDir, "local-copy");
-            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, SourcePath = "raw3", TargetPath = file } };
+            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, SourcePath = "/home/mizu/machete/raw3", TargetPath = file } };
 
             channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata(".", 1, default) } });
             channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Encoding.UTF8.GetBytes("file-contents") });
@@ -103,63 +103,45 @@ namespace VSRAD.PackageTests.Server
         [Fact]
         public async Task CopyFileRLLocalErrorTestAsync()
         {
-            var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/home/mizu/machete"), _project);
+            var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
+            var runner = new ActionRunner(channel.Object, null, null);
 
             var file = Path.GetTempFileName();
             File.SetAttributes(file, FileAttributes.ReadOnly);
-            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, SourcePath = "raw3", TargetPath = file } };
+            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, SourcePath = "/home/mizu/machete/raw3", TargetPath = file } };
             channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata(".", default, default) } });
             channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Encoding.UTF8.GetBytes("file-contents") });
 
             var result = await runner.RunAsync("HTMT", steps);
             Assert.False(result.Successful);
             Assert.Equal($"Access to path {file} on the local machine is denied", result.StepResults[0].Warning);
-
-            file = @"C:\Users\mizu*~*\raw >_<";
-            steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, SourcePath = "raw3", TargetPath = file } };
-            channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata(".", default, default) } });
-
-            result = await runner.RunAsync("HTMT", steps);
-            Assert.False(result.Successful);
-            Assert.Equal($"Local path contains illegal characters: \"{file}\"\r\nWorking directory: \"{Path.GetTempPath()}\"", result.StepResults[0].Warning);
-
-            file = Path.Combine(Path.GetTempPath(), "raw*o*");
-            file += "=>_<=";
-            steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, SourcePath = "raw3", TargetPath = file } };
-            channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata(".", default, default) } });
-            channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Encoding.UTF8.GetBytes("file-contents") });
-
-            result = await runner.RunAsync("HTMT", steps);
-            Assert.False(result.Successful);
-            Assert.Equal($"Local path contains illegal characters: \"{file}\"\r\nWorking directory: \"{Path.GetTempPath()}\"", result.StepResults[0].Warning);
         }
 
         [Fact]
         public async Task CopyFileLRRemoteErrorTestAsync()
         {
-            var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/home/mizu/machete"), _project);
-            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.LocalToRemote, SourcePath = Path.GetTempFileName(), TargetPath = "raw3" } };
+            var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
+            var runner = new ActionRunner(channel.Object, null, null);
+            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.LocalToRemote, SourcePath = Path.GetTempFileName(), TargetPath = "/home/mizu/machete/raw3" } };
 
             channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata(".", default, default) } });
             channel.ThenRespond(new PutFileResponse { Status = PutFileStatus.PermissionDenied });
             var result = await runner.RunAsync("HTMT", steps);
             Assert.False(result.Successful);
-            Assert.Equal("Access to path raw3 on the remote machine is denied", result.StepResults[0].Warning);
+            Assert.Equal("Access to path /home/mizu/machete/raw3 on the remote machine is denied", result.StepResults[0].Warning);
 
             channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata(".", default, default) } });
             channel.ThenRespond(new PutFileResponse { Status = PutFileStatus.OtherIOError });
             result = await runner.RunAsync("HTMT", steps);
             Assert.False(result.Successful);
-            Assert.Equal("File raw3 could not be created on the remote machine", result.StepResults[0].Warning);
+            Assert.Equal("File /home/mizu/machete/raw3 could not be created on the remote machine", result.StepResults[0].Warning);
         }
 
         [Fact]
         public async Task CopyFileLocalErrorTestAsync()
         {
-            var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/home/mizu/machete"), _project);
+            var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
+            var runner = new ActionRunner(channel.Object, null, null);
 
             var localPath = Path.GetTempFileName();
             var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.LocalToLocal, SourcePath = localPath, IfNotModified = ActionIfNotModified.Fail, TargetPath = Path.GetRandomFileName() } };
@@ -171,7 +153,7 @@ namespace VSRAD.PackageTests.Server
             steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.LocalToLocal, SourcePath = nonexistentPath, IfNotModified = ActionIfNotModified.Fail, TargetPath = Path.GetRandomFileName() } };
             result = await runner.RunAsync("HTMT", steps);
             Assert.False(result.Successful);
-            Assert.Equal($@"Path ""C:\Non\Existent\Path\To\Users\mizu\raw3"" does not exist{"\r\n"}Working directory: ""{Path.GetTempPath()}""", result.StepResults[0].Warning);
+            Assert.Equal($@"Path ""C:\Non\Existent\Path\To\Users\mizu\raw3"" does not exist", result.StepResults[0].Warning);
 
             var lockedPath = Path.GetTempFileName();
             var acl = File.GetAccessControl(lockedPath);
@@ -183,18 +165,12 @@ namespace VSRAD.PackageTests.Server
             Assert.False(result.Successful);
             Assert.Equal($"Access to path {lockedPath} on the local machine is denied", result.StepResults[0].Warning);
             File.Delete(lockedPath);
-
-            var illegalPath = @"C:\Users\mizu\raw *~* >_<";
-            steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.LocalToLocal, SourcePath = illegalPath, TargetPath = Path.GetRandomFileName() } };
-            result = await runner.RunAsync("HTMT", steps);
-            Assert.False(result.Successful);
-            Assert.Equal($"Local path contains illegal characters: \"{illegalPath}\"\r\nWorking directory: \"{Path.GetTempPath()}\"", result.StepResults[0].Warning);
         }
 
         [Fact]
         public async Task CopyFileLLTestAsync()
         {
-            var runner = new ActionRunner(null, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: ""), _project);
+            var runner = new ActionRunner(null, null, null);
 
             var file = Path.GetTempFileName();
             var target = Path.GetTempFileName();
@@ -202,8 +178,8 @@ namespace VSRAD.PackageTests.Server
             var steps = new List<IActionStep>
             {
                 // update file timestamp
-                new ExecuteStep { Environment = StepEnvironment.Local, Executable = "cmd.exe", Arguments = $@"/C ""copy /b {Path.GetFileName(file)} +,,""" },
-                new CopyFileStep { Direction = FileCopyDirection.LocalToLocal, SourcePath = Path.GetFileName(file), TargetPath = Path.GetFileName(target), IfNotModified = ActionIfNotModified.Fail }
+                new ExecuteStep { Environment = StepEnvironment.Local, Executable = "cmd.exe", Arguments = $@"/C ""copy /b {Path.GetFileName(file)} +,,""", WorkingDirectory = Path.GetDirectoryName(file) },
+                new CopyFileStep { Direction = FileCopyDirection.LocalToLocal, SourcePath = file, TargetPath = target, IfNotModified = ActionIfNotModified.Fail }
             };
 
             var result = await runner.RunAsync("HTMT", steps);
@@ -224,9 +200,9 @@ namespace VSRAD.PackageTests.Server
             File.SetLastWriteTimeUtc(tmpDir + "\\t", new DateTime(1980, 1, 1));
             File.SetLastWriteTimeUtc(tmpDir + "\\t2", new DateTime(1990, 1, 1));
 
-            var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/home/mizu/machete"), _project);
-            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.LocalToRemote, SourcePath = tmpDir, TargetPath = "rawdir", IfNotModified = ActionIfNotModified.DoNotCopy, IncludeSubdirectories = true } };
+            var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
+            var runner = new ActionRunner(channel.Object, null, null);
+            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.LocalToRemote, SourcePath = tmpDir, TargetPath = "/home/mizu/rawdir", IfNotModified = ActionIfNotModified.DoNotCopy, IncludeSubdirectories = true } };
 
             // t is unchanged, t2's size is different, empty/ is missing
             channel.ThenRespond(new ListFilesResponse
@@ -239,8 +215,7 @@ namespace VSRAD.PackageTests.Server
                 }
             }, (ListFilesCommand command) =>
             {
-                Assert.Equal("rawdir", command.Path);
-                Assert.Equal("/home/mizu/machete", command.WorkDir);
+                Assert.Equal("/home/mizu/rawdir", command.Path);
             });
             channel.ThenRespond(new PutDirectoryResponse { Status = PutDirectoryStatus.Successful }, (PutDirectoryCommand command) =>
             {
@@ -261,14 +236,14 @@ namespace VSRAD.PackageTests.Server
         {
             var tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-            var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/home/mizu/machete"), _project);
-            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.LocalToRemote, SourcePath = tmpDir, TargetPath = "rawdir", IfNotModified = ActionIfNotModified.DoNotCopy } };
+            var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
+            var runner = new ActionRunner(channel.Object, null, null);
+            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.LocalToRemote, SourcePath = tmpDir, TargetPath = "/home/mizu/rawdir", IfNotModified = ActionIfNotModified.DoNotCopy } };
 
             // Path does not exist
             var result = await runner.RunAsync("HTMT", steps);
             Assert.False(result.Successful);
-            Assert.Equal($@"Path ""{tmpDir}"" does not exist{"\r\n"}Working directory: ""{Path.GetTempPath()}""", result.StepResults[0].Warning);
+            Assert.Equal($@"Path ""{tmpDir}"" does not exist", result.StepResults[0].Warning);
 
             // Permission denied
             Directory.CreateDirectory(tmpDir);
@@ -295,9 +270,9 @@ namespace VSRAD.PackageTests.Server
             File.SetLastWriteTimeUtc(tmpDir + "\\t", new DateTime(1980, 1, 1));
             File.SetLastWriteTimeUtc(tmpDir + "\\t2", new DateTime(1990, 1, 1));
 
-            var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/home/mizu/machete"), _project);
-            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, SourcePath = "rawdir", TargetPath = tmpDir, IfNotModified = ActionIfNotModified.DoNotCopy } };
+            var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
+            var runner = new ActionRunner(channel.Object, null, null);
+            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, SourcePath = "/home/mizu/rawdir", TargetPath = tmpDir, IfNotModified = ActionIfNotModified.DoNotCopy } };
 
             // t is unchanged, t2's size is different
             channel.ThenRespond(new ListFilesResponse
@@ -310,14 +285,13 @@ namespace VSRAD.PackageTests.Server
                 }
             }, (ListFilesCommand command) =>
             {
-                Assert.Equal("rawdir", command.Path);
-                Assert.Equal("/home/mizu/machete", command.WorkDir);
+                Assert.Equal("/home/mizu/rawdir", command.Path);
             });
 
             var files = new[] { new PackedFile(new byte[] { 0, 1, 2, 3 }, "t2", new DateTime(1990, 1, 1)) };
             channel.ThenRespond(new GetFilesResponse { Status = GetFilesStatus.Successful, Files = files }, (GetFilesCommand command) =>
             {
-                Assert.Equal(new[] { "/home/mizu/machete", "rawdir" }, command.RootPath);
+                Assert.Equal("/home/mizu/rawdir", command.RootPath);
                 Assert.Equal(new[] { "t2" }, command.Paths);
             });
             var result = await runner.RunAsync("HTMT", steps);
@@ -333,9 +307,9 @@ namespace VSRAD.PackageTests.Server
             Directory.CreateDirectory(tmpDir);
             File.WriteAllText(tmpDir + "\\t", "test");
 
-            var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/home/mizu/machete"), _project);
-            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, SourcePath = "rawdir", TargetPath = tmpDir, IfNotModified = ActionIfNotModified.DoNotCopy } };
+            var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
+            var runner = new ActionRunner(channel.Object, null, null);
+            var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, SourcePath = "/home/mizu/rawdir", TargetPath = tmpDir, IfNotModified = ActionIfNotModified.DoNotCopy } };
 
             // t's size is changed => it'll be requested
             channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata("./", default, default), new FileMetadata("t", 1, default) } });
@@ -364,7 +338,7 @@ namespace VSRAD.PackageTests.Server
                 new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "dvd-prepare" },
                 new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, IfNotModified = ActionIfNotModified.Copy, TargetPath = "/home/parker/audio/unchecked", SourcePath = "" }, // should not be run
             };
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/home/parker/audio"), _project);
+            var runner = new ActionRunner(channel.Object, null, null);
 
             channel.ThenRespond(new ExecutionCompleted { Status = ExecutionStatus.CouldNotLaunch, Stdout = "", Stderr = "" });
             var result = await runner.RunAsync("UFOW", steps, false);
@@ -397,9 +371,9 @@ namespace VSRAD.PackageTests.Server
 
             var steps = new List<IActionStep>
             {
-                new ExecuteStep { Environment = StepEnvironment.Local, Executable = "python.exe", Arguments = $"-c \"print('success', file=open(r'{file}', 'w'))\"" }
+                new ExecuteStep { Environment = StepEnvironment.Local, Executable = "python.exe", Arguments = $"-c \"print('success', file=open(r'{file}', 'w'))\"", WorkingDirectory = Path.GetTempPath() }
             };
-            var runner = new ActionRunner(channel: null, serviceProvider: null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: ""), _project);
+            var runner = new ActionRunner(null, null, null);
             var result = await runner.RunAsync("", steps);
             Assert.True(result.Successful);
             Assert.Equal("", result.StepResults[0].Warning);
@@ -411,48 +385,15 @@ namespace VSRAD.PackageTests.Server
         }
 
         [Fact]
-        public async Task ExecuteLocalWorkingDirectoryTestAsync()
-        {
-            var steps = new List<IActionStep>
-            {
-                new ExecuteStep { Environment = StepEnvironment.Local, Executable = "python.exe", Arguments = $"-c \"import os; print(os.getcwd())\"" }
-            };
-            var env = new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "");
-            var runner = new ActionRunner(channel: null, serviceProvider: null, env, _project);
-            var result = await runner.RunAsync("", steps);
-            Assert.True(result.Successful);
-
-            // When working directory is not specified, it defaults to ActionEnvironment.LocalWorkDir
-            var expectedWorkDir = env.LocalWorkDir.TrimEnd('\\');
-            Assert.Equal($"Captured stdout (exit code 0):\r\n{expectedWorkDir}\r\n", result.StepResults[0].Log);
-
-            ((ExecuteStep)steps[0]).WorkingDirectory = Directory.GetCurrentDirectory();
-            result = await runner.RunAsync("", steps);
-            Assert.True(result.Successful);
-
-            // When working directory is set, it should override ActionEnvironment.LocalWorkDir
-            expectedWorkDir = Directory.GetCurrentDirectory();
-            Assert.Equal($"Captured stdout (exit code 0):\r\n{expectedWorkDir}\r\n", result.StepResults[0].Log);
-        }
-
-        [Fact]
         public async Task ExecuteRemoteWorkingDirectoryTestAsync()
         {
             var channel = new MockCommunicationChannel();
-            var steps = new List<IActionStep> { new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "exe" } };
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/action/env/remote/dir"), _project);
+            var steps = new List<IActionStep> { new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "exe", WorkingDirectory = "/action/env/remote/dir" } };
+            var runner = new ActionRunner(channel.Object, null, null);
 
             channel.ThenRespond<Execute, ExecutionCompleted>(new ExecutionCompleted(), command =>
             {
                 Assert.Equal("/action/env/remote/dir", command.WorkingDirectory);
-            });
-            await runner.RunAsync("", steps);
-            Assert.True(channel.AllInteractionsHandled);
-
-            ((ExecuteStep)steps[0]).WorkingDirectory = "/explicitly/set/remote/dir";
-            channel.ThenRespond<Execute, ExecutionCompleted>(new ExecutionCompleted(), command =>
-            {
-                Assert.Equal("/explicitly/set/remote/dir", command.WorkingDirectory);
             });
             await runner.RunAsync("", steps);
             Assert.True(channel.AllInteractionsHandled);
@@ -493,7 +434,7 @@ namespace VSRAD.PackageTests.Server
             // 4. Level 1 Copy File
             channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata(".", default, DateTime.FromBinary(101)) } });
             channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Encoding.UTF8.GetBytes("file-contents") });
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/home/mizu/machete"), _project);
+            var runner = new ActionRunner(channel.Object, null, null);
             var result = await runner.RunAsync("HTMT", level1Steps);
 
             Assert.True(result.Successful);
@@ -513,28 +454,28 @@ namespace VSRAD.PackageTests.Server
             {
                 new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "va11" },
                 new ReadDebugDataStep(
-                    outputFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "output", CheckTimestamp = true },
-                    watchesFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "watches", CheckTimestamp = false },
-                    dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "status", CheckTimestamp = false },
+                    outputFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "/glitch/city/output", CheckTimestamp = true },
+                    watchesFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "/glitch/city/watches", CheckTimestamp = false },
+                    dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "/glitch/city/status", CheckTimestamp = false },
                     binaryOutput: true, outputOffset: 0)
             };
 
-            var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/glitch/city"), _project);
+            var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
+            var runner = new ActionRunner(channel.Object, null, null);
 
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.FileNotFound }, (FetchMetadata initTimestampFetch) =>
-                Assert.Equal(new[] { "/glitch/city", "output" }, initTimestampFetch.FilePath));
+                Assert.Equal(new[] { "/glitch/city/output" }, initTimestampFetch.FilePath));
             channel.ThenRespond(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0 });
             channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Encoding.UTF8.GetBytes("jill\njulianne") }, (FetchResultRange watchesFetch) =>
-                Assert.Equal(new[] { "/glitch/city", "watches" }, watchesFetch.FilePath));
+                Assert.Equal(new[] { "/glitch/city/watches" }, watchesFetch.FilePath));
             channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Encoding.UTF8.GetBytes(@"
 grid_size (8192, 0, 0)
 group_size (512, 0, 0)
 wave_size 32
 comment 115200") }, (FetchResultRange statusFetch) =>
-                Assert.Equal(new[] { "/glitch/city", "status" }, statusFetch.FilePath));
+                Assert.Equal(new[] { "/glitch/city/status" }, statusFetch.FilePath));
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.Now }, (FetchMetadata outputMetaFetch) =>
-                Assert.Equal(new[] { "/glitch/city", "output" }, outputMetaFetch.FilePath));
+                Assert.Equal(new[] { "/glitch/city/output" }, outputMetaFetch.FilePath));
 
             var result = await runner.RunAsync("Debug", steps);
 
@@ -559,14 +500,14 @@ comment 115200") }, (FetchResultRange statusFetch) =>
             {
                 new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "va11" },
                 new ReadDebugDataStep(
-                    outputFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "output", CheckTimestamp = true },
-                    watchesFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "watches", CheckTimestamp = false },
-                    dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "status", CheckTimestamp = false },
+                    outputFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "/glitch/city/output", CheckTimestamp = true },
+                    watchesFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "/glitch/city/watches", CheckTimestamp = false },
+                    dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "/glitch/city/status", CheckTimestamp = false },
                     binaryOutput: false, outputOffset: 1)
             };
 
             var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/glitch/city"), _project);
+            var runner = new ActionRunner(channel.Object, null, null);
 
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.FileNotFound });
             channel.ThenRespond(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0 });
@@ -593,7 +534,7 @@ wave_size 64") });
 
             Assert.True(result.Successful);
             Assert.True(channel.AllInteractionsHandled);
-            Assert.Equal(@"Output file (output) is smaller than expected.
+            Assert.Equal(@"Output file (/glitch/city/output) is smaller than expected.
 
 Grid size as specified in the dispatch parameters file is (16384, 1, 1), which corresponds to 16384 lanes. With 4 DWORDs per lane, the output file is expected to contain at least 65536 DWORDs, but it only contains 65535 DWORDs.",
             result.StepResults[1].Warning);
@@ -605,35 +546,35 @@ Grid size as specified in the dispatch parameters file is (16384, 1, 1), which c
             var steps = new List<IActionStep>
             {
                 new ReadDebugDataStep(
-                    outputFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "remote/output", CheckTimestamp = true },
-                    watchesFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "remote/watches", CheckTimestamp = true },
-                    dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "remote/status", CheckTimestamp = true },
+                    outputFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "/remote/output", CheckTimestamp = true },
+                    watchesFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "/remote/watches", CheckTimestamp = true },
+                    dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Remote, Path = "/remote/status", CheckTimestamp = true },
                     binaryOutput: true, outputOffset: 0)
             };
 
             var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/glitch/city"), _project);
+            var runner = new ActionRunner(channel.Object, null, null);
 
             /* File not found */
 
             for (int i = 0; i < 3; ++i) // initial timestamp fetch
                 channel.ThenRespond(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.FromFileTime(i) });
-            channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.FileNotFound }, (FetchResultRange w) => Assert.Equal("remote/watches", w.FilePath[1]));
+            channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.FileNotFound }, (FetchResultRange w) => Assert.Equal(new[] { "/remote/watches" }, w.FilePath));
 
             var result = await runner.RunAsync("Debug", steps);
             Assert.False(result.StepResults[0].Successful);
-            Assert.Equal("Valid watches file (remote/watches) could not be found.", result.StepResults[0].Warning);
+            Assert.Equal("Valid watches file (/remote/watches) could not be found.", result.StepResults[0].Warning);
 
             /* File not changed */
 
             for (int i = 0; i < 3; ++i) // initial timestamp fetch
                 channel.ThenRespond(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.FromFileTime(i) });
             channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.Successful, Timestamp = DateTime.FromFileTime(0) },
-                (FetchResultRange w) => Assert.Equal("remote/watches", w.FilePath[1]));
+                (FetchResultRange w) => Assert.Equal(new[] { "/remote/watches" }, w.FilePath));
 
             result = await runner.RunAsync("Debug", steps);
             Assert.False(result.StepResults[0].Successful);
-            Assert.Equal("Valid watches file (remote/watches) was not modified.", result.StepResults[0].Warning);
+            Assert.Equal("Valid watches file (/remote/watches) was not modified.", result.StepResults[0].Warning);
         }
 
         [Theory]
@@ -670,7 +611,7 @@ Grid size as specified in the dispatch parameters file is (16384, 1, 1), which c
                     dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Local, Path = dispatchParamsFile, CheckTimestamp = false },
                     binaryOutput: true, outputOffset)
             };
-            var runner = new ActionRunner(null, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), ""), _project);
+            var runner = new ActionRunner(null, null, null);
             var result = await runner.RunAsync("Debug", steps);
 
             Assert.True(result.Successful);
@@ -709,7 +650,7 @@ Grid size as specified in the dispatch parameters file is (16384, 1, 1), which c
                     dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Local, Path = dispatchParamsFile, CheckTimestamp = false },
                     binaryOutput: false, outputOffset: 1)
             };
-            var runner = new ActionRunner(null, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), "", watches: new ReadOnlyCollection<string>(new[] { "const" })), _project);
+            var runner = new ActionRunner(null, null, new ReadOnlyCollection<string>(new[] { "const" }));
             var result = await runner.RunAsync("Debug", steps);
 
             Assert.True(result.Successful);
@@ -728,25 +669,24 @@ Grid size as specified in the dispatch parameters file is (16384, 1, 1), which c
         public async Task ReadDebugDataLocalErrorTestAsync()
         {
             var outputFile = Path.GetTempFileName();
-            var fileName = Path.GetFileName(outputFile);
 
             var steps = new List<IActionStep>
             {
                 new ReadDebugDataStep(
-                    outputFile: new BuiltinActionFile { Location = StepEnvironment.Local, Path = fileName, CheckTimestamp = true },
+                    outputFile: new BuiltinActionFile { Location = StepEnvironment.Local, Path = outputFile, CheckTimestamp = true },
                     watchesFile: new BuiltinActionFile(),
                     dispatchParamsFile: new BuiltinActionFile(),
                     binaryOutput: true, outputOffset: 0)
             };
 
             var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: ""), _project);
+            var runner = new ActionRunner(channel.Object, null, null);
 
             /* File not changed (GetTempFileName creates an empty file) */
 
             var result = await runner.RunAsync("Debug", steps);
             Assert.False(result.StepResults[0].Successful);
-            Assert.Equal($"Output file ({fileName}) was not modified. Data may be stale.", result.StepResults[0].Warning);
+            Assert.Equal($"Output file ({outputFile}) was not modified. Data may be stale.", result.StepResults[0].Warning);
 
             /* Access denied */
 
@@ -757,21 +697,14 @@ Grid size as specified in the dispatch parameters file is (16384, 1, 1), which c
             ((ReadDebugDataStep)steps[0]).OutputFile.CheckTimestamp = false;
             result = await runner.RunAsync("Debug", steps);
             Assert.False(result.StepResults[0].Successful);
-            Assert.Equal($"Output file could not be opened. Access to path {fileName} on the local machine is denied", result.StepResults[0].Warning);
+            Assert.Equal($"Output file could not be opened. Access to path {outputFile} on the local machine is denied", result.StepResults[0].Warning);
 
             /* File not found */
 
             File.Delete(outputFile);
             result = await runner.RunAsync("Debug", steps);
             Assert.False(result.StepResults[0].Successful);
-            Assert.Equal($"Output file could not be opened. File {fileName} is not found on the local machine", result.StepResults[0].Warning);
-
-            /* Invalid path */
-
-            ((ReadDebugDataStep)steps[0]).OutputFile.Path += "<>";
-            result = await runner.RunAsync("Debug", steps);
-            Assert.False(result.StepResults[0].Successful);
-            Assert.Equal($"Output file could not be opened. Local path contains illegal characters: \"{fileName}<>\"\r\nWorking directory: \"{Path.GetTempPath()}\"", result.StepResults[0].Warning);
+            Assert.Equal($"Output file could not be opened. File {outputFile} is not found on the local machine", result.StepResults[0].Warning);
         }
         #endregion
 
@@ -794,21 +727,21 @@ Grid size as specified in the dispatch parameters file is (16384, 1, 1), which c
                 readDebugData
             };
 
-            var runner = new ActionRunner(channel.Object, null, new ActionEnvironment(localWorkDir: Path.GetTempPath(), remoteWorkDir: "/home/parker"), _project);
+            var runner = new ActionRunner(channel.Object, null, null);
 
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.FromFileTime(100) }, (FetchMetadata command) =>
-                Assert.Equal(new[] { "/home/parker", "/home/parker/audio/checked" }, command.FilePath));
+                Assert.Equal(new[] { "/home/parker/audio/checked" }, command.FilePath));
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.FileNotFound }, (FetchMetadata command) =>
-                Assert.Equal(new[] { "/home/parker", "/home/parker/audio/master" }, command.FilePath));
+                Assert.Equal(new[] { "/home/parker/audio/master" }, command.FilePath));
 
             channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata(".", 1, DateTime.FromBinary(101)) } },
-                (ListFilesCommand command) => { Assert.Equal("/home/parker/audio/checked", command.Path); Assert.Equal("/home/parker", command.WorkDir); });
+                (ListFilesCommand command) => { Assert.Equal("/home/parker/audio/checked", command.Path); });
             channel.ThenRespond(new ResultRangeFetched { Data = Encoding.UTF8.GetBytes("TestCopyStepChecked") },
-                (FetchResultRange command) => Assert.Equal(new[] { "/home/parker", "/home/parker/audio/checked" }, command.FilePath));
+                (FetchResultRange command) => Assert.Equal(new[] { "/home/parker/audio/checked" }, command.FilePath));
             channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata(".", 1, DateTime.FromBinary(101)) } },
-                (ListFilesCommand command) => { Assert.Equal("/home/parker/audio/unchecked", command.Path); Assert.Equal("/home/parker", command.WorkDir); });
+                (ListFilesCommand command) => { Assert.Equal("/home/parker/audio/unchecked", command.Path); });
             channel.ThenRespond(new ResultRangeFetched { Data = Encoding.UTF8.GetBytes("TestCopyStepUnchecked") },
-                (FetchResultRange command) => Assert.Equal(new[] { "/home/parker", "/home/parker/audio/unchecked" }, command.FilePath));
+                (FetchResultRange command) => Assert.Equal(new[] { "/home/parker/audio/unchecked" }, command.FilePath));
 
             // ReadDebugDataStep
             channel.ThenRespond(new ResultRangeFetched());

--- a/VSRAD.PackageTests/Server/ActionRunnerTests.cs
+++ b/VSRAD.PackageTests/Server/ActionRunnerTests.cs
@@ -31,7 +31,7 @@ namespace VSRAD.PackageTests.Server
                 new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, IfNotModified = ActionIfNotModified.Fail, SourcePath = "/home/mizu/machete/tweened.tvpp", TargetPath = Path.GetTempFileName() }
             };
             var localTempFile = Path.GetRandomFileName();
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
 
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.FromBinary(100) }, (FetchMetadata command) =>
             {
@@ -58,7 +58,7 @@ namespace VSRAD.PackageTests.Server
         public async Task CopyFileRLRemoteErrorTestAsync()
         {
             var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
             var steps = new List<IActionStep>
             {
                 new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, IfNotModified = ActionIfNotModified.Fail, SourcePath = "/home/mizu/machete/key3_49", TargetPath = Path.GetRandomFileName() },
@@ -84,7 +84,7 @@ namespace VSRAD.PackageTests.Server
         public async Task CopyFileRLMissingParentDirectoryTestAsync()
         {
             var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
 
             var parentDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Assert.False(Directory.Exists(parentDir));
@@ -104,7 +104,7 @@ namespace VSRAD.PackageTests.Server
         public async Task CopyFileRLLocalErrorTestAsync()
         {
             var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
 
             var file = Path.GetTempFileName();
             File.SetAttributes(file, FileAttributes.ReadOnly);
@@ -121,7 +121,7 @@ namespace VSRAD.PackageTests.Server
         public async Task CopyFileLRRemoteErrorTestAsync()
         {
             var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
             var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.LocalToRemote, SourcePath = Path.GetTempFileName(), TargetPath = "/home/mizu/machete/raw3" } };
 
             channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata(".", default, default) } });
@@ -141,7 +141,7 @@ namespace VSRAD.PackageTests.Server
         public async Task CopyFileLocalErrorTestAsync()
         {
             var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
 
             var localPath = Path.GetTempFileName();
             var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.LocalToLocal, SourcePath = localPath, IfNotModified = ActionIfNotModified.Fail, TargetPath = Path.GetRandomFileName() } };
@@ -170,7 +170,7 @@ namespace VSRAD.PackageTests.Server
         [Fact]
         public async Task CopyFileLLTestAsync()
         {
-            var runner = new ActionRunner(null, null, null);
+            var runner = new ActionRunner(null, null, null, _project);
 
             var file = Path.GetTempFileName();
             var target = Path.GetTempFileName();
@@ -201,7 +201,7 @@ namespace VSRAD.PackageTests.Server
             File.SetLastWriteTimeUtc(tmpDir + "\\t2", new DateTime(1990, 1, 1));
 
             var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
             var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.LocalToRemote, SourcePath = tmpDir, TargetPath = "/home/mizu/rawdir", IfNotModified = ActionIfNotModified.DoNotCopy, IncludeSubdirectories = true } };
 
             // t is unchanged, t2's size is different, empty/ is missing
@@ -237,7 +237,7 @@ namespace VSRAD.PackageTests.Server
             var tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
             var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
             var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.LocalToRemote, SourcePath = tmpDir, TargetPath = "/home/mizu/rawdir", IfNotModified = ActionIfNotModified.DoNotCopy } };
 
             // Path does not exist
@@ -271,7 +271,7 @@ namespace VSRAD.PackageTests.Server
             File.SetLastWriteTimeUtc(tmpDir + "\\t2", new DateTime(1990, 1, 1));
 
             var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
             var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, SourcePath = "/home/mizu/rawdir", TargetPath = tmpDir, IfNotModified = ActionIfNotModified.DoNotCopy } };
 
             // t is unchanged, t2's size is different
@@ -308,7 +308,7 @@ namespace VSRAD.PackageTests.Server
             File.WriteAllText(tmpDir + "\\t", "test");
 
             var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
             var steps = new List<IActionStep> { new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, SourcePath = "/home/mizu/rawdir", TargetPath = tmpDir, IfNotModified = ActionIfNotModified.DoNotCopy } };
 
             // t's size is changed => it'll be requested
@@ -338,7 +338,7 @@ namespace VSRAD.PackageTests.Server
                 new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "dvd-prepare" },
                 new CopyFileStep { Direction = FileCopyDirection.RemoteToLocal, IfNotModified = ActionIfNotModified.Copy, TargetPath = "/home/parker/audio/unchecked", SourcePath = "" }, // should not be run
             };
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
 
             channel.ThenRespond(new ExecutionCompleted { Status = ExecutionStatus.CouldNotLaunch, Stdout = "", Stderr = "" });
             var result = await runner.RunAsync("UFOW", steps, false);
@@ -373,7 +373,7 @@ namespace VSRAD.PackageTests.Server
             {
                 new ExecuteStep { Environment = StepEnvironment.Local, Executable = "python.exe", Arguments = $"-c \"print('success', file=open(r'{file}', 'w'))\"", WorkingDirectory = Path.GetTempPath() }
             };
-            var runner = new ActionRunner(null, null, null);
+            var runner = new ActionRunner(null, null, null, _project);
             var result = await runner.RunAsync("", steps);
             Assert.True(result.Successful);
             Assert.Equal("", result.StepResults[0].Warning);
@@ -389,7 +389,7 @@ namespace VSRAD.PackageTests.Server
         {
             var channel = new MockCommunicationChannel();
             var steps = new List<IActionStep> { new ExecuteStep { Environment = StepEnvironment.Remote, Executable = "exe", WorkingDirectory = "/action/env/remote/dir" } };
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
 
             channel.ThenRespond<Execute, ExecutionCompleted>(new ExecutionCompleted(), command =>
             {
@@ -434,7 +434,7 @@ namespace VSRAD.PackageTests.Server
             // 4. Level 1 Copy File
             channel.ThenRespond(new ListFilesResponse { Files = new[] { new FileMetadata(".", default, DateTime.FromBinary(101)) } });
             channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Encoding.UTF8.GetBytes("file-contents") });
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
             var result = await runner.RunAsync("HTMT", level1Steps);
 
             Assert.True(result.Successful);
@@ -461,7 +461,7 @@ namespace VSRAD.PackageTests.Server
             };
 
             var channel = new MockCommunicationChannel(DebugServer.IPC.ServerPlatform.Linux);
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
 
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.FileNotFound }, (FetchMetadata initTimestampFetch) =>
                 Assert.Equal(new[] { "/glitch/city/output" }, initTimestampFetch.FilePath));
@@ -507,7 +507,7 @@ comment 115200") }, (FetchResultRange statusFetch) =>
             };
 
             var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
 
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.FileNotFound });
             channel.ThenRespond(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0 });
@@ -553,7 +553,7 @@ Grid size as specified in the dispatch parameters file is (16384, 1, 1), which c
             };
 
             var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
 
             /* File not found */
 
@@ -611,7 +611,7 @@ Grid size as specified in the dispatch parameters file is (16384, 1, 1), which c
                     dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Local, Path = dispatchParamsFile, CheckTimestamp = false },
                     binaryOutput: true, outputOffset)
             };
-            var runner = new ActionRunner(null, null, null);
+            var runner = new ActionRunner(null, null, null, _project);
             var result = await runner.RunAsync("Debug", steps);
 
             Assert.True(result.Successful);
@@ -650,7 +650,7 @@ Grid size as specified in the dispatch parameters file is (16384, 1, 1), which c
                     dispatchParamsFile: new BuiltinActionFile { Location = StepEnvironment.Local, Path = dispatchParamsFile, CheckTimestamp = false },
                     binaryOutput: false, outputOffset: 1)
             };
-            var runner = new ActionRunner(null, null, new ReadOnlyCollection<string>(new[] { "const" }));
+            var runner = new ActionRunner(null, null, new ReadOnlyCollection<string>(new[] { "const" }), _project);
             var result = await runner.RunAsync("Debug", steps);
 
             Assert.True(result.Successful);
@@ -680,7 +680,7 @@ Grid size as specified in the dispatch parameters file is (16384, 1, 1), which c
             };
 
             var channel = new MockCommunicationChannel();
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
 
             /* File not changed (GetTempFileName creates an empty file) */
 
@@ -727,7 +727,7 @@ Grid size as specified in the dispatch parameters file is (16384, 1, 1), which c
                 readDebugData
             };
 
-            var runner = new ActionRunner(channel.Object, null, null);
+            var runner = new ActionRunner(channel.Object, null, null, _project);
 
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.FromFileTime(100) }, (FetchMetadata command) =>
                 Assert.Equal(new[] { "/home/parker/audio/checked" }, command.FilePath));

--- a/VSRAD.PackageTests/Server/BreakStateTests.cs
+++ b/VSRAD.PackageTests/Server/BreakStateTests.cs
@@ -16,7 +16,7 @@ namespace VSRAD.PackageTests.Server
         {
             var channel = new MockCommunicationChannel();
             var watches = new ReadOnlyCollection<string>(new[] { "local_id", "group_id", "group_size" });
-            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "madoka" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
+            var file = new BreakStateOutputFile("/home/kyubey/projects/madoka", binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
             var breakStateData = new BreakStateData(watches, file);
 
             var data = new int[1024]; // 2 groups by 2 waves (1 wave = 64 lanes), each containing 1 system dword and 3 watch dwords
@@ -117,7 +117,7 @@ namespace VSRAD.PackageTests.Server
 
             var channel = new MockCommunicationChannel();
             var watches = new ReadOnlyCollection<string>(new[] { "local_id" });
-            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "madoka" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: watchCount * laneCount);
+            var file = new BreakStateOutputFile("/home/kyubey/projects/madoka", binaryOutput: true, offset: 0, timestamp: default, dwordCount: watchCount * laneCount);
             var breakStateData = new BreakStateData(watches, file);
 
             Assert.Equal(groupCount, breakStateData.GetGroupCount(groupSize, waveSize, 0));
@@ -157,13 +157,13 @@ namespace VSRAD.PackageTests.Server
         {
             var channel = new MockCommunicationChannel();
             var watches = new ReadOnlyCollection<string>(new[] { "h" });
-            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "log.tar" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
+            var file = new BreakStateOutputFile("/home/kyubey/projects/log.tar", binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
             var breakStateData = new BreakStateData(watches, file);
 
             channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Array.Empty<byte>() },
             (command) =>
             {
-                Assert.Equal(new[] { "/home/kyubey/projects", "log.tar" }, command.FilePath);
+                Assert.Equal(new[] { "/home/kyubey/projects/log.tar" }, command.FilePath);
             });
             var warning = await breakStateData.ChangeGroupWithWarningsAsync(channel.Object, groupIndex: 0, groupSize: 512, waveSize: 64, nGroups: 1);
             Assert.Equal("Group #0 is incomplete: expected to read 4096 bytes but the output file contains 0.", warning);
@@ -176,7 +176,7 @@ namespace VSRAD.PackageTests.Server
         {
             var channel = new MockCommunicationChannel();
             var watches = new ReadOnlyCollection<string>(new[] { "h" });
-            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "log.tar" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
+            var file = new BreakStateOutputFile("/home/kyubey/projects/log.tar", binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
             var breakStateData = new BreakStateData(watches, file);
 
             Assert.Equal(2, breakStateData.GetGroupCount(groupSize: 256, waveSize: 64, nGroups: 4));
@@ -201,7 +201,7 @@ namespace VSRAD.PackageTests.Server
             Buffer.BlockCopy(data, 0, localData, 0, localData.Length);
 
             var watches = new ReadOnlyCollection<string>(new[] { "local_id" });
-            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "madoka" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: 2 * 256);
+            var file = new BreakStateOutputFile("/home/kyubey/projects/madoka", binaryOutput: true, offset: 0, timestamp: default, dwordCount: 2 * 256);
             var breakStateData = new BreakStateData(watches, file, localData);
 
             var warning = await breakStateData.ChangeGroupWithWarningsAsync(channel: null, groupIndex: 1, groupSize: 64, waveSize: 32, nGroups: 2);


### PR DESCRIPTION
#190 but targeted on `dev-stable`.

Original description by @timlathy:

This PR closes #160. See the issue for an overview of the capability checking mechanism.

In addition to the server capabilities check, this PR includes a change to how paths in action steps are resolved. Previously, remote paths that were relative to the working directory (`$(RemoteWorkDir)`) could not be converted to absolute paths on the extension side because we couldn't tell whether the remote host uses Windows or Unix paths. Now the server identifies its platform along with capabilities, so we can join paths on the VS side and send just the absolute path in IPC commands.