### PR TITLE
Clang messages not appear in Error List fix

### DIFF
--- a/VSRAD.Package/BuildTools/Errors/Parser.cs
+++ b/VSRAD.Package/BuildTools/Errors/Parser.cs
@@ -102,11 +102,11 @@ namespace VSRAD.Package.BuildTools.Errors
 
         private static MessageKind ParseMessageKind(string kind)
         {
-            switch (kind)
+            switch (kind.ToUpperInvariant())
             {
-                case "E": case "error": case "ERROR": case "fatal error": return MessageKind.Error;
-                case "W": case "warning": case "WARNING": return MessageKind.Warning;
-                case "note": return MessageKind.Note;
+                case "E": case "ERROR": case "FATAL ERROR": return MessageKind.Error;
+                case "W": case "WARNING": return MessageKind.Warning;
+                case "NOTE": return MessageKind.Note;
                 default: throw new ArgumentException(kind, nameof(kind));
             }
         }

--- a/VSRAD.Package/BuildTools/Errors/Parser.cs
+++ b/VSRAD.Package/BuildTools/Errors/Parser.cs
@@ -37,7 +37,7 @@ namespace VSRAD.Package.BuildTools.Errors
         }
 
         private static readonly Regex ClangErrorRegex = new Regex(
-            @"(?<file>.+):(?<line>\d+):(?<col>\d+):\s*(?<kind>error|warning|note):\s(?<text>.+)", RegexOptions.Compiled);
+            @"(?<file>.+):(?<line>\d+):(?<col>\d+):\s*(?<kind>error|warning|note|fatal error):\s(?<text>.+)", RegexOptions.Compiled);
 
         private static Message ParseClangMessage(string header)
         {
@@ -104,7 +104,7 @@ namespace VSRAD.Package.BuildTools.Errors
         {
             switch (kind)
             {
-                case "E": case "error": case "ERROR": return MessageKind.Error;
+                case "E": case "error": case "ERROR": case "fatal error": return MessageKind.Error;
                 case "W": case "warning": case "WARNING": return MessageKind.Warning;
                 case "note": return MessageKind.Note;
                 default: throw new ArgumentException(kind, nameof(kind));

--- a/VSRAD.PackageTests/BuildTools/Errors/ParserTests.cs
+++ b/VSRAD.PackageTests/BuildTools/Errors/ParserTests.cs
@@ -18,6 +18,10 @@ Relative\path\host.c:4:2: warning: implicitly declaring library function 'printf
         printf(""h"");
         ^
 C:\Absolute\Path\host.c:4:2: note: include the header<stdio.h> or explicitly provide a declaration for 'printf'
+
+input.s:16:10: fatal error: 'abcde.s' file not found
+#include ""abcde.s""
+         ^~~~~~~~~
 ";
 
         public static readonly Message[] ClangExpectedMessages = new Message[]
@@ -35,7 +39,11 @@ C:\Absolute\Path\host.c:4:2: note: include the header<stdio.h> or explicitly pro
         printf(""h"");
         ^"},
             new Message { Kind = MessageKind.Note, Line = 4, Column = 2, SourceFile = @"C:\Absolute\Path\host.c", Text =
-                "include the header<stdio.h> or explicitly provide a declaration for 'printf'" },
+                "include the header<stdio.h> or explicitly provide a declaration for 'printf'\r\n" },
+            new Message { Kind = MessageKind.Error, Line = 16, Column = 10, SourceFile = "input.s", Text =
+@"'abcde.s' file not found
+#include ""abcde.s""
+         ^~~~~~~~~" }
         };
 
         [Fact]


### PR DESCRIPTION
Resolves #311 

This PR adds support for Clang `Fatal errors` that used to be ignored.

Example of error message:

```
input.s:16:10: fatal error: 'abcde.s' file not found
#include "abcde.s"
         ^~~~~~~~~
```