### PR TITLE
Incomplete function names fix

### DIFF
--- a/VSRAD.Build/VSRAD.Build.csproj
+++ b/VSRAD.Build/VSRAD.Build.csproj
@@ -9,9 +9,6 @@
     <RootNamespace>VSRAD.Build</RootNamespace>
     <AssemblyName>VSRAD.Build</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-	<StartAction>Program</StartAction>
-	<StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
-	<StartArguments>/rootsuffix Exp</StartArguments>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/VSRAD.Build/VSRAD.Build.csproj
+++ b/VSRAD.Build/VSRAD.Build.csproj
@@ -9,6 +9,9 @@
     <RootNamespace>VSRAD.Build</RootNamespace>
     <AssemblyName>VSRAD.Build</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+	<StartAction>Program</StartAction>
+	<StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+	<StartArguments>/rootsuffix Exp</StartArguments>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/VSRAD.Syntax/FunctionList/FunctionListControl.xaml
+++ b/VSRAD.Syntax/FunctionList/FunctionListControl.xaml
@@ -49,6 +49,7 @@
                   MouseDoubleClick="FunctionsName_MouseDoubleClick"
                   PreviewKeyDown="Functions_PreviewKeyDown"
                   >
+            <ScrollViewer.HorizontalScrollBarVisibility>Hidden</ScrollViewer.HorizontalScrollBarVisibility>
             <ListView.Resources>
                 <Style TargetType="GridViewColumnHeader">
                     <Setter Property="Visibility" Value="Collapsed" />

--- a/VSRAD.Syntax/FunctionList/FunctionListControl.xaml
+++ b/VSRAD.Syntax/FunctionList/FunctionListControl.xaml
@@ -61,7 +61,7 @@
             <ListView.View>
                 <GridView x:Name="functionsGridView">
                     <GridViewColumn Header="Line" DisplayMemberBinding="{Binding Path=LineNumber}" Width="Auto"/>
-                    <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Path=Text}"/>
+                    <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Path=Text}" Width="Auto"/>
                 </GridView>
             </ListView.View>
         </ListView>

--- a/VSRAD.Syntax/FunctionList/FunctionListControl.xaml
+++ b/VSRAD.Syntax/FunctionList/FunctionListControl.xaml
@@ -53,6 +53,10 @@
                 <Style TargetType="GridViewColumnHeader">
                     <Setter Property="Visibility" Value="Collapsed" />
                 </Style>
+                <Style TargetType="TextBlock">
+                    <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+                    <Setter Property="ToolTip" Value="{Binding RelativeSource={RelativeSource Self}, Path=Text }" />
+                </Style>
             </ListView.Resources>
             <ListView.View>
                 <GridView x:Name="functionsGridView">

--- a/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
+++ b/VSRAD.Syntax/FunctionList/FunctionListControl.xaml.cs
@@ -54,7 +54,11 @@ namespace VSRAD.Syntax.FunctionList
         public void ShowHideLineNumber()
         {
             hideLineNumber = !hideLineNumber;
-            AutosizeColumns();
+
+            // Show/Hide first column
+            functionsGridView.Columns[0].Width = hideLineNumber
+                                               ? 0
+                                               : double.NaN;
         }
 
         public void ClearSearch() => Search.Text = "";
@@ -142,26 +146,32 @@ namespace VSRAD.Syntax.FunctionList
 
             ApplySort();
 
-            /* Needs to update line number column width after adding new items */
+            // Needs to update line number column width after adding new items
             AutosizeColumns();
         }
 
         private void AutosizeColumns()
         {
-            /* This is a well know behaviour of GridView https://stackoverflow.com/questions/560581/how-to-autosize-and-right-align-gridviewcolumn-data-in-wpf/1931423#1931423 */
-            functionsGridView.Columns[0].Width = 0;
-            if (!hideLineNumber)
-                functionsGridView.Columns[0].Width = double.NaN;
-            functionsGridView.Columns[1].Width = 0;
-            functionsGridView.Columns[1].Width = double.NaN;
+            // Setting to double.NaN frees ActualWidth upper bound
+            functionsGridView.Columns[0].Width = hideLineNumber
+                                               ? 0
+                                               : double.NaN;
+        }
+
+        private void AdjustColumnsOnRendering()
+        {
+            // Line Number ActualWidth will apply only after UpdateLayout only then it can be compared with min width
+            // Only happens when column is not hidden
+            if (functionsGridView.Columns[0].ActualWidth > 0)
+            {
+                functionsGridView.Columns[0].Width = Math.Max(functionsGridView.Columns[0].ActualWidth, 45.4 /*min width equals to 5 digits*/);
+            }
+            functionsGridView.Columns[1].Width = FunctionListWindow.ActualWidth - functionsGridView.Columns[0].Width;
         }
 
         private void SetLineNumberColumnWidth()
         {
-            // Line Number ActualWidth will apply only after UpdateLayout only then it can be compared with min width
-            if (functionsGridView.Columns[0].ActualWidth > 0)
-                functionsGridView.Columns[0].Width = Math.Max(functionsGridView.Columns[0].ActualWidth, 45.4 /*min width equals to 5 digits*/);
-
+            AdjustColumnsOnRendering();
             LineNumberButtonColumn.Width = new GridLength(functionsGridView.Columns[0].ActualWidth);
         }
 


### PR DESCRIPTION
Fixes [#303 ](https://github.com/vsrad/radeon-asm-tools/issues/303).
Column sizes are explicitly calculated on the rendering stage.