### PR TITLE
Unsuccessful debug action handling

### DIFF
--- a/VSRAD.Deborgar/IEngineIntegration.cs
+++ b/VSRAD.Deborgar/IEngineIntegration.cs
@@ -7,12 +7,14 @@ namespace VSRAD.Deborgar
         public string File { get; }
         public uint[] Lines { get; }
         public bool IsStepping { get; }
+        public bool CompletedSuccessfully { get; }
 
-        public ExecutionCompletedEventArgs(string file, uint[] lines, bool isStepping)
+        public ExecutionCompletedEventArgs(string file, uint[] lines, bool isStepping, bool completedSuccessfully)
         {
             File = file;
             Lines = lines;
             IsStepping = isStepping;
+            CompletedSuccessfully = completedSuccessfully;
         }
     }
 

--- a/VSRAD.Package/ProjectSystem/ActionLauncher.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLauncher.cs
@@ -123,6 +123,7 @@ namespace VSRAD.Package.ProjectSystem
                 var runner = new ActionRunner(_channel, _serviceProvider, env, _project);
                 var runResult = await runner.RunAsync(action.Name, action.Steps, _project.Options.Profile.General.ContinueActionExecOnError).ConfigureAwait(false);
                 var actionError = await _actionLogger.LogActionWithWarningsAsync(runResult).ConfigureAwait(false);
+                if (!actionError.HasValue) _breakpointTracker.UpdateBreakTarget((file, breakLines));
                 return new ActionExecution(actionError, transients, runResult);
             }
             finally

--- a/VSRAD.Package/ProjectSystem/BreakpointTracker.cs
+++ b/VSRAD.Package/ProjectSystem/BreakpointTracker.cs
@@ -17,6 +17,7 @@ namespace VSRAD.Package.ProjectSystem
         (string, uint[]) GetBreakTarget();
         void SetRunToLine(string file, uint line);
         void ResetToFirstBreakTarget();
+        void UpdateBreakTarget((string, uint[]) target);
     }
 
     [Export(typeof(IBreakpointTracker))]
@@ -76,9 +77,10 @@ namespace VSRAD.Package.ProjectSystem
                 _runToLine = null;
             }
 
-            _breakTargets[target.Item1] = target.Item2;
             return target;
         }
+
+        public void UpdateBreakTarget((string, uint[]) target) => _breakTargets[target.Item1] = target.Item2;
 
         public (string, uint[]) GetBreakTarget()
         {

--- a/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
+++ b/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
@@ -110,7 +110,7 @@ namespace VSRAD.Package.ProjectSystem
 
         private void RaiseExecutionCompleted(string file, uint[] lines, bool isStepping, BreakState breakState)
         {
-            var args = new ExecutionCompletedEventArgs(file, lines, isStepping);
+            var args = new ExecutionCompletedEventArgs(file, lines, isStepping, breakState != null);
             ExecutionCompleted?.Invoke(this, args);
             _breakLineTagger.OnExecutionCompleted(args);
             BreakEntered(this, breakState);

--- a/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphTagger.cs
+++ b/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphTagger.cs
@@ -46,7 +46,10 @@ namespace VSRAD.Package.ProjectSystem.EditorExtensions
                     m.Invalidate();
 
                 // Draw our own markers
-                DebugExecutionCompleted?.Invoke(this, execCompleted);
+                if (execCompleted.CompletedSuccessfully)
+                    DebugExecutionCompleted?.Invoke(this, execCompleted);
+                else
+                    RemoveBreakLineMarkers();
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Resolves #306 

Previously, unsuccessful debug action would still trigger the line markers moving to the next breakpoint, which is misleading.

This PR handles this situation, so no line markers would be drawn and next debugger invocation will properly identify next breakpoint location.