### PR TITLE
FL displays incomplete function names fix

### DIFF
--- a/VSRAD.Syntax/FunctionList/FunctionListControl.xaml
+++ b/VSRAD.Syntax/FunctionList/FunctionListControl.xaml
@@ -35,7 +35,7 @@
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Name="LineNumberButtonColumn" Width="*"/>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Name="FunctionNameButtonColumn" Width="*"/>
             </Grid.ColumnDefinitions>
 
             <Button Content="Line" x:Name="byNumber" Click="ByNumber_Click" Grid.Column="0"/>
@@ -49,6 +49,7 @@
                   MouseDoubleClick="FunctionsName_MouseDoubleClick"
                   PreviewKeyDown="Functions_PreviewKeyDown"
                   >
+            <ScrollViewer.HorizontalScrollBarVisibility>Hidden</ScrollViewer.HorizontalScrollBarVisibility>
             <ListView.Resources>
                 <Style TargetType="GridViewColumnHeader">
                     <Setter Property="Visibility" Value="Collapsed" />

--- a/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
@@ -153,7 +153,7 @@ namespace VSRAD.Syntax.FunctionList
             if (!hideLineNumber)
                 functionsGridView.Columns[0].Width = double.NaN;
             functionsGridView.Columns[1].Width = 0;
-            functionsGridView.Columns[1].Width = double.NaN;
+            functionsGridView.Columns[1].Width = FunctionNameButtonColumn.ActualWidth;
         }
 
         private void SetLineNumberColumnWidth()


### PR DESCRIPTION
Resolves #303 

Edited hacky way to autosize Function List columns and disabled horizontal scrollbar, which fixes the incomplete function names bug.