### PR TITLE
Asm2 lexer update

### DIFF
--- a/VSRAD.Syntax/Core/Lexer/Asm2Lexer.cs
+++ b/VSRAD.Syntax/Core/Lexer/Asm2Lexer.cs
@@ -1,4 +1,4 @@
-﻿using Antlr4.Runtime;
+using Antlr4.Runtime;
 using Microsoft.VisualStudio.Text;
 using System.Collections.Generic;
 using VSRAD.Syntax.Core.Tokens;
@@ -92,6 +92,7 @@ namespace VSRAD.Syntax.Core.Lexer
             { RadAsm2Lexer.BITAND, RadAsmTokenType.Operation },
             { RadAsm2Lexer.BITXOR, RadAsmTokenType.Operation },
             { RadAsm2Lexer.BITNOT, RadAsmTokenType.Operation },
+            { RadAsm2Lexer.RARROW, RadAsmTokenType.Operation },
 
             { RadAsm2Lexer.ESCAPE, RadAsmTokenType.Structural },
             { RadAsm2Lexer.COMMA, RadAsmTokenType.Comma },

--- a/VSRAD.Syntax/Core/Lexer/Asm2Lexer.cs
+++ b/VSRAD.Syntax/Core/Lexer/Asm2Lexer.cs
@@ -93,6 +93,7 @@ namespace VSRAD.Syntax.Core.Lexer
             { RadAsm2Lexer.BITXOR, RadAsmTokenType.Operation },
             { RadAsm2Lexer.BITNOT, RadAsmTokenType.Operation },
 
+            { RadAsm2Lexer.ESCAPE, RadAsmTokenType.Structural },
             { RadAsm2Lexer.COMMA, RadAsmTokenType.Comma },
             { RadAsm2Lexer.SEMI, RadAsmTokenType.Semi },
             { RadAsm2Lexer.COLON, RadAsmTokenType.Colon },

--- a/VSRAD.SyntaxParser/RadAsm2.g4
+++ b/VSRAD.SyntaxParser/RadAsm2.g4
@@ -1,4 +1,4 @@
-﻿grammar RadAsm2;
+grammar RadAsm2;
 
 function
     : FUNCTION END
@@ -73,7 +73,7 @@ BUILTIN_FUNCTION
     | 'float'
     | 'floor'
     | 'map'
-    | 'zip_with'
+    | 'zip'
     | 'head'
     | 'tail'
     | 'take'

--- a/VSRAD.SyntaxParser/RadAsm2.g4
+++ b/VSRAD.SyntaxParser/RadAsm2.g4
@@ -1,4 +1,4 @@
-﻿grammar RadAsm2;
+grammar RadAsm2;
 
 function
     : FUNCTION END
@@ -142,6 +142,7 @@ BITNOT  : '~'   ;
 
 /* "Structural symbols" */
 
+ESCAPE     : '\\';
 COMMA      : ',' ;
 SEMI       : ';' ;
 COLON      : ':' ;
@@ -207,5 +208,5 @@ EOL
     ;
 
 UNKNOWN
-    : ~[ \t\r\n,:;?()[\]{}=<>!&|~+\\-*%^/]+
+    : ~[ \t\r\n,:;?()[\]{}=<>!&|~+\\-*%^/\\]+
     ;

--- a/VSRAD.SyntaxParser/RadAsm2.g4
+++ b/VSRAD.SyntaxParser/RadAsm2.g4
@@ -1,4 +1,4 @@
-grammar RadAsm2;
+﻿grammar RadAsm2;
 
 function
     : FUNCTION END
@@ -13,10 +13,8 @@ BUILTIN_FUNCTION
     | 'sendmsg'
     | 'asic'
     | 'type'
-    | 'assert'
     | 'len'
     | 'lit'
-    | 'data'
     | 'abs'
     | 'abs_lo'
     | 'abs_hi'
@@ -67,10 +65,27 @@ BUILTIN_FUNCTION
     | 'set_cs'
     | 'load_collision_waveid'
     | 'load_intrawave_collision'
+    | 'assert'
     | 'align'
-    | 'label_offset'
+    | 'data'
     | 'label_diff'
     | 'label_diff_eq'
+    | 'float'
+    | 'floor'
+    | 'map'
+    | 'zip_with'
+    | 'head'
+    | 'tail'
+    | 'take'
+    | 'drop'
+    | 'rotate'
+    | 'replicate'
+    | 'reverse'
+    | 'cons'
+    | 'concat'
+    | 'list'
+    | 's_list'
+    | 'v_list'
     ;
 
 SHADER      : 'shader' ;

--- a/VSRAD.SyntaxParser/RadAsm2.g4
+++ b/VSRAD.SyntaxParser/RadAsm2.g4
@@ -1,4 +1,4 @@
-grammar RadAsm2;
+﻿grammar RadAsm2;
 
 function
     : FUNCTION END
@@ -154,6 +154,7 @@ BITOR   : '|'   ;
 BITAND  : '&'   ;
 BITXOR  : '^'   ;
 BITNOT  : '~'   ;
+RARROW  : '->'  ;
 
 /* "Structural symbols" */
 


### PR DESCRIPTION
This PR adds new lexer tokens for `asm2` syntax.

### Escape token
Added escape `\` token to fix identifier parsing which is joined with `\`.

Previously, **_arg1_** and **_arg2_** were not tokenized as identifiers (**_arg1\\_** and **_arg2\\_** were _UNKNOWN_ tokens). Because of what the parser did not work correctly in such a situation.  Now **_arg1\\_** is tokenized as 2 different tokens - _IDENTIFIER_, _ESCAPE_.

```
function (arg1\
         ,arg2\
         ,arg3)

end
```

### Native functions
Added new native functions: `float, floor, map, zip, head, tail, take, drop, rotate, replicate, reverse, cons, concat, list, s_list, v_list`

### Arrow operator
Added right arrow `->` operator used by lambdas.