### PR TITLE
Debug Server WSL debugging

### DIFF
--- a/VSRAD.DebugServer/Properties/launchSettings.json
+++ b/VSRAD.DebugServer/Properties/launchSettings.json
@@ -3,6 +3,11 @@
     "VSRAD.DebugServer": {
       "commandName": "Project",
       "commandLineArgs": "9339"
+    },
+    "WSL": {
+      "commandName": "WSL2",
+      "environmentVariables": {},
+      "distributionName": ""
     }
   }
 }


### PR DESCRIPTION
This PR modifies `Debug Server` project configuration so it is possible to debug linux build of `Debug Server` in `Visual Studio` using ssh port forwarding and other VS instance with running extension to simulate working with remote host.

This feature is very convenient for debuging the linux-specific `Debug Server` features.