### PR TITLE
Ux improvements [stable]

### DIFF
--- a/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerHeaderControl.xaml
@@ -9,7 +9,7 @@
              xmlns:utils="clr-namespace:VSRAD.Package.Utils"
              mc:Ignorable="d"
              x:Name="Root"
-             d:DesignHeight="140" d:DesignWidth="720">
+             d:DesignHeight="200" d:DesignWidth="720">
     <UserControl.ContextMenu>
         <ContextMenu>
             <MenuItem Header="Show hidden system variable" IsChecked="{Binding Options.VisualizerOptions.ShowSystemVariable, Mode=TwoWay}" IsCheckable="True"/>
@@ -18,7 +18,8 @@
             <MenuItem IsEnabled="False" Header="Show:"/>
             <MenuItem Header="Columns" IsChecked="{Binding Options.VisualizerOptions.ShowColumnsField, Mode=TwoWay}" IsCheckable="True"/>
             <MenuItem Header="App args" IsChecked="{Binding Options.VisualizerOptions.ShowAppArgsField, Mode=TwoWay}" IsCheckable="True"/>
-            <MenuItem Header="Break args" IsChecked="{Binding Options.VisualizerOptions.ShowBreakArgsField, Mode=TwoWay}" IsCheckable="True"/>
+            <MenuItem Header="App args 2" IsChecked="{Binding Options.VisualizerOptions.ShowAppArgs2Field, Mode=TwoWay}" IsCheckable="True"/>
+            <MenuItem Header="App args 3" IsChecked="{Binding Options.VisualizerOptions.ShowAppArgs3Field, Mode=TwoWay}" IsCheckable="True"/>
             <MenuItem Header="Wavemap" IsChecked="{Binding Options.VisualizerOptions.ShowWavemap, Mode=TwoWay}" IsCheckable="True"/>
         </ContextMenu>
     </UserControl.ContextMenu>
@@ -286,7 +287,19 @@
                         <Style TargetType="RowDefinition">
                             <Setter Property="Height" Value="Auto" />
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding Options.VisualizerOptions.ShowBreakArgsField}" Value="False">
+                                <DataTrigger Binding="{Binding Options.VisualizerOptions.ShowAppArgs2Field}" Value="False">
+                                    <Setter Property="Height" Value="0" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </RowDefinition.Style>
+                </RowDefinition>
+                <RowDefinition>
+                    <RowDefinition.Style>
+                        <Style TargetType="RowDefinition">
+                            <Setter Property="Height" Value="Auto" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Options.VisualizerOptions.ShowAppArgs3Field}" Value="False">
                                     <Setter Property="Height" Value="0" />
                                 </DataTrigger>
                             </Style.Triggers>
@@ -308,7 +321,8 @@
             </Grid.RowDefinitions>
             <Label Grid.Row="0" Grid.Column="0" Content="Columns:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
             <Label Grid.Row="1" Grid.Column="0" Content="App args:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
-            <Label Grid.Row="2" Grid.Column="0" Content="Break args:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
+            <Label Grid.Row="2" Grid.Column="0" Content="App args 2:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
+            <Label Grid.Row="3" Grid.Column="0" Content="App args 3:" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
             <TextBox Text="{Binding Options.VisualizerColumnStyling.VisibleColumns, UpdateSourceTrigger=PropertyChanged}"
                      Grid.Row="0" Grid.Column="1" Height="24" VerticalContentAlignment="Center"
                      Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
@@ -318,12 +332,17 @@
                       IsEditable="True" Grid.Column="1" Height="24" VerticalContentAlignment="Center"
                       ItemsSource="{Binding Options.DebuggerOptions.LastAppArgs, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}"
                       DisplayMemberPath="Value" x:Name="LastAppArgsCombo" Grid.Row="1" IsTextSearchEnabled="False"/>
-            <TextBox Text="{Binding Options.DebuggerOptions.BreakArgs, UpdateSourceTrigger=PropertyChanged}"
+            <TextBox Text="{Binding Options.DebuggerOptions.AppArgs2, UpdateSourceTrigger=PropertyChanged}"
                      Grid.Row="2" Grid.Column="1" Height="24" VerticalContentAlignment="Center"
                      Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
                      Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
                      BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
-            <Grid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Stretch">
+            <TextBox Text="{Binding Options.DebuggerOptions.AppArgs3, UpdateSourceTrigger=PropertyChanged}"
+                     Grid.Row="3" Grid.Column="1" Height="24" VerticalContentAlignment="Center"
+                     Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+                     Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
+                     BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
+            <Grid Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Stretch">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="85"/>
                     <ColumnDefinition Width="*"/>

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -36,8 +36,11 @@ namespace VSRAD.Package.Options
         private string _appArgs = "";
         public string AppArgs { get => _appArgs; set => SetField(ref _appArgs, value); }
 
-        private string _breakArgs = "";
-        public string BreakArgs { get => _breakArgs; set => SetField(ref _breakArgs, value); }
+        private string _appArgs2 = "";
+        public string AppArgs2 { get => _appArgs2; set => SetField(ref _appArgs2, value); }
+
+        private string _appArgs3 = "";
+        public string AppArgs3 { get => _appArgs3; set => SetField(ref _appArgs3, value); }
 
         private bool _autosave = true;
         public bool Autosave { get => _autosave; set => SetField(ref _autosave, value); }

--- a/VSRAD.Package/Options/DefaultOptionValues.cs
+++ b/VSRAD.Package/Options/DefaultOptionValues.cs
@@ -14,7 +14,7 @@ namespace VSRAD.Package.Options
         #endregion
         #region Debugger
         public const string DebuggerExecutable = "python.exe";
-        public const string DebuggerArguments = "script.py -w $(" + RadMacros.Watches + ") -l $(" + RadMacros.BreakLine + ") -v \"$(" + RadMacros.DebugAppArgs + ")\" -t $(" + RadMacros.Counter + ") -p \"$(" + RadMacros.DebugBreakArgs + ")\" -f \"$(" + RadMacros.ActiveSourceFile + ")\" -o \"$(" + RadMacros.DebuggerOutputPath + ")\"";
+        public const string DebuggerArguments = "script.py -w $(" + RadMacros.Watches + ") -l $(" + RadMacros.BreakLine + ") -v \"$(" + RadMacros.DebugAppArgs + ")\" -t $(" + RadMacros.Counter + ") -p \"$(" + RadMacros.DebugAppArgs2 + ")\" -f \"$(" + RadMacros.ActiveSourceFile + ")\" -o \"$(" + RadMacros.DebuggerOutputPath + ")\"";
         public const string DebuggerWorkingDirectory = "$(" + RadMacros.DeployDirectory + ")";
         public const string DebuggerOutputPath = "";
         public const bool DebuggerBinaryOutput = false;

--- a/VSRAD.Package/Options/VisualizerOptions.cs
+++ b/VSRAD.Package/Options/VisualizerOptions.cs
@@ -41,9 +41,13 @@ namespace VSRAD.Package.Options
         [DefaultValue(true)]
         public bool ShowAppArgsField { get => _showAppArgsField; set => SetField(ref _showAppArgsField, value); }
 
-        private bool _showBreakArgsField;
+        private bool _showAppArgs2Field;
         [DefaultValue(true)]
-        public bool ShowBreakArgsField { get => _showBreakArgsField; set => SetField(ref _showBreakArgsField, value); }
+        public bool ShowAppArgs2Field { get => _showAppArgs2Field; set => SetField(ref _showAppArgs2Field, value); }
+
+        private bool _showAppArgs3Field;
+        [DefaultValue(true)]
+        public bool ShowAppArgs3Field { get => _showAppArgs3Field; set => SetField(ref _showAppArgs3Field, value); }
 
         private bool _showWavemap;
         [DefaultValue(true)]

--- a/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
+++ b/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
@@ -30,6 +30,10 @@ namespace VSRAD.Package.ProjectSystem
 
         // this regex matches words like `\vargs` without indices like [0]
         private static readonly Regex _activeWordWithoutBracketsRegex = new Regex(@"[\w\\$]*", RegexOptions.Compiled | RegexOptions.Singleline);
+        // this regex find matches like `\vargs[kernarg_1:kernarg_2]`
+        private static readonly Regex _activeWordWithBracketsRegex = new Regex(@"[\w\\$]*\[[^\[\]]*\]", RegexOptions.Compiled | RegexOptions.Singleline);
+        // this regex find empty brackets
+        private static readonly Regex _emptyBracketsRegex = new Regex(@"\[\s*\]", RegexOptions.Compiled);
 
         [ImportingConstructor]
         public ActiveCodeEditor(SVsServiceProvider serviceProvider, ITextDocumentFactoryService textDocumentService)
@@ -60,7 +64,8 @@ namespace VSRAD.Package.ProjectSystem
             if (activeWord.Length == 0)
             {
                 var wpfTextView = GetTextViewFromVsTextView(GetActiveTextView());
-                activeWord = GetWordOnPosition(wpfTextView.TextBuffer, wpfTextView.Caret.Position.BufferPosition);
+                activeWord = GetWordOnPosition(wpfTextView.TextBuffer, wpfTextView.Caret.Position.BufferPosition,
+                    matchBrackets);
             }
             return activeWord.Trim();
         }
@@ -72,7 +77,9 @@ namespace VSRAD.Package.ProjectSystem
             var caretIndex = position - line.Start;
 
             // check actual word
-            foreach (Match match in _activeWordWithoutBracketsRegex.Matches(lineText))
+            foreach (Match match in matchBrackets
+                            ? _activeWordWithBracketsRegex.Matches(lineText)
+                            : _activeWordWithoutBracketsRegex.Matches(lineText))
             {
                 if (match.Index <= caretIndex && (match.Index + match.Length) >= caretIndex)
                 {

--- a/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
+++ b/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
@@ -30,10 +30,6 @@ namespace VSRAD.Package.ProjectSystem
 
         // this regex matches words like `\vargs` without indices like [0]
         private static readonly Regex _activeWordWithoutBracketsRegex = new Regex(@"[\w\\$]*", RegexOptions.Compiled | RegexOptions.Singleline);
-        // this regex find matches like `\vargs[kernarg_1:kernarg_2]`
-        private static readonly Regex _activeWordWithBracketsRegex = new Regex(@"[\w\\$]*\[[^\[\]]*\]", RegexOptions.Compiled | RegexOptions.Singleline);
-        // this regex find empty brackets
-        private static readonly Regex _emptyBracketsRegex = new Regex(@"\[\s*\]", RegexOptions.Compiled);
 
         [ImportingConstructor]
         public ActiveCodeEditor(SVsServiceProvider serviceProvider, ITextDocumentFactoryService textDocumentService)
@@ -64,8 +60,7 @@ namespace VSRAD.Package.ProjectSystem
             if (activeWord.Length == 0)
             {
                 var wpfTextView = GetTextViewFromVsTextView(GetActiveTextView());
-                activeWord = GetWordOnPosition(wpfTextView.TextBuffer, wpfTextView.Caret.Position.BufferPosition,
-                    matchBrackets);
+                activeWord = GetWordOnPosition(wpfTextView.TextBuffer, wpfTextView.Caret.Position.BufferPosition);
             }
             return activeWord.Trim();
         }
@@ -77,9 +72,7 @@ namespace VSRAD.Package.ProjectSystem
             var caretIndex = position - line.Start;
 
             // check actual word
-            foreach (Match match in matchBrackets
-                            ? _activeWordWithBracketsRegex.Matches(lineText)
-                            : _activeWordWithoutBracketsRegex.Matches(lineText))
+            foreach (Match match in _activeWordWithoutBracketsRegex.Matches(lineText))
             {
                 if (match.Index <= caretIndex && (match.Index + match.Length) >= caretIndex)
                 {

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
@@ -79,7 +79,8 @@ namespace VSRAD.Package.ProjectSystem.Macros
         public const string AWatches = "RadAWatches";
         public const string BreakLine = "RadBreakLine";
         public const string DebugAppArgs = "RadDebugAppArgs";
-        public const string DebugBreakArgs = "RadDebugBreakArgs";
+        public const string DebugAppArgs2 = "RadDebugAppArgs2";
+        public const string DebugAppArgs3 = "RadDebugAppArgs3";
         public const string Counter = "RadCounter";
         public const string NGroups = "RadNGroups";
         public const string GroupSize = "RadGroupSize";
@@ -134,7 +135,8 @@ namespace VSRAD.Package.ProjectSystem.Macros
                 { RadMacros.AWatches, string.Join(":", debuggerOptions.GetAWatchSnapshot()) },
                 { RadMacros.BreakLine, string.Join(":", values.BreakLines ?? new[] { 0u }) },
                 { RadMacros.DebugAppArgs, debuggerOptions.AppArgs },
-                { RadMacros.DebugBreakArgs, debuggerOptions.BreakArgs },
+                { RadMacros.DebugAppArgs2, debuggerOptions.AppArgs2 },
+                { RadMacros.DebugAppArgs3, debuggerOptions.AppArgs3 },
                 { RadMacros.Counter, debuggerOptions.Counter.ToString() },
                 { RadMacros.NGroups, debuggerOptions.NGroups.ToString() },
                 { RadMacros.GroupSize, debuggerOptions.GroupSize.ToString() }

--- a/VSRAD.Package/ProjectSystem/Macros/MacroListEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroListEditor.xaml.cs
@@ -48,7 +48,8 @@ namespace VSRAD.Package.ProjectSystem.Macros
             new MacroItem(RadMacros.Watches, "<visualizer watches, colon-separated>", userDefined: false),
             new MacroItem(RadMacros.BreakLine, "<next breakpoint line(s), colon-separated>", userDefined: false),
             new MacroItem(RadMacros.DebugAppArgs, "<app args, set in visualizer>", userDefined: false),
-            new MacroItem(RadMacros.DebugBreakArgs, "<break args, set in visualizer>", userDefined: false),
+            new MacroItem(RadMacros.DebugAppArgs2, "<app args 2, set in visualizer>", userDefined: false),
+            new MacroItem(RadMacros.DebugAppArgs3, "<app args 3, set in visualizer>", userDefined: false),
             new MacroItem(RadMacros.Counter, "<counter, set in visualizer>", userDefined: false),
             new MacroItem(RadMacros.NGroups, "<ngroups, set in visualizer>", userDefined: false),
             new MacroItem(RadMacros.GroupSize, "<group size, set in visualizer>", userDefined: false)

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
@@ -43,6 +43,10 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             var visualizerAppearance = json["VisualizerAppearance"].ToObject<VisualizerAppearance>();
             var visualizerColumnStyling = json["VisualizerColumnStyling"].ToObject<DebugVisualizer.ColumnStylingOptions>();
             var activeProfile = json["ActiveProfile"].ToString();
+            var breakArgs = json["DebuggerOptions"]["BreakArgs"].ToString();
+
+            if (breakArgs != null)
+                debuggerOptions.AppArgs2 = breakArgs;
 
             var options = new ProjectOptions(
                 debuggerOptions,
@@ -56,6 +60,8 @@ namespace VSRAD.Package.ProjectSystem.Profiles
                 foreach (var host in json["TargetHosts"].ToObject<List<string>>())
                     options.TargetHosts.Add(host);
 
+            foreach (var host in options.TargetHosts)
+                options.TargetHosts.Add(host);
             options.ActiveProfile = activeProfile;
 
             return options;

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
@@ -60,8 +60,6 @@ namespace VSRAD.Package.ProjectSystem.Profiles
                 foreach (var host in json["TargetHosts"].ToObject<List<string>>())
                     options.TargetHosts.Add(host);
 
-            foreach (var host in options.TargetHosts)
-                options.TargetHosts.Add(host);
             options.ActiveProfile = activeProfile;
 
             return options;


### PR DESCRIPTION
#201 but targeted on `dev-stable`. Diff:

* No changes connected to `Open in editor` since this feature is done by #246.
* No fix NRE if old config file didn't had TargetHosts field, done by #254

Original description with respect to diff:

Changed:

* Renamed `Break Args` field to `App Args 2`, `RadDebugBreakArgs` macro to `RadDebugAppArgs2`;
* Previously, `Add to watches` feature selected active word including indices (`var[a][b][c]`), now it ignores them (in previous example just `var` will be added to the watch list).

Added:

* `App Args 3` field and corresponding macro `RadDebugAppArgs3`.
