### PR TITLE
Flexible datatypes

### DIFF
--- a/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
@@ -20,10 +20,44 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
         {
             _table = table;
 
-            var typeItems = Array.Empty<MenuItem>(); // TODO: manually add corresponding values
+            //var typeItems = Array.Empty<MenuItem>(); // TODO: manually add corresponding values
 
             //var typeItems = ((VariableType[])Enum.GetValues(typeof(VariableType)))
             //    .Select(type => new MenuItem(type.ToString(), (s, e) => typeChanged(_currentRow, type)));
+
+            var typeItems = new MenuItem[]
+            {
+                new MenuItem("Hex", new MenuItem[]
+                {
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Hex, Size = 32 })),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Hex, Size = 16 })),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Hex, Size = 8  }))
+                }),
+                new MenuItem("Int", new MenuItem[]
+                {
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Int, Size = 32 })),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Int, Size = 16 })),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Int, Size = 8  }))
+                }),
+                new MenuItem("UInt", new MenuItem[]
+                {
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Uint, Size = 32 })),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Uint, Size = 16 })),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Uint, Size = 8  }))
+                }),
+                new MenuItem("Float", new MenuItem[]
+                {
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 32 })),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 16 }))
+                }),
+                new MenuItem("Bin", new MenuItem[]
+                {
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 32 })),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 16 })),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 8  }))
+                }),
+                new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Half, Size = 0 }))
+            };
 
             var fgColor = new MenuItem("Font Color", new[]
             {
@@ -78,7 +112,7 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
                 item.Checked = false;
 
             var selectedWatch = VisualizerTable.GetRowWatchState(_table.Rows[hit.RowIndex]);
-            _menu.MenuItems[(int)selectedWatch.Info.Type].Checked = true;
+            //_menu.MenuItems[(int)selectedWatch.Info.Type].Checked = true;
             _avgprButton.Enabled = _currentRow != 0 || !_table.ShowSystemRow;
             _avgprButton.Checked = selectedWatch.IsAVGPR;
 

--- a/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
@@ -7,7 +7,7 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
 {
     public sealed class TypeContextMenu : IContextMenu
     {
-        public delegate void TypeChanged(int rowIndex, VariableType type);
+        public delegate void TypeChanged(int rowIndex, VariableInfo type);
         public delegate void AVGPRStateChanged(int rowIndex, bool state);
         public delegate void InsertRow(int rowIndex, bool after);
 
@@ -20,8 +20,10 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
         {
             _table = table;
 
-            var typeItems = ((VariableType[])Enum.GetValues(typeof(VariableType)))
-                .Select(type => new MenuItem(type.ToString(), (s, e) => typeChanged(_currentRow, type)));
+            var typeItems = Array.Empty<MenuItem>(); // TODO: manually add corresponding values
+
+            //var typeItems = ((VariableType[])Enum.GetValues(typeof(VariableType)))
+            //    .Select(type => new MenuItem(type.ToString(), (s, e) => typeChanged(_currentRow, type)));
 
             var fgColor = new MenuItem("Font Color", new[]
             {
@@ -76,7 +78,7 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
                 item.Checked = false;
 
             var selectedWatch = VisualizerTable.GetRowWatchState(_table.Rows[hit.RowIndex]);
-            _menu.MenuItems[(int)selectedWatch.Type].Checked = true;
+            _menu.MenuItems[(int)selectedWatch.Info.Type].Checked = true;
             _avgprButton.Enabled = _currentRow != 0 || !_table.ShowSystemRow;
             _avgprButton.Checked = selectedWatch.IsAVGPR;
 

--- a/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
@@ -24,34 +24,34 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
             {
                 new MenuItem("Hex", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Hex, Size = 32 })),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Hex, Size = 16 })),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Hex, Size = 8  }))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex, 16))),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex,  8)))
                 }),
                 new MenuItem("Int", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Int, Size = 32 })),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Int, Size = 16 })),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Int, Size = 8  }))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Int, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Int, 16))),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Int,  8)))
                 }),
                 new MenuItem("UInt", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Uint, Size = 32 })),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Uint, Size = 16 })),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Uint, Size = 8  }))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Uint, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Uint, 16))),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Uint,  8)))
                 }),
                 new MenuItem("Float", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 32 })),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 16 }))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 16)))
                 }),
                 new MenuItem("Bin", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Bin, Size = 32 })),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Bin, Size = 16 })),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Bin, Size = 8  }))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 16))),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin,  8)))
                 }),
-                new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Half, Size = 0 }))
+                new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Half, 0)))
             };
 
             var fgColor = new MenuItem("Font Color", new[]

--- a/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
@@ -20,11 +20,6 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
         {
             _table = table;
 
-            //var typeItems = Array.Empty<MenuItem>(); // TODO: manually add corresponding values
-
-            //var typeItems = ((VariableType[])Enum.GetValues(typeof(VariableType)))
-            //    .Select(type => new MenuItem(type.ToString(), (s, e) => typeChanged(_currentRow, type)));
-
             var typeItems = new MenuItem[]
             {
                 new MenuItem("Hex", new MenuItem[]
@@ -52,9 +47,9 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
                 }),
                 new MenuItem("Bin", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 32 })),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 16 })),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 8  }))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Bin, Size = 32 })),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Bin, Size = 16 })),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Bin, Size = 8  }))
                 }),
                 new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Half, Size = 0 }))
             };
@@ -112,7 +107,6 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
                 item.Checked = false;
 
             var selectedWatch = VisualizerTable.GetRowWatchState(_table.Rows[hit.RowIndex]);
-            //_menu.MenuItems[(int)selectedWatch.Info.Type].Checked = true;
             _avgprButton.Enabled = _currentRow != 0 || !_table.ShowSystemRow;
             _avgprButton.Checked = selectedWatch.IsAVGPR;
 

--- a/VSRAD.Package/DebugVisualizer/CustomTableGraphics.cs
+++ b/VSRAD.Package/DebugVisualizer/CustomTableGraphics.cs
@@ -31,7 +31,7 @@ namespace VSRAD.Package.DebugVisualizer
                     | DataGridViewPaintParts.Border
                     | DataGridViewPaintParts.Focus
                     | DataGridViewPaintParts.SelectionBackground
-                    | DataGridViewPaintParts.ContentForeground
+                    //| DataGridViewPaintParts.ContentForeground // not needed because we are using custom string painter below
                 );
 
             if (!selectedWatch.IsEmpty)

--- a/VSRAD.Package/DebugVisualizer/CustomTableGraphics.cs
+++ b/VSRAD.Package/DebugVisualizer/CustomTableGraphics.cs
@@ -37,7 +37,7 @@ namespace VSRAD.Package.DebugVisualizer
             if (!selectedWatch.IsEmpty)
             {
                 var typeTextPos = new PointF((float)e.RowBounds.Left + 7, (float)e.RowBounds.Top + 4);
-                e.Graphics.DrawString(selectedWatch.Type.ShortName(),
+                e.Graphics.DrawString(selectedWatch.Info.ShortName(),
                     _table.RowHeadersDefaultCellStyle.Font,
                     new SolidBrush(_table.RowHeadersDefaultCellStyle.ForeColor),
                     typeTextPos);

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerContext.cs
@@ -24,8 +24,8 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
         private string _selectedWatch;
         public string SelectedWatch { get => _selectedWatch; set => SetField(ref _selectedWatch, value); }
 
-        private VariableType _selectedType;
-        public VariableType SelectedType { get => _selectedType; set => SetField(ref _selectedType, value); }
+        private VariableInfo _selectedType;
+        public VariableInfo SelectedType { get => _selectedType; set => SetField(ref _selectedType, value); }
 
         private bool _useHeatMap = false;
         public bool UseHeatMap { get => _useHeatMap; set => SetField(ref _useHeatMap, value); }

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
@@ -10,14 +10,14 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
         public int RowCount => _view.RowCount;
         public int ColumnCount => _view.ColumnCount;
 
-        public bool IsSingleWordValue => _type == VariableType.Half;
+        public bool IsSingleWordValue => _type.Type == VariableType.Half;
 
         private readonly SliceWatchView _view;
-        private readonly VariableType _type;
+        private readonly VariableInfo _type;
         private readonly TypedWatchValue _minValue;
         private readonly TypedWatchValue _maxValue;
 
-        public TypedSliceWatchView(SliceWatchView view, VariableType type)
+        public TypedSliceWatchView(SliceWatchView view, VariableInfo type)
         {
             _view = view;
             _type = type;
@@ -34,114 +34,118 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
 
         public float GetRelativeValue(int row, int column, int word = 0)
         {
-            switch (_type)
-            {
-                case VariableType.Uint:
-                case VariableType.Hex:
-                case VariableType.Bin:
-                    return ((float)(_view[row, column] - _minValue.uintValue)) / (_maxValue.uintValue - _minValue.uintValue);
-                case VariableType.Int:
-                    return ((float)((int)_view[row, column] - _minValue.intValue)) / (_maxValue.intValue - _minValue.intValue);
-                case VariableType.Float:
-                    var floatValue = BitConverter.ToSingle(BitConverter.GetBytes(_view[row, column]), 0);
-                    return (floatValue - _minValue.floatValue) / (_maxValue.floatValue - _minValue.floatValue);
-                case VariableType.Half:
-                    floatValue = Half.ToFloat(BitConverter.ToUInt16(BitConverter.GetBytes(_view[row, column]), startIndex: word * 2));
-                    return (floatValue - _minValue.floatValue) / (_maxValue.floatValue - _minValue.floatValue);
-            }
-            throw new NotImplementedException();
+            // TODO: reimplement for VariableInfo
+            return 0.0f;
+            //switch (_type)
+            //{
+            //    case VariableType.Uint:
+            //    case VariableType.Hex:
+            //    case VariableType.Bin:
+            //        return ((float)(_view[row, column] - _minValue.uintValue)) / (_maxValue.uintValue - _minValue.uintValue);
+            //    case VariableType.Int:
+            //        return ((float)((int)_view[row, column] - _minValue.intValue)) / (_maxValue.intValue - _minValue.intValue);
+            //    case VariableType.Float:
+            //        var floatValue = BitConverter.ToSingle(BitConverter.GetBytes(_view[row, column]), 0);
+            //        return (floatValue - _minValue.floatValue) / (_maxValue.floatValue - _minValue.floatValue);
+            //    case VariableType.Half:
+            //        floatValue = Half.ToFloat(BitConverter.ToUInt16(BitConverter.GetBytes(_view[row, column]), startIndex: word * 2));
+            //        return (floatValue - _minValue.floatValue) / (_maxValue.floatValue - _minValue.floatValue);
+            //}
+            //throw new NotImplementedException();
         }
 
-        private static void GetMinMaxValues(SliceWatchView view, VariableType type, out TypedWatchValue min, out TypedWatchValue max)
+        private static void GetMinMaxValues(SliceWatchView view, VariableInfo info, out TypedWatchValue min, out TypedWatchValue max)
         {
-            switch (type)
-            {
-                case VariableType.Uint:
-                case VariableType.Hex:
-                case VariableType.Bin:
-                    uint umin =  uint.MaxValue;
-                    uint umax = uint.MinValue;
-                    for (int row = 0; row < view.RowCount; ++row)
-                    {
-                        for (int col = 0; col < view.ColumnCount; ++col)
-                        {
-                            uint value = view[row, col];
-                            if (value < umin)
-                                umin = value;
-                            if (value > umax)
-                                umax = value;
-                        }
-                    }
-                    min = new TypedWatchValue { uintValue = umin };
-                    max = new TypedWatchValue { uintValue = umax };
-                    return;
-                case VariableType.Int:
-                    int imin = int.MaxValue;
-                    int imax = int.MinValue;
-                    for (int row = 0; row < view.RowCount; ++row)
-                    {
-                        for (int col = 0; col < view.ColumnCount; ++col)
-                        {
-                            int value = (int)view[row, col];
-                            if (value < imin)
-                                imin = value;
-                            if (value > imax)
-                                imax = value;
-                        }
-                    }
-                    min = new TypedWatchValue { intValue = imin };
-                    max = new TypedWatchValue { intValue = imax };
-                    return;
-                case VariableType.Float:
-                    float fmin = float.MaxValue;
-                    float fmax = float.MinValue;
-                    for (int row = 0; row < view.RowCount; ++row)
-                    {
-                        for (int col = 0; col < view.ColumnCount; ++col)
-                        {
-                            float value = BitConverter.ToSingle(BitConverter.GetBytes(view[row, col]), 0);
-                            if (float.IsNaN(value))
-                                continue;
-                            if (value < fmin)
-                                fmin = value;
-                            if (value > fmax)
-                                fmax = value;
-                        }
-                    }
-                    min = new TypedWatchValue { floatValue = fmin };
-                    max = new TypedWatchValue { floatValue = fmax };
-                    return;
-                case VariableType.Half:
-                    fmin = float.MaxValue;
-                    fmax = float.MinValue;
-                    for (int row = 0; row < view.RowCount; ++row)
-                    {
-                        for (int col = 0; col < view.ColumnCount; ++col)
-                        {
-                            byte[] bytes = BitConverter.GetBytes(view[row, col]);
-                            float firstHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 0));
-                            float secondHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 2));
-                            if (!float.IsNaN(firstHalf))
-                            {
-                                if (firstHalf < fmin)
-                                    fmin = firstHalf;
-                                if (firstHalf > fmax)
-                                    fmax = firstHalf;
-                            }
-                            if (!float.IsNaN(secondHalf))
-                            {
-                                if (secondHalf < fmin)
-                                    fmin = secondHalf;
-                                if (secondHalf > fmax)
-                                    fmax = secondHalf;
-                            }
-                        }
-                    }
-                    min = new TypedWatchValue { floatValue = fmin };
-                    max = new TypedWatchValue { floatValue = fmax };
-                    return;
-            }
-            throw new NotImplementedException();
+            min = new TypedWatchValue { floatValue = float.MinValue };
+            max = new TypedWatchValue { floatValue = float.MaxValue };
+            return;
+            // TODO: reimplement for VariableInfo
+            //switch (type)
+            //{
+            //    case VariableType.Uint:
+            //    case VariableType.Hex:
+            //    case VariableType.Bin:
+            //        uint umin =  uint.MaxValue;
+            //        uint umax = uint.MinValue;
+            //        for (int row = 0; row < view.RowCount; ++row)
+            //        {
+            //            for (int col = 0; col < view.ColumnCount; ++col)
+            //            {
+            //                uint value = view[row, col];
+            //                if (value < umin)
+            //                    umin = value;
+            //                if (value > umax)
+            //                    umax = value;
+            //            }
+            //        }
+            //        min = new TypedWatchValue { uintValue = umin };
+            //        max = new TypedWatchValue { uintValue = umax };
+            //        return;
+            //    case VariableType.Int:
+            //        int imin = int.MaxValue;
+            //        int imax = int.MinValue;
+            //        for (int row = 0; row < view.RowCount; ++row)
+            //        {
+            //            for (int col = 0; col < view.ColumnCount; ++col)
+            //            {
+            //                int value = (int)view[row, col];
+            //                if (value < imin)
+            //                    imin = value;
+            //                if (value > imax)
+            //                    imax = value;
+            //            }
+            //        }
+            //        min = new TypedWatchValue { intValue = imin };
+            //        max = new TypedWatchValue { intValue = imax };
+            //        return;
+            //    case VariableType.Float:
+            //        float fmin = float.MaxValue;
+            //        float fmax = float.MinValue;
+            //        for (int row = 0; row < view.RowCount; ++row)
+            //        {
+            //            for (int col = 0; col < view.ColumnCount; ++col)
+            //            {
+            //                float value = BitConverter.ToSingle(BitConverter.GetBytes(view[row, col]), 0);
+            //                if (float.IsNaN(value))
+            //                    continue;
+            //                if (value < fmin)
+            //                    fmin = value;
+            //                if (value > fmax)
+            //                    fmax = value;
+            //            }
+            //        }
+            //        min = new TypedWatchValue { floatValue = fmin };
+            //        max = new TypedWatchValue { floatValue = fmax };
+            //        return;
+            //    case VariableType.Half:
+            //        fmin = float.MaxValue;
+            //        fmax = float.MinValue;
+            //        for (int row = 0; row < view.RowCount; ++row)
+            //        {
+            //            for (int col = 0; col < view.ColumnCount; ++col)
+            //            {
+            //                byte[] bytes = BitConverter.GetBytes(view[row, col]);
+            //                float firstHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 0));
+            //                float secondHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 2));
+            //                if (!float.IsNaN(firstHalf))
+            //                {
+            //                    if (firstHalf < fmin)
+            //                        fmin = firstHalf;
+            //                    if (firstHalf > fmax)
+            //                        fmax = firstHalf;
+            //                }
+            //                if (!float.IsNaN(secondHalf))
+            //                {
+            //                    if (secondHalf < fmin)
+            //                        fmin = secondHalf;
+            //                    if (secondHalf > fmax)
+            //                        fmax = secondHalf;
+            //                }
+            //            }
+            //        }
+            //        min = new TypedWatchValue { floatValue = fmin };
+            //        max = new TypedWatchValue { floatValue = fmax };
+            //        return;
         }
 
         [StructLayout(LayoutKind.Explicit)]

--- a/VSRAD.Package/DebugVisualizer/VariableType.cs
+++ b/VSRAD.Package/DebugVisualizer/VariableType.cs
@@ -1,5 +1,9 @@
-﻿namespace VSRAD.Package.DebugVisualizer
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace VSRAD.Package.DebugVisualizer
 {
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum VariableType
     {
 #pragma warning disable CA1720 // Identifier contains type name
@@ -7,10 +11,17 @@
 #pragma warning restore CA1720 // Identifier contains type name
     };
 
-    public struct VariableInfo : System.IEquatable<VariableInfo>
+    public readonly struct VariableInfo : System.IEquatable<VariableInfo>
     {
-        public VariableType Type;
-        public int Size;
+        [JsonConstructor]
+        public VariableInfo(VariableType type, int size)
+        {
+            Type = type;
+            Size = size;
+        }
+
+        public readonly VariableType Type;
+        public readonly int Size;
 
         public bool Equals(VariableInfo other) =>
             other.Type == Type && other.Size == Size;
@@ -53,17 +64,17 @@
             switch (shortName[0])
             {
                 case 'B':
-                    return new VariableInfo { Type = VariableType.Bin,   Size = int.Parse(shortName.Substring(1)) };
+                    return new VariableInfo(VariableType.Bin, int.Parse(shortName.Substring(1)));
                 case 'F':
-                    return new VariableInfo { Type = VariableType.Float, Size = int.Parse(shortName.Substring(1)) };
+                    return new VariableInfo(VariableType.Float, int.Parse(shortName.Substring(1)));
                 case 'h':
-                    return new VariableInfo { Type = VariableType.Half,  Size = 0 /*we dont use size for half's*/ };
+                    return new VariableInfo(VariableType.Half, 0); // we dont use size for half's
                 case 'H':
-                    return new VariableInfo { Type = VariableType.Hex,   Size = int.Parse(shortName.Substring(1)) };
+                    return new VariableInfo(VariableType.Hex, int.Parse(shortName.Substring(1)));
                 case 'I':
-                    return new VariableInfo { Type = VariableType.Int,   Size = int.Parse(shortName.Substring(1)) };
+                    return new VariableInfo(VariableType.Int, int.Parse(shortName.Substring(1)));
                 default:
-                    return new VariableInfo { Type = VariableType.Uint,  Size = int.Parse(shortName.Substring(1)) };
+                    return new VariableInfo(VariableType.Uint, int.Parse(shortName.Substring(1)));
             }
         }
     }

--- a/VSRAD.Package/DebugVisualizer/VariableType.cs
+++ b/VSRAD.Package/DebugVisualizer/VariableType.cs
@@ -7,45 +7,63 @@
 #pragma warning restore CA1720 // Identifier contains type name
     };
 
+    public struct VariableInfo : System.IEquatable<VariableInfo>
+    {
+        public VariableType Type;
+        public int Size;
+
+        public bool Equals(VariableInfo other) =>
+            other.Type == Type && other.Size == Size;
+
+        public override bool Equals(object obj) =>
+            obj is VariableInfo other && Equals(other);
+
+        public override int GetHashCode() => (Type, Size).GetHashCode();
+
+        public static bool operator ==(VariableInfo left, VariableInfo right) => left.Equals(right);
+
+        public static bool operator !=(VariableInfo left, VariableInfo right) => !(left == right);
+    }
+
     public static class VariableTypeUtils
     {
-        public static string ShortName(this VariableType type)
+        public static string ShortName(this VariableInfo info)
         {
-            switch (type)
+            switch (info.Type)
             {
                 case VariableType.Bin:
-                    return "B";
+                    return "B" + info.Size.ToString();
                 case VariableType.Float:
-                    return "F";
+                    return "F" + info.Size.ToString();
                 case VariableType.Half:
-                    return "h";
+                    return "h"; // we dont use size for half's
                 case VariableType.Hex:
-                    return "H";
+                    return "H" + info.Size.ToString();
                 case VariableType.Int:
-                    return "I";
+                    return "I" + info.Size.ToString();
                 case VariableType.Uint:
-                    return "U";
+                    return "U" + info.Size.ToString();
                 default:
                     return string.Empty;
             }
         }
 
-        public static VariableType TypeFromShortName(string shortName)
+        public static VariableInfo TypeFromShortName(string shortName)
         {
-            switch (shortName)
+            switch (shortName[0])
             {
-                case "B":
-                    return VariableType.Bin;
-                case "F":
-                    return VariableType.Float;
-                case "h":
-                    return VariableType.Half;
-                case "H":
-                    return VariableType.Hex;
-                case "I":
-                    return VariableType.Int;
+                case 'B':
+                    return new VariableInfo { Type = VariableType.Bin,   Size = int.Parse(shortName.Substring(1)) };
+                case 'F':
+                    return new VariableInfo { Type = VariableType.Float, Size = int.Parse(shortName.Substring(1)) };
+                case 'h':
+                    return new VariableInfo { Type = VariableType.Half,  Size = 0 /*we dont use size for half's*/ };
+                case 'H':
+                    return new VariableInfo { Type = VariableType.Hex,   Size = int.Parse(shortName.Substring(1)) };
+                case 'I':
+                    return new VariableInfo { Type = VariableType.Int,   Size = int.Parse(shortName.Substring(1)) };
                 default:
-                    return VariableType.Uint;
+                    return new VariableInfo { Type = VariableType.Uint,  Size = int.Parse(shortName.Substring(1)) };
             }
         }
     }

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -110,7 +110,7 @@ To switch to manual grid size selection, right-click on the space next to the Gr
         {
             RefreshDataStyling();
             _table.Rows.Clear();
-            _table.AppendVariableRow(new Watch("System", new VariableInfo { Type = VariableType.Hex, Size = 32 }, isAVGPR: false), canBeRemoved: false);
+            _table.AppendVariableRow(new Watch("System", new VariableInfo(VariableType.Hex, 32), isAVGPR: false), canBeRemoved: false);
             _table.ShowSystemRow = _context.Options.VisualizerOptions.ShowSystemVariable;
             _table.AlignmentChanged(
                     _context.Options.VisualizerAppearance.NameColumnAlignment,
@@ -174,7 +174,7 @@ To switch to manual grid size selection, right-click on the space next to the Gr
         private void AddWatch(string watchName)
         {
             _table.RemoveNewWatchRow();
-            _table.AppendVariableRow(new Watch(watchName, new VariableInfo { Type = VariableType.Int, Size = 32 }, isAVGPR: false));
+            _table.AppendVariableRow(new Watch(watchName, new VariableInfo(VariableType.Int, 32), isAVGPR: false));
             _table.PrepareNewWatchRow();
             _context.Options.DebuggerOptions.Watches.Clear();
             _context.Options.DebuggerOptions.Watches.AddRange(_table.GetCurrentWatchState());

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -110,7 +110,7 @@ To switch to manual grid size selection, right-click on the space next to the Gr
         {
             RefreshDataStyling();
             _table.Rows.Clear();
-            _table.AppendVariableRow(new Watch("System", VariableType.Hex, isAVGPR: false), canBeRemoved: false);
+            _table.AppendVariableRow(new Watch("System", new VariableInfo { Type = VariableType.Hex, Size = 32 }, isAVGPR: false), canBeRemoved: false);
             _table.ShowSystemRow = _context.Options.VisualizerOptions.ShowSystemVariable;
             _table.AlignmentChanged(
                     _context.Options.VisualizerAppearance.NameColumnAlignment,
@@ -174,7 +174,7 @@ To switch to manual grid size selection, right-click on the space next to the Gr
         private void AddWatch(string watchName)
         {
             _table.RemoveNewWatchRow();
-            _table.AppendVariableRow(new Watch(watchName, VariableType.Int, isAVGPR: false));
+            _table.AppendVariableRow(new Watch(watchName, new VariableInfo { Type = VariableType.Int, Size = 32 }, isAVGPR: false));
             _table.PrepareNewWatchRow();
             _context.Options.DebuggerOptions.Watches.Clear();
             _context.Options.DebuggerOptions.Watches.AddRange(_table.GetCurrentWatchState());

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -55,7 +55,7 @@ namespace VSRAD.Package.DebugVisualizer
             _computedStyling = new ComputedColumnStyling();
             _getValidWatches = getValidWatches;
 
-            RowHeadersWidth = 30;
+            RowHeadersWidth = 35;
             RowHeadersWidthSizeMode = DataGridViewRowHeadersWidthSizeMode.DisableResizing;
             ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
             RowHeadersVisible = true;

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -266,7 +266,7 @@ namespace VSRAD.Package.DebugVisualizer
                     var scrollingOffset = HorizontalScrollingOffset;
                     if (!string.IsNullOrWhiteSpace(rowWatchName))
                         Rows[e.RowIndex].Cells[NameColumnIndex].Value = rowWatchName.Trim();
-                    Rows[e.RowIndex].HeaderCell.Value = new VariableInfo { Type = VariableType.Hex, Size = 32 }.ShortName();
+                    Rows[e.RowIndex].HeaderCell.Value = new VariableInfo(VariableType.Hex, 32).ShortName();
                     Rows[e.RowIndex].HeaderCell.Tag = IsAVGPR(rowWatchName); // avgpr
                     RowStyling.UpdateRowHighlight(row, _fontAndColor.FontAndColorState, _getValidWatches());
                     LockWatchRowForEditing(row);

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -131,7 +131,7 @@ namespace VSRAD.Package.DebugVisualizer
             ProcessInsertKey(Keys.Control | Keys.C);
         }
 
-        private void VariableTypeChanged(int rowIndex, VariableType type)
+        private void VariableTypeChanged(int rowIndex, VariableInfo type)
         {
             var changedRows = _selectionController.GetClickTargetRows(rowIndex);
             foreach (var row in changedRows)
@@ -196,7 +196,7 @@ namespace VSRAD.Package.DebugVisualizer
         {
             var index = Rows.Add();
             Rows[index].Cells[NameColumnIndex].Value = watch.Name;
-            Rows[index].HeaderCell.Value = watch.Type.ShortName();
+            Rows[index].HeaderCell.Value = watch.Info.ShortName();
             Rows[index].HeaderCell.Tag = watch.IsAVGPR;
             Rows[index].DefaultCellStyle.BackColor = _fontAndColor.FontAndColorState.HighlightBackground[(int)DataHighlightColor.Inactive];
             LockWatchRowForEditing(Rows[index], canBeRemoved);
@@ -266,7 +266,7 @@ namespace VSRAD.Package.DebugVisualizer
                     var scrollingOffset = HorizontalScrollingOffset;
                     if (!string.IsNullOrWhiteSpace(rowWatchName))
                         Rows[e.RowIndex].Cells[NameColumnIndex].Value = rowWatchName.Trim();
-                    Rows[e.RowIndex].HeaderCell.Value = VariableType.Hex.ShortName();
+                    Rows[e.RowIndex].HeaderCell.Value = new VariableInfo { Type = VariableType.Hex, Size = 32 }.ShortName();
                     Rows[e.RowIndex].HeaderCell.Tag = IsAVGPR(rowWatchName); // avgpr
                     RowStyling.UpdateRowHighlight(row, _fontAndColor.FontAndColorState, _getValidWatches());
                     LockWatchRowForEditing(row);

--- a/VSRAD.Package/DebugVisualizer/Watch.cs
+++ b/VSRAD.Package/DebugVisualizer/Watch.cs
@@ -7,8 +7,8 @@ namespace VSRAD.Package.DebugVisualizer
     {
         public string Name { get; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
-        public VariableType Type { get; }
+        //[JsonConverter(typeof(StringEnumConverter))]
+        public VariableInfo Info { get; }
 
         public bool IsAVGPR { get; }
 
@@ -16,16 +16,16 @@ namespace VSRAD.Package.DebugVisualizer
         public bool IsEmpty => string.IsNullOrWhiteSpace(Name);
 
         [JsonConstructor]
-        public Watch(string name, VariableType type, bool isAVGPR)
+        public Watch(string name, VariableInfo type, bool isAVGPR)
         {
             Name = name;
-            Type = type;
+            Info = type;
             IsAVGPR = isAVGPR;
         }
 
-        public bool Equals(Watch w) => Name == w.Name && Type == w.Type && IsAVGPR == w.IsAVGPR;
+        public bool Equals(Watch w) => Name == w.Name && Info == w.Info && IsAVGPR == w.IsAVGPR;
         public override bool Equals(object o) => o is Watch w && Equals(w);
-        public override int GetHashCode() => (Name, Type, IsAVGPR).GetHashCode();
+        public override int GetHashCode() => (Name, Info, IsAVGPR).GetHashCode();
         public static bool operator ==(Watch left, Watch right) => left.Equals(right);
         public static bool operator !=(Watch left, Watch right) => !(left == right);
     }

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -91,7 +91,30 @@ namespace VSRAD.Package.Options
                 if (reader.TokenType == JsonToken.String)
                     watches.Add(new Watch((string)reader.Value, new VariableInfo(VariableType.Hex, 32), isAVGPR: false));
                 else if (reader.TokenType == JsonToken.StartObject)
-                    watches.Add(JObject.Load(reader).ToObject<Watch>());
+                {
+                    if (!reader.Read()) continue;
+                    if (reader.TokenType != JsonToken.PropertyName || reader.Value.ToString() != "Name") continue;
+
+                    if (!reader.Read()) continue;
+                    if (reader.TokenType != JsonToken.String) continue;
+                    var name = reader.Value.ToString();
+
+                    if (!reader.Read()) continue;
+                    if (reader.TokenType != JsonToken.PropertyName || reader.Value.ToString() != "Info") continue;
+
+                    if (!reader.Read()) continue;
+                    if (reader.TokenType != JsonToken.StartObject) continue;
+                    var info = JObject.Load(reader).ToObject<VariableInfo>();
+
+                    if (!reader.Read()) continue;
+                    if (reader.TokenType != JsonToken.PropertyName || reader.Value.ToString() != "IsAVGPR") continue;
+
+                    if (!reader.Read()) continue;
+                    if (reader.TokenType != JsonToken.Boolean) continue;
+                    var isAVGPR = (bool)reader.Value;
+
+                    watches.Add(new Watch(name, info, isAVGPR));
+                }
             }
 
             return watches;

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -89,7 +89,7 @@ namespace VSRAD.Package.Options
             while (reader.Read() && reader.TokenType != JsonToken.EndArray)
             {
                 if (reader.TokenType == JsonToken.String)
-                    watches.Add(new Watch((string)reader.Value, new VariableInfo { Type = VariableType.Hex, Size = 32 }, isAVGPR: false));
+                    watches.Add(new Watch((string)reader.Value, new VariableInfo(VariableType.Hex, 32), isAVGPR: false));
                 else if (reader.TokenType == JsonToken.StartObject)
                     watches.Add(JObject.Load(reader).ToObject<Watch>());
             }

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -100,11 +100,23 @@ namespace VSRAD.Package.Options
                     var name = reader.Value.ToString();
 
                     if (!reader.Read()) continue;
-                    if (reader.TokenType != JsonToken.PropertyName || reader.Value.ToString() != "Info") continue;
+                    if (reader.TokenType != JsonToken.PropertyName) continue;
 
-                    if (!reader.Read()) continue;
-                    if (reader.TokenType != JsonToken.StartObject) continue;
-                    var info = JObject.Load(reader).ToObject<VariableInfo>();
+                    VariableInfo info;
+
+                    if (reader.Value.ToString() == "Info")
+                    {
+                        if (!reader.Read()) continue;
+                        if (reader.TokenType != JsonToken.StartObject) continue;
+                        info = JObject.Load(reader).ToObject<VariableInfo>();
+                    }
+                    else
+                    {
+                        if (reader.Value.ToString() != "Type") continue;
+                        if (!reader.Read()) continue;
+                        if (reader.TokenType != JsonToken.String) continue;
+                        info = new VariableInfo((VariableType)Enum.Parse(typeof(VariableType), reader.Value.ToString()), 32);
+                    }
 
                     if (!reader.Read()) continue;
                     if (reader.TokenType != JsonToken.PropertyName || reader.Value.ToString() != "IsAVGPR") continue;

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -89,7 +89,7 @@ namespace VSRAD.Package.Options
             while (reader.Read() && reader.TokenType != JsonToken.EndArray)
             {
                 if (reader.TokenType == JsonToken.String)
-                    watches.Add(new Watch((string)reader.Value, VariableType.Hex, isAVGPR: false));
+                    watches.Add(new Watch((string)reader.Value, new VariableInfo { Type = VariableType.Hex, Size = 32 }, isAVGPR: false));
                 else if (reader.TokenType == JsonToken.StartObject)
                     watches.Add(JObject.Load(reader).ToObject<Watch>());
             }

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -79,8 +79,10 @@ namespace VSRAD.Package.Utils
                     return $"({firstHalf}; {secondHalf})";
                 case VariableType.Bin:
                     var bin = Convert.ToString(data, 2);
+                    if (varInfo.Size != 32) bin = bin.Substring(0, varInfo.Size);
+                    if (string.IsNullOrEmpty(bin)) bin = "0";
                     if (leadingZeroes)
-                        bin = bin.PadLeft(32, '0');
+                        bin = bin.PadLeft(varInfo.Size, '0');
                     if (binHexSeparator != 0)
                         bin = InsertNumberSeparators(bin, binHexSeparator);
                     return "0b" + bin;

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -31,9 +31,10 @@ namespace VSRAD.Package.Utils
             switch (varInfo.Type)
             {
                 case VariableType.Hex:
-                    var hex = data.ToString("x");
+                    var hex = data.ToString("x").Substring(0, varInfo.Size / 4);
+                    if (string.IsNullOrEmpty(hex)) hex = "0";
                     if (leadingZeroes)
-                        hex = hex.PadLeft(8, '0');
+                        hex = hex.PadLeft(varInfo.Size / 4, '0');
                     if (binHexSeparator != 0)
                         hex = InsertNumberSeparators(hex, binHexSeparator);
                     return "0x" + hex;

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -31,7 +31,8 @@ namespace VSRAD.Package.Utils
             switch (varInfo.Type)
             {
                 case VariableType.Hex:
-                    var hex = data.ToString("x").Substring(0, varInfo.Size / 4);
+                    var hex = data.ToString("x");
+                    if (varInfo.Size != 32) hex = hex.Substring(8 - (varInfo.Size / 4), varInfo.Size / 4);
                     if (string.IsNullOrEmpty(hex)) hex = "0";
                     if (leadingZeroes)
                         hex = hex.PadLeft(varInfo.Size / 4, '0');
@@ -79,7 +80,7 @@ namespace VSRAD.Package.Utils
                     return $"({firstHalf}; {secondHalf})";
                 case VariableType.Bin:
                     var bin = Convert.ToString(data, 2);
-                    if (varInfo.Size != 32) bin = bin.Substring(0, varInfo.Size);
+                    if (varInfo.Size != 32) bin = bin.Substring(32 - varInfo.Size, varInfo.Size);
                     if (string.IsNullOrEmpty(bin)) bin = "0";
                     if (leadingZeroes)
                         bin = bin.PadLeft(varInfo.Size, '0');

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -39,7 +39,13 @@ namespace VSRAD.Package.Utils
                         hex = InsertNumberSeparators(hex, binHexSeparator);
                     return "0x" + hex;
                 case VariableType.Float:
-                    return BitConverter.ToSingle(BitConverter.GetBytes(data), 0).ToString();
+                    switch (varInfo.Size)
+                    {
+                        case 16:
+                            return Half.ToFloat(BitConverter.ToUInt16(BitConverter.GetBytes(data), 0)).ToString();
+                        default: // 32
+                            return BitConverter.ToSingle(BitConverter.GetBytes(data), 0).ToString();
+                    }
                 case VariableType.Uint:
                     return intSeparator == 0 ? data.ToString() : InsertNumberSeparators(data.ToString(), intSeparator);
                 case VariableType.Int:

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -47,7 +47,18 @@ namespace VSRAD.Package.Utils
                             return BitConverter.ToSingle(BitConverter.GetBytes(data), 0).ToString();
                     }
                 case VariableType.Uint:
-                    return intSeparator == 0 ? data.ToString() : InsertNumberSeparators(data.ToString(), intSeparator);
+                    var uIntBytes = BitConverter.GetBytes(data);
+                    switch (varInfo.Size)
+                    {
+                        case 32:
+                            return intSeparator == 0 ? data.ToString() : InsertNumberSeparators(data.ToString(), intSeparator);
+                        case 16:
+                            var res16 = BitConverter.ToUInt16(uIntBytes, 0);
+                            return intSeparator == 0 ? res16.ToString() : InsertNumberSeparators(res16.ToString(), intSeparator);
+                        default: // 8
+                            var res8 = uIntBytes[0].ToString();
+                            return intSeparator == 0 ? res8.ToString() : InsertNumberSeparators(res8.ToString(), intSeparator);
+                    }
                 case VariableType.Int:
                     return intSeparator == 0 ? ((int)data).ToString() : InsertNumberSeparators(((int)data).ToString(), intSeparator);
                 case VariableType.Half:

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -26,9 +26,9 @@ namespace VSRAD.Package.Utils
             return sb.ToString();
         }
 
-        public static string FormatDword(VariableType variableType, uint data, uint binHexSeparator, uint intSeparator, bool leadingZeroes)
+        public static string FormatDword(VariableInfo varInfo, uint data, uint binHexSeparator, uint intSeparator, bool leadingZeroes)
         {
-            switch (variableType)
+            switch (varInfo.Type)
             {
                 case VariableType.Hex:
                     var hex = data.ToString("x");

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -56,11 +56,22 @@ namespace VSRAD.Package.Utils
                             var res16 = BitConverter.ToUInt16(uIntBytes, 0);
                             return intSeparator == 0 ? res16.ToString() : InsertNumberSeparators(res16.ToString(), intSeparator);
                         default: // 8
-                            var res8 = uIntBytes[0].ToString();
+                            var res8 = uIntBytes[3].ToString(); // little endian
                             return intSeparator == 0 ? res8.ToString() : InsertNumberSeparators(res8.ToString(), intSeparator);
                     }
                 case VariableType.Int:
-                    return intSeparator == 0 ? ((int)data).ToString() : InsertNumberSeparators(((int)data).ToString(), intSeparator);
+                    var intBytes = BitConverter.GetBytes(data);
+                    switch (varInfo.Size)
+                    {
+                        case 32:
+                            return intSeparator == 0 ? ((int)data).ToString() : InsertNumberSeparators(((int)data).ToString(), intSeparator);
+                        case 16:
+                            var res16 = BitConverter.ToInt16(intBytes, 0);
+                            return intSeparator == 0 ? res16.ToString() : InsertNumberSeparators(res16.ToString(), intSeparator);
+                        default: // 8
+                            var res8 = ((sbyte)intBytes[3]).ToString(); // little endian
+                            return intSeparator == 0 ? res8.ToString() : InsertNumberSeparators(res8.ToString(), intSeparator);
+                    }
                 case VariableType.Half:
                     byte[] bytes = BitConverter.GetBytes(data);
                     float firstHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 0));


### PR DESCRIPTION
This PR adds more flexible way to define datatypes. Now you can not only choose representation (`Hex`, `Int`, `UInt`, `Float`, `Bin` or `Half`), but also size - 32, 16 or 8 bits (only 32 and 16 for `Float`).

![image](https://user-images.githubusercontent.com/39794543/154732680-ac9cb022-11f4-424f-ba5b-407c3fa68c5a.png)

_Note_: For now `SliceVisualizer` is not supported, since it's last version is not on stable branch and we still discuss the details of it's implementation.
