### PR TITLE
Separate Continue On Errors setting for every action

### DIFF
--- a/VSRAD.Package/Options/ProfileOptions.cs
+++ b/VSRAD.Package/Options/ProfileOptions.cs
@@ -71,6 +71,9 @@ namespace VSRAD.Package.Options
             }
         }
 
+        private bool _continueOnError = false;
+        public bool ContinueOnError { get => _continueOnError; set => SetField(ref _continueOnError, value); }
+
         public const string BuiltinActionDebug = "Debug";
 
         [JsonProperty(ItemConverterType = typeof(ActionStepJsonConverter))]
@@ -78,7 +81,7 @@ namespace VSRAD.Package.Options
 
         public async Task<Result<ActionProfileOptions>> EvaluateAsync(IMacroEvaluator evaluator, ActionEvaluationEnvironment env)
         {
-            var evaluated = new ActionProfileOptions { Name = Name };
+            var evaluated = new ActionProfileOptions { Name = Name, ContinueOnError = ContinueOnError };
             foreach (var step in Steps)
             {
                 if ((await step.EvaluateAsync(evaluator, env, Name)).TryGetResult(out var evaluatedStep, out var error))
@@ -98,9 +101,6 @@ namespace VSRAD.Package.Options
 
         private bool _runActionsLocally = false;
         public bool RunActionsLocally { get => _runActionsLocally; set => SetField(ref _runActionsLocally, value); }
-
-        private bool _continueActionExecOnError = false;
-        public bool ContinueActionExecOnError { get => _continueActionExecOnError; set => SetField(ref _continueActionExecOnError, value); }
 
         private string _localWorkDir = "$(" + CleanProfileMacros.LocalWorkDir + ")";
         public string LocalWorkDir { get => _localWorkDir; set => SetField(ref _localWorkDir, value); }

--- a/VSRAD.Package/ProjectSystem/ActionLauncher.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLauncher.cs
@@ -126,7 +126,7 @@ namespace VSRAD.Package.ProjectSystem
                 _projectSources.SaveProjectState();
 
                 var runner = new ActionRunner(_channel, _serviceProvider, transients.Watches, _project);
-                var runResult = await runner.RunAsync(action.Name, action.Steps, _project.Options.Profile.General.ContinueActionExecOnError).ConfigureAwait(false);
+                var runResult = await runner.RunAsync(action.Name, action.Steps, action.ContinueOnError).ConfigureAwait(false);
                 var actionError = await _actionLogger.LogActionWithWarningsAsync(runResult).ConfigureAwait(false);
                 return new ActionExecution(actionError, transients, runResult);
             }

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml
@@ -115,7 +115,6 @@
                                 <RowDefinition Height="26"/>
                                 <RowDefinition Height="26"/>
                                 <RowDefinition Height="26"/>
-                                <RowDefinition Height="26"/>
                             </Grid.RowDefinitions>
                             <Label Content="Profile Name:" VerticalContentAlignment="Center" Margin="0,0" Padding="4,0" Height="22" Grid.Row="0" Grid.Column="0"/>
                             <TextBox Height="22" VerticalContentAlignment="Center" Grid.Row="0" Grid.Column="1">
@@ -155,13 +154,6 @@
                                     Command="{Binding DataContext.RichEditCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"
                                     CommandParameter="{Binding RelativeSource={RelativeSource Self}}"
                                     IsEnabled="{Binding RunActionsLocally, Mode=OneWay, Converter={StaticResource InverseBoolConverter}}"/>
-
-                            <StackPanel Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal">
-                                <Label Content="Continue action execution on errors:" VerticalContentAlignment="Center" Margin="0,0" Padding="4,0" Height="22" HorizontalContentAlignment="Left"/>
-                                <CheckBox VerticalContentAlignment="Center" Height="22"
-                                      IsChecked="{Binding ContinueActionExecOnError, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                      ToolTip="Continue action execution on errors"/>
-                            </StackPanel>
                         </Grid>
                     </ScrollViewer>
                 </DataTemplate>
@@ -223,6 +215,7 @@
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="26"/>
+                                <RowDefinition Height="26"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
                             <Label Content="Name:" VerticalContentAlignment="Center" Margin="0,0" Padding="4,0" Height="22" Grid.Row="0" Grid.Column="0"/>
@@ -244,10 +237,13 @@
                                     </Style>
                                 </TextBox.Style>
                             </TextBox>
-                            <local:ActionEditor Steps="{Binding Steps}" Grid.Row="1" Grid.ColumnSpan="2" ActionName="{Binding Name}"
-                                                AllActionNames="{Binding DataContext.ActionsPage.ActionNames, ElementName=Root}"
-                                                MacroEditor="{Binding DataContext.MacroEditor, ElementName=Root}"
-                                                CurrentProfile="{Binding DataContext.SelectedProfile, ElementName=Root}" />
+                            <Label Content="Continue execution on errors:" VerticalContentAlignment="Center" Margin="0,0" Padding="4,0" Height="22" Grid.Row="1" Grid.Column="0"/>
+                            <CheckBox IsChecked="{Binding ContinueOnError, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalContentAlignment="Center" Height="22"
+                                      Grid.Row="1" Grid.Column="1" ToolTip="Continue action execution on errors" />
+                            <local:ActionEditor Steps="{Binding Steps}" Grid.Row="2" Grid.ColumnSpan="2" ActionName="{Binding Name}"
+                                            AllActionNames="{Binding DataContext.ActionsPage.ActionNames, ElementName=Root}"
+                                            MacroEditor="{Binding DataContext.MacroEditor, ElementName=Root}"
+                                            CurrentProfile="{Binding DataContext.SelectedProfile, ElementName=Root}" />
                         </Grid>
                     </ScrollViewer>
                 </DataTemplate>


### PR DESCRIPTION
There is cases when different actions inside one profile require different `Continue execution on errors` value. This PR provides separate `Continue execution on errors` checkbox for every action instead of one for whole profile as before.

`Continue execution on errors` moved from `General` tab of profile settings to the Action settings window, between `Name` and `Steps`:

![image](https://user-images.githubusercontent.com/39794543/137502360-658bc925-e442-482d-9953-69485bac482f.png)
