### PR TITLE
Fix NRE when debug server response cannot be read [stable]

### DIFF
--- a/VSRAD.DebugServer/Client.cs
+++ b/VSRAD.DebugServer/Client.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -66,12 +67,6 @@ namespace VSRAD.DebugServer
                 try
                 {
                     var command = await ReadCommandAsync().ConfigureAwait(false);
-                    if (command == null)
-                    {
-                        Log.CliendDisconnected();
-                        _socket.Close();
-                        break;
-                    }
 
                     await _globalCommandLock.WaitAsync();
                     lockAcquired = true;
@@ -84,7 +79,7 @@ namespace VSRAD.DebugServer
                 }
                 catch (Exception e)
                 {
-                    if (e is OperationCanceledException || (e.InnerException is SocketException se && se.SocketErrorCode == SocketError.ConnectionReset))
+                    if (e is OperationCanceledException || e is EndOfStreamException || (e.InnerException is SocketException se && se.SocketErrorCode == SocketError.ConnectionReset))
                         Log.CliendDisconnected();
                     else
                         Log.FatalClientException(e);

--- a/VSRAD.DebugServer/IPC/StreamExtensions.cs
+++ b/VSRAD.DebugServer/IPC/StreamExtensions.cs
@@ -19,7 +19,7 @@ namespace VSRAD.DebugServer
             {
                 byte[] messageLengthBytes = new byte[4];
                 if (await stream.ReadAsync(messageLengthBytes, 0, 4).ConfigureAwait(false) != 4)
-                    return default;
+                    throw new EndOfStreamException();
 
                 int messageLength = BitConverter.ToInt32(messageLengthBytes, 0);
                 if (messageLength == 0) // Reply to a ping with a pong
@@ -36,7 +36,7 @@ namespace VSRAD.DebugServer
                     var received = await stream.ReadAsync(messageBytes, buffered, messageLength - buffered).ConfigureAwait(false);
                     buffered += received;
                     if (buffered != messageLength && received == 0)
-                        return default;
+                        throw new EndOfStreamException();
                 }
                 using (var memStream = new MemoryStream(messageBytes))
                 using (var reader = new IPCReader(memStream))
@@ -50,7 +50,7 @@ namespace VSRAD.DebugServer
             {
                 byte[] messageLengthBytes = new byte[4];
                 if (await stream.ReadAsync(messageLengthBytes, 0, 4).ConfigureAwait(false) != 4)
-                    return default;
+                    throw new EndOfStreamException();
 
                 int messageLength = BitConverter.ToInt32(messageLengthBytes, 0);
                 if (messageLength == 0) // Reply to a ping with a pong
@@ -67,7 +67,7 @@ namespace VSRAD.DebugServer
                     var received = await stream.ReadAsync(messageBytes, buffered, messageLength - buffered).ConfigureAwait(false);
                     buffered += received;
                     if (buffered != messageLength && received == 0)
-                        return default;
+                        throw new EndOfStreamException();
                 }
                 using (var memStream = new MemoryStream(messageBytes))
                 using (var reader = new IPCReader(memStream))


### PR DESCRIPTION
#211 but targeted on `dev-stable`.

Original description by @timlathy:

Properly handle this situation by:

1. throwing an exception (EndOfStream) instead of silently returning null;
2. always force disconnecting when there's an exception.

The problem only affected the VS extension; Debug Server's behavior was correct. The changes in `Client.cs` are only needed to switch from checking for `null` to catching the end of stream exception.