### PR TITLE
Fix: Function List proper Open in Editor handling

### DIFF
--- a/VSRAD.Syntax/Core/DocumentFactory.cs
+++ b/VSRAD.Syntax/Core/DocumentFactory.cs
@@ -20,6 +20,7 @@ namespace VSRAD.Syntax.Core
         private readonly Dictionary<string, IDocument> _documents;
         private readonly Lazy<IInstructionListManager> _instructionManager;
         private readonly Lazy<IInvisibleTextDocumentFactory> _invisibleDocumentFactory;
+        private readonly DTE _dte;
 
 
         public event ActiveDocumentChangedEventHandler ActiveDocumentChanged;
@@ -42,7 +43,11 @@ namespace VSRAD.Syntax.Core
 
             var dte = _serviceProvider.ServiceProvider.GetService(typeof(DTE)) as DTE;
             dte.Events.WindowEvents.WindowActivated += OnChangeActivatedWindow;
+
+            _dte = dte;
         }
+
+        public string GetActiveDocumentPath() => _dte.ActiveDocument.FullName;
 
         public IDocument GetOrCreateDocument(string path)
         {

--- a/VSRAD.Syntax/Core/IDocumentFactory.cs
+++ b/VSRAD.Syntax/Core/IDocumentFactory.cs
@@ -8,6 +8,10 @@ namespace VSRAD.Syntax.Core
 
     public interface IDocumentFactory
     {
+        /// <summary>
+        /// Returns current active document full path
+        /// </summary>
+        /// <returns>String, active document full path</returns>
         string GetActiveDocumentPath();
 
         /// <summary>

--- a/VSRAD.Syntax/Core/IDocumentFactory.cs
+++ b/VSRAD.Syntax/Core/IDocumentFactory.cs
@@ -8,6 +8,8 @@ namespace VSRAD.Syntax.Core
 
     public interface IDocumentFactory
     {
+        string GetActiveDocumentPath();
+
         /// <summary>
         /// Gets <see cref="IDocument"/> or creates if doesn't exist
         /// </summary>

--- a/VSRAD.Syntax/FunctionList/FunctionListProvider.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionListProvider.cs
@@ -121,7 +121,7 @@ namespace VSRAD.Syntax.FunctionList
                 ClearFunctionList();
         }
 
-        private void ActiveDocumentChanged(IDocument activeDocument)
+        private void ActiveDocumentChanged(IDocument activeDocument) // KEKER TODO
         {
             if (_functionListControl == null) return;
 
@@ -156,7 +156,10 @@ namespace VSRAD.Syntax.FunctionList
                 return;
 
             var document = _documentFactory.GetOrCreateDocument(analysisResult.Snapshot.TextBuffer);
-            UpdateFunctionList(document, analysisResult, cancellationToken);
+            // there is cases, when new document is opened, but it do not become active (see Open in Editor: Preserve active document)
+            // in this case we don't want to update function list, so check that target document is in fact active
+            if (_documentFactory.GetActiveDocumentPath() == document.Path)
+                UpdateFunctionList(document, analysisResult, cancellationToken);
         }
 
         private void UpdateFunctionList(IDocument document, IAnalysisResult analysisResult, CancellationToken cancellationToken)

--- a/VSRAD.Syntax/FunctionList/FunctionListProvider.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionListProvider.cs
@@ -121,7 +121,7 @@ namespace VSRAD.Syntax.FunctionList
                 ClearFunctionList();
         }
 
-        private void ActiveDocumentChanged(IDocument activeDocument) // KEKER TODO
+        private void ActiveDocumentChanged(IDocument activeDocument)
         {
             if (_functionListControl == null) return;
 


### PR DESCRIPTION
This PR fixes incorrect handling of opening new file in editor by the `Function List`.

Steps to reproduce:
1.  Open any assembly source file in project, so `Function List` will update according to it's contents
2. Check both `Open in Editor: ...` checkboxes inside `RAD Options`
3. Create action that contains `Open in Editor` step with other assembly source file, that should trigger `Function List` to update
4. Run this action

You will see, that new pane is created for the source file from the `Open in Editor` step while active document tab should remain the same. However, `Function List` will be updated with contents of newly opened file, so it will be desynchonized with current active document, which is not expected.

With changes in this PR `Function List` won't update if newly opened document is not active, so in same case it will continue to show functions from original document.