### PR TITLE
[BugFix] GroupSize value for NDRange3D mode

### DIFF
--- a/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
+++ b/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
@@ -112,7 +112,9 @@ namespace VSRAD.Package.DebugVisualizer
             _projectOptions.DebuggerOptions.NGroups = _currentDispatchParams.NDRange3D
                 ? _currentDispatchParams.DimX * _currentDispatchParams.DimY * _currentDispatchParams.DimZ
                 : _currentDispatchParams.DimX;
-            _projectOptions.DebuggerOptions.GroupSize = _currentDispatchParams.GroupSizeX;
+            _projectOptions.DebuggerOptions.GroupSize = _currentDispatchParams.NDRange3D
+                ? _currentDispatchParams.GroupSizeX * _currentDispatchParams.GroupSizeY * _currentDispatchParams.GroupSizeZ
+                : _currentDispatchParams.GroupSizeX;
 
             _updateOptions = true;
             Update();


### PR DESCRIPTION
This PR fixes GroupSize value for NDRange3D mode.
Previously, dispatch parameters in visualizer did not work properly for 3D groups.

Dispatch parameter example:
```
grid_size (32, 1, 8)
group_size (32, 1, 8)
wave_size 32
```