### PR TITLE
Action Names handling [stable]

### DIFF
--- a/VSRAD.Package/Commands/ActionsMenuCommand.cs
+++ b/VSRAD.Package/Commands/ActionsMenuCommand.cs
@@ -52,7 +52,8 @@ namespace VSRAD.Package.Commands
         {
             if (GetActionNameByCommandId(commandId).TryGetResult(out var actionName, out var error))
             {
-                var isDebugAction = actionName == SelectedProfile.MenuCommands.DebugAction;
+                var isDebugAction = (SelectedProfile.Actions.FirstOrDefault(a => a.Name == actionName) is ActionProfileOptions action
+                        && _actionLauncher.IsDebugAction(action, new System.Collections.Generic.List<string>()));
                 if (_actionLauncher.TryLaunchActionByName(actionName, moveToNextDebugTarget: isDebugAction) is Error e)
                     Errors.Show(e);
             }

--- a/VSRAD.Package/ProjectSystem/ActionLauncher.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLauncher.cs
@@ -217,7 +217,7 @@ namespace VSRAD.Package.ProjectSystem
             return new ActionCompletedEventArgs(actionError, action, transients, runResult);
         }
 
-        public bool IsDebugAction(ActionProfileOptions action, List<string> actionstraversed)
+        public bool IsDebugAction(ActionProfileOptions action, List<string> actionsTraversed)
         {
             foreach (var step in action.Steps)
             {
@@ -225,14 +225,14 @@ namespace VSRAD.Package.ProjectSystem
                     return true;
                 if (step is RunActionStep runAction)
                 {
-                    if (actionstraversed.Contains(runAction.Name)) continue; // skip RunAction's that contain circular dependencies
-                    actionstraversed.Add(runAction.Name);
+                    if (actionsTraversed.Contains(runAction.Name)) continue; // skip RunAction's that contain circular dependencies
+                    actionsTraversed.Add(runAction.Name);
                     if (_project.Options.Profile.Actions.FirstOrDefault(a => a.Name == runAction.Name) is ActionProfileOptions nestedAction
-                        && IsDebugAction(nestedAction, actionstraversed))
+                        && IsDebugAction(nestedAction, actionsTraversed))
                         return true;
                 }
             }
-            actionstraversed.Clear();
+            actionsTraversed.Clear();
             return false;
         }
 

--- a/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
+++ b/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
@@ -48,7 +48,7 @@ namespace VSRAD.Package.ProjectSystem
             if (e.RunResult == null) // RunResult is null when an error has occurred
                 return;
 
-            if (_actionLauncher.IsDebugAction(e.Action))
+            if (_actionLauncher.IsDebugAction(e.Action, new System.Collections.Generic.List<string>()))
                 RaiseExecutionCompleted(e.Transients.ActiveSourceFullPath ?? "", e.Transients.BreakLines ?? new[] { 0u }, isStepping: false, e.RunResult.BreakState);
         }
 

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindow.xaml
@@ -228,7 +228,7 @@
                             <Label Content="Name:" VerticalContentAlignment="Center" Margin="0,0" Padding="4,0" Height="22" Grid.Row="0" Grid.Column="0"/>
                             <TextBox Height="22" Width="160" HorizontalAlignment="Left" VerticalContentAlignment="Center" Grid.Row="0" Grid.Column="1">
                                 <TextBox.Text>
-                                    <Binding Path="Name" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
+                                    <Binding Path="Name" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged" ValidatesOnExceptions="True">
                                         <Binding.ValidationRules>
                                             <local:NonEmptyNameValidationRule TargetName="Action" ValidatesOnTargetUpdated="True"/>
                                         </Binding.ValidationRules>

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindowContext.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindowContext.cs
@@ -91,6 +91,9 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 
         private void OnActionNameChanged(object sender, ActionNameChangedEventArgs e)
         {
+            if (ActionNames.Contains(e.NewName.Trim()))
+                throw new ArgumentException($"Action \"{e.NewName}\" already exist in current profile");
+
             foreach (var page in Pages)
             {
                 foreach (var step in page.Steps)

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindowContext.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileOptionsWindowContext.cs
@@ -229,7 +229,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 
         public void AddAction()
         {
-            var newAction = new ActionProfileOptions { Name = "New Action" };
+            var newAction = new ActionProfileOptions { Name = ActionHelper.GetNextActionName(SelectedProfile.Actions) };
             SelectedProfile.Actions.Add(newAction);
             SelectedPage = newAction;
         }

--- a/VSRAD.Package/Utils/ActionHelper.cs
+++ b/VSRAD.Package/Utils/ActionHelper.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using VSRAD.Package.Options;
 
 namespace VSRAD.Package.Utils

--- a/VSRAD.Package/Utils/ActionHelper.cs
+++ b/VSRAD.Package/Utils/ActionHelper.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VSRAD.Package.Options;
+
+namespace VSRAD.Package.Utils
+{
+    public static class ActionHelper
+    {
+        public static string GetNextActionName(ObservableCollection<ActionProfileOptions> actions)
+        {
+            var currentActionName = "New Action";
+            var counter = 0;
+            foreach (var action in actions.OrderBy(a => a.Name))
+            {
+                if (action.Name == currentActionName)
+                    currentActionName = $"New Action {++counter}";
+            }
+            return currentActionName;
+        }
+    }
+}

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -259,6 +259,7 @@
     </Compile>
     <Compile Include="ToolWindows\EvaluateSelectedWindow.cs" />
     <Compile Include="ToolWindows\SliceVisualizerWindow.cs" />
+    <Compile Include="Utils\ActionHelper.cs" />
     <Compile Include="Utils\ArrayRange.cs" />
     <Compile Include="Utils\BreakModeConverter.cs" />
     <Compile Include="Utils\PinnableMruCollection.cs" />

--- a/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
@@ -105,5 +105,45 @@ namespace VSRAD.PackageTests.ProjectSystem
 
             breakLineTagger.Verify(t => t.OnExecutionCompleted(execCompletedEvent));
         }
+
+        [Fact]
+        public void ProperHandlingOfCircularDepsTest()
+        {
+            TestHelper.InitializePackageTaskFactory();
+
+            /* Create a test project */
+
+            var projectMock = new Mock<IProject>();
+            var options = new ProjectOptions();
+            options.SetProfiles(new Dictionary<string, ProfileOptions> { { "Default", new ProfileOptions() } }, activeProfile: "Default");
+            projectMock.Setup((p) => p.Options).Returns(options);
+            var breakLineTagger = new Mock<BreakLineGlyphTaggerProvider>();
+            projectMock.Setup((p) => p.GetExportByMetadataAndType(It.IsAny<Predicate<IAppliesToMetadataView>>(), It.IsAny<Predicate<IViewTaggerProvider>>()))
+                .Returns(breakLineTagger.Object);
+            var project = projectMock.Object;
+            project.Options.Profile.MenuCommands.DebugAction = "Debug";
+            project.Options.Profile.General.LocalWorkDir = "local/dir";
+            project.Options.Profile.General.RemoteWorkDir = "/periphery/votw";
+            project.Options.Profile.Actions.Add(new ActionProfileOptions { Name = "Debug" });
+            project.Options.Profile.Actions.Add(new ActionProfileOptions { Name = "New Action" });
+            // Create circular dependency
+            project.Options.Profile.Actions[0].Steps.Add(new RunActionStep { Name = "New Action" });
+            project.Options.Profile.Actions[1].Steps.Add(new RunActionStep { Name = "Debug" });
+
+            var codeEditor = new Mock<IActiveCodeEditor>();
+            var breakpointTracker = new Mock<IBreakpointTracker>();
+
+            var serviceProvider = new Mock<SVsServiceProvider>();
+
+            var channel = new MockCommunicationChannel();
+            var sourceManager = new Mock<IProjectSourceManager>();
+            var actionLauncher = new ActionLauncher(project, new Mock<IActionLogger>().Object, channel.Object, sourceManager.Object,
+                codeEditor.Object, breakpointTracker.Object, serviceProvider.Object);
+            var debuggerIntegration = new DebuggerIntegration(project, actionLauncher, codeEditor.Object, breakpointTracker.Object);
+
+            var engine = debuggerIntegration.RegisterEngine();
+            // Should not throw StackOverflow
+            engine.Execute(false);
+        }
     }
 }

--- a/VSRAD.PackageTests/ProjectSystem/Profiles/ProfileOptionsWindowContextTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Profiles/ProfileOptionsWindowContextTests.cs
@@ -384,6 +384,73 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
                 Assert.Null(r.Target);
         }
 
+        [Fact]
+        public void DefaultActionNamesSuffixTest()
+        {
+            var project = CreateTestProject();
+            // Emulate adding 5 actions with '+' button
+            for (var _i = 0; _i < 5; ++_i)
+            {
+                project.Options.Profiles["kana"].Actions.Add(new ActionProfileOptions
+                {
+                    Name = Package.Utils.ActionHelper.GetNextActionName(project.Options.Profiles["kana"].Actions)
+                });
+            }
+
+            Assert.Collection(project.Options.Profiles["kana"].Actions,
+                a0 => Assert.Equal("Debug", a0.Name),
+                a1 => Assert.Equal("New Action", a1.Name),
+                a2 => Assert.Equal("New Action 1", a2.Name),
+                a3 => Assert.Equal("New Action 2", a3.Name),
+                a4 => Assert.Equal("New Action 3", a4.Name),
+                a5 => Assert.Equal("New Action 4", a5.Name));
+
+            // Rename "Debug" -> "New Action 5"
+            project.Options.Profiles["kana"].Actions[0].Name = "New Action 5";
+
+            project.Options.Profiles["kana"].Actions.Add(new ActionProfileOptions
+            {
+                Name = Package.Utils.ActionHelper.GetNextActionName(project.Options.Profiles["kana"].Actions)
+            });
+
+            Assert.Collection(project.Options.Profiles["kana"].Actions,
+                a0 => Assert.Equal("New Action 5", a0.Name),
+                a1 => Assert.Equal("New Action", a1.Name),
+                a2 => Assert.Equal("New Action 1", a2.Name),
+                a3 => Assert.Equal("New Action 2", a3.Name),
+                a4 => Assert.Equal("New Action 3", a4.Name),
+                a5 => Assert.Equal("New Action 4", a5.Name),
+                a6 => Assert.Equal("New Action 6", a6.Name));
+
+            // Remove some actions
+            project.Options.Profiles["kana"].Actions.RemoveAt(3); // New Action 2
+            project.Options.Profiles["kana"].Actions.RemoveAt(3); // New Action 3
+            project.Options.Profiles["kana"].Actions.RemoveAt(3); // New Action 4
+
+            project.Options.Profiles["kana"].Actions.Add(new ActionProfileOptions
+            {
+                Name = Package.Utils.ActionHelper.GetNextActionName(project.Options.Profiles["kana"].Actions)
+            });
+
+            Assert.Collection(project.Options.Profiles["kana"].Actions,
+                a0 => Assert.Equal("New Action 5", a0.Name),
+                a1 => Assert.Equal("New Action", a1.Name),
+                a2 => Assert.Equal("New Action 1", a2.Name),
+                a3 => Assert.Equal("New Action 6", a3.Name),
+                a4 => Assert.Equal("New Action 2", a4.Name));
+        }
+
+        [Fact]
+        public void ActionRenamingValidationTest()
+        {
+            var project = CreateTestProject();
+            project.Options.Profiles["kana"].Actions.Add(new ActionProfileOptions { Name = "New Action" });
+
+            var context = new ProfileOptionsWindowContext(project, null, null);
+            var exception = Assert.Throws<ArgumentException>(() => GetDirtyProfile(context, "kana").Actions[1].Name = "Debug");
+            Assert.Equal("Action \"Debug\" already exist in current profile", exception.Message);
+        }
+
         #region Profile Transfer
         [Fact]
         public void ImportExportTest()


### PR DESCRIPTION
*#265 but targeted on current `dev-stable`*

___

Resolves #263 

This PR improves validation of the Action names. Previously, it was possible to have two Actions with the same name, which in some cases (for example `RunAction`) could lead to the undefined behaviour and even to crash of the Visual Studio.

This PR fixes possible crashed and adds new features:

* Now new Actions added by a `+` button are provided with unique number suffix to prevent creating of two Actions with the same name:
![image](https://user-images.githubusercontent.com/39794543/134509189-f19e0457-2cf5-4687-85fb-6971b1a95698.png)

* Added additional validation for renaming an Action, which ensures that new Action name is unique:
![image](https://user-images.githubusercontent.com/39794543/134509422-25764739-97f4-450f-8802-afc4e1fead02.png)
