### PR TITLE
Clear RAD Output on every action run

### DIFF
--- a/VSRAD.Package/ProjectSystem/ActionLogger.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLogger.cs
@@ -27,6 +27,8 @@ namespace VSRAD.Package.ProjectSystem
 
         public async Task<Error?> LogActionWithWarningsAsync(ActionRunResult runResult)
         {
+            await _outputWriter.ClearAsync();
+
             var title = runResult.ActionName + " action " + (runResult.Successful ? "SUCCEEDED" : "FAILED") + $" in {runResult.TotalMillis}ms";
 
             var log = new StringBuilder();


### PR DESCRIPTION
This PR modifies the behavior of the `RAD Output` pane. Now it is cleared before every action execution, which means that it stores only info about last action run.