### PR TITLE
Set as Startup Project behavior fix

### DIFF
--- a/VSRAD.Package/ProjectSystem/Project.cs
+++ b/VSRAD.Package/ProjectSystem/Project.cs
@@ -64,15 +64,22 @@ namespace VSRAD.Package.ProjectSystem
                 _onLoadCallbacks.Add(callback);
         }
 
-        public void Load()
+        public void Load(ProjectOptions projectOptions)
         {
-            Options = ProjectOptions.Read(_visualOptionsFilePath, _profilesFilePath, _oldOptionsFilePath);
+            if (projectOptions == null)
+            {
+                Options = ProjectOptions.Read(_visualOptionsFilePath, _profilesFilePath, _oldOptionsFilePath);
 
-            Options.PropertyChanged += OptionsPropertyChanged;
-            Options.DebuggerOptions.PropertyChanged += OptionsPropertyChanged;
-            Options.VisualizerOptions.PropertyChanged += OptionsPropertyChanged;
-            Options.VisualizerAppearance.PropertyChanged += OptionsPropertyChanged;
-            Options.VisualizerColumnStyling.PropertyChanged += OptionsPropertyChanged;
+                Options.PropertyChanged += OptionsPropertyChanged;
+                Options.DebuggerOptions.PropertyChanged += OptionsPropertyChanged;
+                Options.VisualizerOptions.PropertyChanged += OptionsPropertyChanged;
+                Options.VisualizerAppearance.PropertyChanged += OptionsPropertyChanged;
+                Options.VisualizerColumnStyling.PropertyChanged += OptionsPropertyChanged;
+            }
+            else
+            {
+                Options = projectOptions;
+            }
 
             UnconfiguredProject.Services.ExportProvider.GetExportedValue<BreakpointIntegration>();
             UnconfiguredProject.Services.ExportProvider.GetExportedValue<BuildToolsServer>();

--- a/VSRAD.Package/ProjectSystem/SolutionManager.cs
+++ b/VSRAD.Package/ProjectSystem/SolutionManager.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
+using System.Collections.Generic;
 using VSRAD.Package.Commands;
 
 namespace VSRAD.Package.ProjectSystem
@@ -20,6 +21,8 @@ namespace VSRAD.Package.ProjectSystem
         public event EventHandler<ProjectLoadedEventArgs> ProjectLoaded;
 
         private Project _currentRadProject;
+
+        private Dictionary<string, Options.ProjectOptions> _options = new Dictionary<string, Options.ProjectOptions>();
 
         public SolutionManager(IVsMonitorSelection vsMonitorSelection)
         {
@@ -84,7 +87,15 @@ namespace VSRAD.Package.ProjectSystem
             if (_currentRadProject == null)
                 return;
 
-            _currentRadProject.Load();
+            if (_options.TryGetValue(cpsProject.FullPath, out var options))
+            {
+                _currentRadProject.Load(options);
+            }
+            else
+            {
+                _currentRadProject.Load(null);
+                _options.Add(cpsProject.FullPath, _currentRadProject.Options);
+            }
 
             var exportProvider = cpsProject.Services.ExportProvider;
             var loadedEventArgs = new ProjectLoadedEventArgs


### PR DESCRIPTION
This PR fixes critical bug, when project configs becoming unusable after changing of the startup project. Steps to reproduce:

1. Open solution with multiple projects
2. Open `Debug Visualizer` and run debug
3. Change startup project
4. Change startup project back to initial project
5. Add new watch
6. Run debug again

You should see that the new watch is grayed out and it's data is not displayed.