### PR TITLE
[wip] Default Options Values

### DIFF
--- a/VSRAD.Package/Options/DefaultOptionValues.cs
+++ b/VSRAD.Package/Options/DefaultOptionValues.cs
@@ -7,7 +7,7 @@ namespace VSRAD.Package.Options
     {
         #region General
         public const string DeployDirectory = "";
-        public const string RemoteMachineAdredd = "127.0.0.1";
+        public const string RemoteMachineAdress = "127.0.0.1";
         public const int Port = 9339;
         public const string AdditionalSources = "";
         public const bool CopySources = true;

--- a/VSRAD.Package/Options/ProjectOptions.cs
+++ b/VSRAD.Package/Options/ProjectOptions.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -47,10 +48,12 @@ namespace VSRAD.Package.Options
         private string _activeProfile = "Default";
         public string ActiveProfile { get => _activeProfile; set { if (value != null) SetField(ref _activeProfile, value, raiseIfEqual: true); } }
 
-        private string _remoteMachine = "127.0.0.1";
+        private string _remoteMachine = DefaultOptionValues.RemoteMachineAdress;
+        [DefaultValue(DefaultOptionValues.RemoteMachineAdress)]
         public string RemoteMachine { get => _remoteMachine; set => SetField(ref _remoteMachine, value); }
 
-        private int _port = 9339;
+        private int _port = DefaultOptionValues.Port;
+        [DefaultValue(DefaultOptionValues.Port)]
         public int Port { get => _port; set => SetField(ref _port, value); }
 
         [JsonIgnore]


### PR DESCRIPTION
This PR fixes some default options values.
For example, after creation of new project on `dev-stable`, `TargetHosts` control will look like this:

![Pasted image 20220523105236](https://user-images.githubusercontent.com/39794543/169814630-c01f1e5f-67f8-495d-97c7-1748d218f5b0.png)

This PR returns proper behavior:

![Pasted image 20220523135133](https://user-images.githubusercontent.com/39794543/169814757-9f7811d5-352e-44ca-953f-c4d2738349e9.png)

## Consider next

* Looks like I added the only reference for `DefaultOptionValues` with this change. Do we need it? And if we do, maybe consider using it instead of hardcode values?
* We need to check initialization of others options, probably there is some issues similar to `TargetHosts`.