### PR TITLE
Profile Editor Hang Fix

### DIFF
--- a/VSRAD.Package/ProjectSystem/Macros/DirtyProfileMacroEditor.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/DirtyProfileMacroEditor.cs
@@ -120,7 +120,7 @@ namespace VSRAD.Package.ProjectSystem.Macros
                 var watches = _project.Options.DebuggerOptions.GetWatchSnapshot();
                 return new MacroEvaluatorTransientValues(sourceLine, file, breakLines, watches);
             }
-            catch (InvalidOperationException e) when (e.Message == ActiveCodeEditor.NoFilesOpenError)
+            catch (UserException e) when (e.Message == ActiveCodeEditor.NoFilesOpenError)
             {
                 return new MacroEvaluatorTransientValues(0,
                     sourcePath: "<current source full path>",


### PR DESCRIPTION
Resolves #297 

When no file opened in editor, VS hanged on attempt to add a new step in Profile Editor. This was caused by the incorrect error handling in `DirtyProfileMacroEditor`, which this PR fixes.