### PR TITLE
Add to Watches: Added escape token handling

### DIFF
--- a/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
+++ b/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
@@ -107,7 +107,7 @@ namespace VSRAD.Package.ProjectSystem
             for (indexEnd = caretIndex; indexEnd < lineText.Length; indexEnd++)
             {
                 var ch = lineText[indexEnd];
-                if (!(char.IsLetterOrDigit(ch) || ch == '_' || ch == '$' || ch == '\\'))
+                if (!(char.IsLetterOrDigit(ch) || ch == '_' || ch == '$'))
                 {
                     break;
                 }

--- a/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
+++ b/VSRAD.Package/ProjectSystem/ActiveCodeEditor.cs
@@ -29,7 +29,7 @@ namespace VSRAD.Package.ProjectSystem
         private readonly ITextDocumentFactoryService _textDocumentService;
 
         // this regex matches words like `\vargs` without indices like [0]
-        private static readonly Regex _activeWordWithoutBracketsRegex = new Regex(@"[\w\\$]*", RegexOptions.Compiled | RegexOptions.Singleline);
+        private static readonly Regex _activeWordWithoutBracketsRegex = new Regex(@"[\w$]*", RegexOptions.Compiled | RegexOptions.Singleline);
         // this regex find matches like `\vargs[kernarg_1:kernarg_2]`
         private static readonly Regex _activeWordWithBracketsRegex = new Regex(@"[\w\\$]*\[[^\[\]]*\]", RegexOptions.Compiled | RegexOptions.Singleline);
         // this regex find empty brackets


### PR DESCRIPTION
Resolves #281.

For escape token usage refer to #279.

Before this PR when using `Add to wathches` on the `arg1` in the following example,
the `arg1\` watch would be added. This PR excludes the `\` escape token from `Add to watches`
match.

```
function (arg1\
         ,arg2\
         ,arg3)
end
```