### PR TITLE
Environment Variables for Execute step

### DIFF
--- a/VSRAD.DebugServer/Client.cs
+++ b/VSRAD.DebugServer/Client.cs
@@ -97,7 +97,7 @@ namespace VSRAD.DebugServer
 
         private async Task<ICommand> ReadCommandAsync()
         {
-            var (command, bytesReceived) = await _socket.GetStream().ReadSerializedCommandAsync<ICommand>().ConfigureAwait(false);
+            var (command, bytesReceived) = await _socket.GetStream().ReadSerializedCommandAsync<ICommand>(Capabilities).ConfigureAwait(false);
             if (command != null)
                 Log.CommandReceived(command, bytesReceived);
 

--- a/VSRAD.DebugServer/IPC/Capabilities.cs
+++ b/VSRAD.DebugServer/IPC/Capabilities.cs
@@ -6,13 +6,15 @@ namespace VSRAD.DebugServer.IPC
 #pragma warning disable CA1028 // Using byte for enum storage because it's used for binary serialization
     public enum ServerCapability : byte
     {
-        Base = 0
+        Base = 0,
+        EnvVarSet = 1
     }
 
     public enum ExtensionCapability : byte
     {
         Base = 0,
-        ExecutionTimedOutResponse = 1 // The extension accepts ExecutionTimedOutResponse and replies with ExecutionTimedOutActionCommand. When this capability is absent, the server defaults to TerminateProcesses = true
+        ExecutionTimedOutResponse = 1, // The extension accepts ExecutionTimedOutResponse and replies with ExecutionTimedOutActionCommand. When this capability is absent, the server defaults to TerminateProcesses = true
+        EnvVarSet = 2
     }
 
     public enum ServerPlatform : byte
@@ -31,12 +33,14 @@ namespace VSRAD.DebugServer.IPC
         public static readonly HashSet<ExtensionCapability> LatestExtensionCapabilities = new HashSet<ExtensionCapability>(new[]
         {
             ExtensionCapability.Base,
-            ExtensionCapability.ExecutionTimedOutResponse
+            ExtensionCapability.ExecutionTimedOutResponse,
+            ExtensionCapability.EnvVarSet
         });
 
         public static readonly HashSet<ServerCapability> LatestServerCapabilities = new HashSet<ServerCapability>(new[]
         {
-            ServerCapability.Base
+            ServerCapability.Base,
+            ServerCapability.EnvVarSet
         });
 
         public CapabilityInfo(string version, ServerPlatform platform, HashSet<ServerCapability> capabilities)

--- a/VSRAD.DebugServer/IPC/Commands.cs
+++ b/VSRAD.DebugServer/IPC/Commands.cs
@@ -100,6 +100,8 @@ namespace VSRAD.DebugServer.IPC.Commands
 
         public int ExecutionTimeoutSecs { get; set; }
 
+        public Dictionary<string, string> EnvironmentVariables { get; private set; } = new Dictionary<string, string>();
+
         public override string ToString() => string.Join(Environment.NewLine, new[]
         {
             "Execute",
@@ -117,7 +119,8 @@ namespace VSRAD.DebugServer.IPC.Commands
             Executable = reader.ReadString(),
             Arguments = reader.ReadString(),
             RunAsAdministrator = reader.ReadBoolean(),
-            ExecutionTimeoutSecs = reader.ReadInt32()
+            ExecutionTimeoutSecs = reader.ReadInt32(),
+            EnvironmentVariables = reader.ReadLengthPrefixedStringDict()
         };
 
         public void Serialize(IPCWriter writer)
@@ -127,6 +130,7 @@ namespace VSRAD.DebugServer.IPC.Commands
             writer.Write(Arguments);
             writer.Write(RunAsAdministrator);
             writer.Write(ExecutionTimeoutSecs);
+            writer.WriteLengthPrefixedDict(EnvironmentVariables);
         }
     }
 

--- a/VSRAD.DebugServer/IPC/StreamExtensions.cs
+++ b/VSRAD.DebugServer/IPC/StreamExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,7 +14,7 @@ namespace VSRAD.DebugServer
         // Since every command and response contains at least one byte (message type), zero-length messages are treated as pings
         private static readonly byte[] _pingMessage = new byte[] { 0, 0, 0, 0 };
 
-        public static async Task<(T, int)> ReadSerializedCommandAsync<T>(this Stream stream) where T : ICommand
+        public static async Task<(T, int)> ReadSerializedCommandAsync<T>(this Stream stream, HashSet<ExtensionCapability> extensionCapabilities) where T : ICommand
         {
             while (true) // Loop to reply to pings (sent in case of long-running commands)
             {
@@ -40,7 +41,7 @@ namespace VSRAD.DebugServer
                 }
                 using (var memStream = new MemoryStream(messageBytes))
                 using (var reader = new IPCReader(memStream))
-                    return ((T)reader.ReadCommand(), messageLength);
+                    return ((T)reader.ReadCommand(extensionCapabilities), messageLength);
             }
         }
 

--- a/VSRAD.DebugServer/SharedUtils/ObservableProcess.cs
+++ b/VSRAD.DebugServer/SharedUtils/ObservableProcess.cs
@@ -45,6 +45,9 @@ namespace VSRAD.DebugServer.SharedUtils
                 _process.StartInfo.RedirectStandardOutput = true;
                 _process.StartInfo.RedirectStandardError = true;
             }
+            foreach (KeyValuePair<string, string> envVar in command.EnvironmentVariables)
+                _process.StartInfo.EnvironmentVariables.Add(envVar.Key, envVar.Value);
+
             _waitForCompletion = command.WaitForCompletion;
             _timeout = command.ExecutionTimeoutSecs;
         }

--- a/VSRAD.Package/Options/Actions.cs
+++ b/VSRAD.Package/Options/Actions.cs
@@ -220,6 +220,9 @@ namespace VSRAD.Package.Options
         private bool _confirmTerminationOnTimeout = true;
         public bool ConfirmTerminationOnTimeout { get => _confirmTerminationOnTimeout; set => SetField(ref _confirmTerminationOnTimeout, value); }
 
+        private string _environmentVariables = "";
+        public string EnvironmentVariables { get => _environmentVariables; set => SetField(ref _environmentVariables, value); }
+
         public override string ToString()
         {
             if (string.IsNullOrWhiteSpace(Executable))
@@ -281,7 +284,8 @@ namespace VSRAD.Package.Options
                 // Hence it is always true for a remote ExecuteStep. If it's forced to run locally, we should respect this behavior.
                 WaitForCompletion = Environment == StepEnvironment.Remote || WaitForCompletion,
                 TimeoutSecs = TimeoutSecs,
-                ConfirmTerminationOnTimeout = ConfirmTerminationOnTimeout
+                ConfirmTerminationOnTimeout = ConfirmTerminationOnTimeout,
+                EnvironmentVariables = EnvironmentVariables
             };
         }
     }

--- a/VSRAD.Package/Options/Actions.cs
+++ b/VSRAD.Package/Options/Actions.cs
@@ -250,6 +250,11 @@ namespace VSRAD.Package.Options
             if (string.IsNullOrWhiteSpace(Executable))
                 return EvaluationError(sourceAction, "Execute", "No executable specified");
 
+            if (env.ServerCapabilities.Capabilities != null && // server capabilities is null while we editing action without running debug session
+                !string.IsNullOrWhiteSpace(EnvironmentVariables) &&
+                !env.ServerCapabilities.Capabilities.Contains(ServerCapability.EnvVarSet))
+                return EvaluationError(sourceAction, "Execute", "Remote environment variables are set, but Debug Server does not support this functionality. Please, get the latest Debug Server.");
+
             var executableResult = await evaluator.EvaluateAsync(Executable);
             if (!executableResult.TryGetResult(out var evaluatedExecutable, out var error))
                 return error;

--- a/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
@@ -31,6 +31,7 @@
         <local:ActionEditorIfNotModifiedConverter x:Key="IfNotModifiedConverter"/>
         <utils:WpfBoolToIndexConverter x:Key="BoolToIndexConverter"/>
         <utils:WpfInverseBoolConverter x:Key="InverseBoolConverter"/>
+        <utils:WpfEvironmentVariableConverter x:Key="EnvironmentVariableConverter"/>
         <utils:WpfBoolToVisibilityConverter x:Key="VisibleWhenTrueConverter" TrueValue="Visible" FalseValue="Collapsed" />
         <utils:WpfBoolToVisibilityConverter x:Key="VisibleWhenFalseConverter" TrueValue="Collapsed" FalseValue="Visible" />
     </UserControl.Resources>
@@ -209,6 +210,7 @@
                                 </RowDefinition>
                                 <RowDefinition Height="26"/>
                                 <RowDefinition Height="26"/>
+                                <RowDefinition Height="26"/>
                             </Grid.RowDefinitions>
                             <Label Content="Environment:" VerticalContentAlignment="Center" Padding="4,0" Height="22" Grid.Row="0" Grid.Column="0"/>
                             <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Height="22">
@@ -254,6 +256,10 @@
                                 <ComboBoxItem Content="Ask" ToolTip="Show a dialog with a choice to wait for the process to finish or terminate it"/>
                                 <ComboBoxItem Content="Terminate" ToolTip="Terminate the process and its subprocesses immediately"/>
                             </ComboBox>
+
+                            <Label Content="Environment Variables:" VerticalContentAlignment="Center" Padding="4,0" Height="22" Grid.Row="8" Grid.Column="0"/>
+                            <TextBox Text="{Binding EnvironmentVariables, UpdateSourceTrigger=PropertyChanged}" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                     Height="22" Width="160" Grid.Row="8" Grid.Column="1"/>
                         </Grid>
                     </DataTemplate>
                     <DataTemplate DataType="{x:Type opts:OpenInEditorStep}">

--- a/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/ActionEditor.xaml
@@ -31,7 +31,6 @@
         <local:ActionEditorIfNotModifiedConverter x:Key="IfNotModifiedConverter"/>
         <utils:WpfBoolToIndexConverter x:Key="BoolToIndexConverter"/>
         <utils:WpfInverseBoolConverter x:Key="InverseBoolConverter"/>
-        <utils:WpfEvironmentVariableConverter x:Key="EnvironmentVariableConverter"/>
         <utils:WpfBoolToVisibilityConverter x:Key="VisibleWhenTrueConverter" TrueValue="Visible" FalseValue="Collapsed" />
         <utils:WpfBoolToVisibilityConverter x:Key="VisibleWhenFalseConverter" TrueValue="Collapsed" FalseValue="Visible" />
     </UserControl.Resources>

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -277,6 +277,8 @@ namespace VSRAD.Package.Server
                 WaitForCompletion = step.WaitForCompletion,
                 ExecutionTimeoutSecs = step.TimeoutSecs
             };
+            command.EnvironmentVariables.Add("MESSAGE", "Hello");
+            command.EnvironmentVariables.Add("MESSAGE2", "world");
             IResponse response;
             if (step.Environment == StepEnvironment.Local)
             {

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -277,8 +277,11 @@ namespace VSRAD.Package.Server
                 WaitForCompletion = step.WaitForCompletion,
                 ExecutionTimeoutSecs = step.TimeoutSecs
             };
-            command.EnvironmentVariables.Add("MESSAGE", "Hello");
-            command.EnvironmentVariables.Add("MESSAGE2", "world");
+            foreach (var envVar in step.EnvironmentVariables.Split(';'))
+            {
+                var keyValue = envVar.Split('=');
+                command.EnvironmentVariables.Add(keyValue[0], keyValue[1]);
+            }
             IResponse response;
             if (step.Environment == StepEnvironment.Local)
             {

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -277,10 +277,14 @@ namespace VSRAD.Package.Server
                 WaitForCompletion = step.WaitForCompletion,
                 ExecutionTimeoutSecs = step.TimeoutSecs
             };
-            foreach (var envVar in step.EnvironmentVariables.Split(';'))
+            if (!string.IsNullOrWhiteSpace(step.EnvironmentVariables))
             {
-                var keyValue = envVar.Split('=');
-                command.EnvironmentVariables.Add(keyValue[0], keyValue[1]);
+                foreach (var envVar in step.EnvironmentVariables.Split(';'))
+                {
+                    var keyValue = envVar.Split('=');
+                    if (keyValue.Length != 2) continue; // skip invalid variables
+                    command.EnvironmentVariables.Add(keyValue[0], keyValue[1]);
+                }
             }
             IResponse response;
             if (step.Environment == StepEnvironment.Local)

--- a/VSRAD.PackageTests/Server/ActionRunnerTests.cs
+++ b/VSRAD.PackageTests/Server/ActionRunnerTests.cs
@@ -455,6 +455,33 @@ namespace VSRAD.PackageTests.Server
             Assert.Null(result.StepResults[1].SubAction);
         }
 
+        [Fact]
+        public async Task SetsEnvironmentVarialbesLocalAsync()
+        {
+            var channel = new MockCommunicationChannel();
+            var cmd = "cmd.exe";
+            var env = "A1=\"A system of cells.\";A2=\"Within cells interlinked.\"";
+
+            var question = new ExecuteStep();
+            question.Arguments = "/C \"echo %A1%\"";
+            question.Executable = cmd;
+            question.Environment = StepEnvironment.Local;
+            question.EnvironmentVariables = env;
+
+            var answer = new ExecuteStep();
+            answer.Arguments = "/C \"echo %A2%\"";
+            answer.Executable = cmd;
+            answer.Environment = StepEnvironment.Local;
+            answer.EnvironmentVariables = env;
+
+            var runner = new ActionRunner(channel, MockController(), null);
+            var response = await runner.RunAsync("Baseline Test", new List<IActionStep>() { question, answer });
+
+            Assert.True(response.Successful);
+            Assert.Equal("Captured stdout (exit code 0):\r\n\"A system of cells.\"\r\n", response.StepResults[0].Log);
+            Assert.Equal("Captured stdout (exit code 0):\r\n\"Within cells interlinked.\"\r\n", response.StepResults[1].Log);
+        }
+
         #region ReadDebugDataStep
         [Fact]
         public async Task ReadDebugDataRemoteTestAsync()


### PR DESCRIPTION
This PR adds a new textbox named `Environment Variables` to the `Execute` step properties. Specified environment variables will be set for the execution of the command.