### PR TITLE
Debug Visualizer Name column scaling

### DIFF
--- a/VSRAD.Package/DebugVisualizer/MouseMove/ScaleOperation.cs
+++ b/VSRAD.Package/DebugVisualizer/MouseMove/ScaleOperation.cs
@@ -44,7 +44,9 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
             _operationStarted = false;
             _orgMouseX = Cursor.Position.X;
             _orgeX = e.X;
-            _orgWidth = _isNameColumn ? _table.Columns[0].Width : _tableState.ColumnWidth;
+            _orgWidth = _isNameColumn
+                            ? _table.Columns[_tableState.NameColumnIndex].Width
+                            : _tableState.ColumnWidth;
             _orgScroll = _tableState.GetCurrentScroll();
             _orgNColumns = _tableState.CountVisibleDataColumns(hit.ColumnIndex, !leftedge);
             _orgSColumns = _orgScroll / _orgWidth;
@@ -56,6 +58,10 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
 
         public static bool ShouldChangeCursor(DataGridView.HitTestInfo hit, TableState state, int x)
         {
+            // match the right edge of the name column regardless of its position
+            if (Math.Abs(x - state.NameColumnEdge) < _maxDistanceFromDivider)
+                return true;
+
             if (state.ScalingMode == ScalingMode.ResizeQuad)
             {
                 float f = state.GetNormalizedXCoordinate(x);

--- a/VSRAD.Package/DebugVisualizer/MouseMove/ScaleOperation.cs
+++ b/VSRAD.Package/DebugVisualizer/MouseMove/ScaleOperation.cs
@@ -104,7 +104,8 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
                 || (_tableState.ScalingMode == ScalingMode.ResizeQuad && !_lefthalf)
                 || (_tableState.ScalingMode == ScalingMode.ResizeHalf && !_lefthalf))
             {
-                int orgL = _orgNColumns * _orgWidth - _orgScroll;
+                int orgL = _isNameColumn ? _orgWidth
+                                         : _orgNColumns * _orgWidth - _orgScroll;
                 int curL = orgL + diff;
                 if (orgL > 0)
                 {
@@ -122,8 +123,9 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
             else if ((_tableState.ScalingMode == ScalingMode.ResizeQuad && _lefthalf)
                 || (_tableState.ScalingMode == ScalingMode.ResizeHalf && _lefthalf))
             {
-                int orgL = _tableState.Table.Width - _orgeX;
-                int curL = orgL - diff;
+                int orgL = _isNameColumn ? _orgWidth
+                                         : _tableState.Table.Width - _orgeX;
+                int curL = _isNameColumn ? orgL + diff : orgL - diff;
                 if (orgL > 0)
                 {
                     float s = (float)curL / orgL;

--- a/VSRAD.Package/DebugVisualizer/MouseMove/ScaleOperation.cs
+++ b/VSRAD.Package/DebugVisualizer/MouseMove/ScaleOperation.cs
@@ -44,7 +44,7 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
             _operationStarted = false;
             _orgMouseX = Cursor.Position.X;
             _orgeX = e.X;
-            _orgWidth = _isNameColumn
+            _orgWidth = _isNameColumn && _tableState.NameColumnScalingEnabled
                             ? _table.Columns[_tableState.NameColumnIndex].Width
                             : _tableState.ColumnWidth;
             _orgScroll = _tableState.GetCurrentScroll();
@@ -58,8 +58,8 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
 
         public static bool ShouldChangeCursor(DataGridView.HitTestInfo hit, TableState state, int x)
         {
-            // match the right edge of the name column regardless of its position
-            if (Math.Abs(x - state.NameColumnEdge) < _maxDistanceFromDivider)
+            // match the right edge of the name column regardless of its position if name column scaling is enabled
+            if ((Math.Abs(x - state.NameColumnEdge) < _maxDistanceFromDivider) && state.NameColumnScalingEnabled)
                 return true;
 
             if (state.ScalingMode == ScalingMode.ResizeQuad)
@@ -113,7 +113,7 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
                     curWidth = Math.Max(minWidth, curWidth);
                     s = (float)curWidth / _orgWidth;
                     int curScroll = _orgSColumns * curWidth + (int)(s * _orgSPixels);
-                    if (_isNameColumn)
+                    if (_isNameColumn && _tableState.NameColumnScalingEnabled)
                         _tableState.ScaleNameColumn(curWidth);
                     else
                         _tableState.SetWidthAndScroll(curWidth, curScroll);
@@ -131,7 +131,7 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
                     curWidth = Math.Max(minWidth, curWidth);
                     s = (float)curWidth / _orgWidth;
                     int curScroll = (int)(_orgScroll * s + _tableState.GetDataRegionWidth() * (s - 1));
-                    if (_isNameColumn)
+                    if (_isNameColumn && _tableState.NameColumnScalingEnabled)
                         _tableState.ScaleNameColumn(curWidth);
                     else
                         _tableState.SetWidthAndScroll(curWidth, curScroll);
@@ -145,7 +145,7 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
                 int curWidth = (int)(s * _orgWidth);
                 curWidth = Math.Max(minWidth, curWidth);
                 int curScroll = _orgScroll + (_orgNColumns - 1) * (curWidth - _orgWidth);
-                if (_isNameColumn)
+                if (_isNameColumn && _tableState.NameColumnScalingEnabled)
                     _tableState.ScaleNameColumn(curWidth);
                 else
                     _tableState.SetWidthAndScroll(curWidth, curScroll);

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerTable.cs
@@ -28,7 +28,8 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
             HeatMapMode = false;
             ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
 
-            _state = new TableState(this, 60, 0); // todo: verify that name column scaling does not break slice
+            _state = new TableState(this, 60, 0);
+            _state.NameColumnScalingEnabled = false; // slice does not have name column
 
             _mouseMoveController = new MouseMove.MouseMoveController(this, _state);
             _selectionController = new SelectionController(this);

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerTable.cs
@@ -28,7 +28,7 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
             HeatMapMode = false;
             ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
 
-            _state = new TableState(this, 60);
+            _state = new TableState(this, 60, 0); // todo: verify that name column scaling does not break slice
 
             _mouseMoveController = new MouseMove.MouseMoveController(this, _state);
             _selectionController = new SelectionController(this);

--- a/VSRAD.Package/DebugVisualizer/TableState.cs
+++ b/VSRAD.Package/DebugVisualizer/TableState.cs
@@ -14,6 +14,7 @@ namespace VSRAD.Package.DebugVisualizer
         public IReadOnlyList<DataGridViewColumn> DataColumns => _dataColumns;
         public int ColumnWidth { get; set; }
         public ScalingMode ScalingMode { get; set; } = ScalingMode.ResizeColumn;
+        public int NameColumnIndex { get; }
 
         private readonly List<DataGridViewColumn> _dataColumns = new List<DataGridViewColumn>();
 
@@ -28,15 +29,18 @@ namespace VSRAD.Package.DebugVisualizer
         // displayed after all data columns
         public int PhantomColumnIndex { get; private set; } = -1;
 
+        public int NameColumnEdge { get => Table.Columns[NameColumnIndex].Width + Table.RowHeadersWidth; }
+
         public int GetCurrentScroll()
         {
             return Table.HorizontalScrollingOffset + AdditionalScrollOffset;
         }
 
-        public TableState(DataGridView table, int columnWidth)
+        public TableState(DataGridView table, int columnWidth, int nameColumnIndex)
         {
             Table = table;
             ColumnWidth = columnWidth;
+            NameColumnIndex = nameColumnIndex;
 
             // Out of the box DataGridView is unable to change the width of even several dozen columns in real time because it recalculates layout after each individual column is resized
             // (https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/DataGridViewMethods.cs,dc107b02a9e367cc)
@@ -101,7 +105,7 @@ namespace VSRAD.Package.DebugVisualizer
         {
             var firstVisible = GetFirstVisibleDataColumnIndex();
             var n = DataColumns.Count(c => c.Visible);
-            var phantomWidth = Math.Max(2, Table.Width - Table.Columns[0].Width - Table.TopLeftHeaderCell.Size.Width - w);
+            var phantomWidth = Math.Max(2, Table.Width - Table.Columns[NameColumnIndex].Width - Table.TopLeftHeaderCell.Size.Width - w);
             TableShouldSuppressOnColumnWidthChangedEvent = true;
 
             foreach (var column in DataColumns)
@@ -124,7 +128,7 @@ namespace VSRAD.Package.DebugVisualizer
 
         public void ScaleNameColumn(int w)
         {
-            Table.Columns[0].Width = w;
+            Table.Columns[NameColumnIndex].Width = w;
         }
 
         public int CountVisibleDataColumns(int index, bool include_current)
@@ -136,13 +140,13 @@ namespace VSRAD.Package.DebugVisualizer
 
         public int GetDataRegionWidth()
         {
-            return Table.Size.Width - Table.RowHeadersWidth - Table.Columns[0].Width;
+            return Table.Size.Width - Table.RowHeadersWidth - Table.Columns[NameColumnIndex].Width;
         }
 
         public float GetNormalizedXCoordinate(int x)
         {
             var DataRegionWidth = GetDataRegionWidth();
-            var DataRegionMouseX = x - Table.RowHeadersWidth - Table.Columns[0].Width;
+            var DataRegionMouseX = x - Table.RowHeadersWidth - Table.Columns[NameColumnIndex].Width;
 
             return (float)DataRegionMouseX / DataRegionWidth;
         }

--- a/VSRAD.Package/DebugVisualizer/TableState.cs
+++ b/VSRAD.Package/DebugVisualizer/TableState.cs
@@ -10,7 +10,7 @@ namespace VSRAD.Package.DebugVisualizer
     {
         public DataGridView Table { get; }
         public int DataColumnOffset { get; private set; } = 1;
-        public int minAllowedWidth {get; } = 30;
+        public int minAllowedWidth { get; } = 30;
         public IReadOnlyList<DataGridViewColumn> DataColumns => _dataColumns;
         public int ColumnWidth { get; set; }
         public ScalingMode ScalingMode { get; set; } = ScalingMode.ResizeColumn;
@@ -120,6 +120,11 @@ namespace VSRAD.Package.DebugVisualizer
             AdditionalScrollOffset = Math.Min(0, s);
             ColumnWidth = w;
             Table.HorizontalScrollingOffset = Math.Max(0, s);
+        }
+
+        public void ScaleNameColumn(int w)
+        {
+            Table.Columns[0].Width = w;
         }
 
         public int CountVisibleDataColumns(int index, bool include_current)

--- a/VSRAD.Package/DebugVisualizer/TableState.cs
+++ b/VSRAD.Package/DebugVisualizer/TableState.cs
@@ -14,6 +14,7 @@ namespace VSRAD.Package.DebugVisualizer
         public IReadOnlyList<DataGridViewColumn> DataColumns => _dataColumns;
         public int ColumnWidth { get; set; }
         public ScalingMode ScalingMode { get; set; } = ScalingMode.ResizeColumn;
+        public bool NameColumnScalingEnabled { get; set; }
         public int NameColumnIndex { get; }
 
         private readonly List<DataGridViewColumn> _dataColumns = new List<DataGridViewColumn>();

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -47,6 +47,7 @@ namespace VSRAD.Package.DebugVisualizer
                         SetRowContentsFromBreakState(row);
             };
             _table.SetScalingMode(_context.Options.VisualizerAppearance.ScalingMode);
+            _table.SetNameColumnScalingEnabled(_context.Options.VisualizerAppearance.ScaleNameColumn);
             TableHost.Setup(_table);
             RestoreSavedState();
         }
@@ -134,6 +135,9 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                     break;
                 case nameof(Options.VisualizerAppearance.ScalingMode):
                     _table.SetScalingMode(_context.Options.VisualizerAppearance.ScalingMode);
+                    break;
+                case nameof(Options.VisualizerAppearance.ScaleNameColumn):
+                    _table.SetNameColumnScalingEnabled(_context.Options.VisualizerAppearance.ScaleNameColumn);
                     break;
                 case nameof(Options.DebuggerOptions.GroupSize):
                 case nameof(Options.VisualizerOptions.MaskLanes):

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -106,6 +106,8 @@ namespace VSRAD.Package.DebugVisualizer
 
         public void SetScalingMode(ScalingMode mode) => _state.ScalingMode = mode;
 
+        public void SetNameColumnScalingEnabled(bool nameColumnScalingEnabled) => _state.NameColumnScalingEnabled = nameColumnScalingEnabled;
+
         public void ScaleControls(float scaleFactor)
         {
             var rowHeight = (int)(scaleFactor * 20);

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -248,7 +248,6 @@ namespace VSRAD.Package.DebugVisualizer
                 HeaderText = "Name",
                 ReadOnly = false,
                 Frozen = true,
-                AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells,
                 SortMode = DataGridViewColumnSortMode.NotSortable
             });
             CreateMissingDataColumns(DataColumnCount);

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -78,7 +78,7 @@ namespace VSRAD.Package.DebugVisualizer
             AllowUserToResizeRows = false;
             EnableHeadersVisualStyles = false; // custom font and color settings for cell headers
 
-            _state = new TableState(this, columnWidth: 60);
+            _state = new TableState(this, columnWidth: 60, NameColumnIndex);
             SetupColumns();
             Debug.Assert(_state.DataColumnOffset == DataColumnOffset);
             Debug.Assert(_state.PhantomColumnIndex == PhantomColumnIndex);

--- a/VSRAD.Package/Options/VisualizerAppearance.cs
+++ b/VSRAD.Package/Options/VisualizerAppearance.cs
@@ -66,6 +66,10 @@ namespace VSRAD.Package.Options
             set => SetField(ref _scalingMode, value);
         }
 
+        private bool _scaleNameColumn = true;
+
+        public bool ScaleNameColumn { get => _scaleNameColumn; set => SetField(ref _scaleNameColumn, value); }
+
         private int _darkenAlternatingRowsBy = 0;
         public int DarkenAlternatingRowsBy { get => _darkenAlternatingRowsBy; set => SetField(ref _darkenAlternatingRowsBy, value); }
     }

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -179,6 +179,10 @@
                             </ComboBox>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Height="25">
+                            <CheckBox Content="Scale the Name column" VerticalAlignment="Center"
+                                      IsChecked="{Binding Options.VisualizerAppearance.ScaleNameColumn, UpdateSourceTrigger=PropertyChanged}"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Height="25">
                             <TextBlock Text="Wavemap element size" VerticalAlignment="Center"/>
                             <viz:NumberInput VerticalAlignment="Center" Width="50" Minimum="7" Maximum="100" Margin="5,0,0,0"
                                             Value="{Binding Options.VisualizerOptions.WavemapElementSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>


### PR DESCRIPTION
This PR modifies the behavior of `Name` column of `Debug Visualizer`. Insted of auto-setting the width based on contents, now user can scale this column manually.