### PR TITLE
Fix highlighting identifier concatinated with escape token

### DIFF
--- a/VSRAD.Syntax/Helpers/SnapshotPointExtension.cs
+++ b/VSRAD.Syntax/Helpers/SnapshotPointExtension.cs
@@ -34,7 +34,7 @@ namespace VSRAD.Syntax.Helpers
         private static bool IsSuitableChar(this SnapshotPoint snapshotPoint)
         {
             var pointChar = snapshotPoint.GetChar();
-            return char.IsLetterOrDigit(pointChar) || pointChar == '_' || pointChar == '\\' || pointChar == '.';
+            return char.IsLetterOrDigit(pointChar) || pointChar == '_' || pointChar == '.';
         }
     }
 }


### PR DESCRIPTION
Fixed identifier highlighting for such case (`value1`):

```
var value1 = 1
var value2 = 2
some_func(value1\
         ,value2)
```