### PR TITLE
Version handshake

### DIFF
--- a/VSRAD.DebugServer/Dispatcher.cs
+++ b/VSRAD.DebugServer/Dispatcher.cs
@@ -16,6 +16,7 @@ namespace VSRAD.DebugServer
             PutFileCommand pf => new PutFileHandler(pf).RunAsync(),
             Deploy d => new DeployHandler(d, clientLog).RunAsync(),
             ListEnvironmentVariables lev => new ListEnvironmentVariablesHandler(lev).RunAsync(),
+            GetMinimalExtensionVersion gmex => new GetMinimalExtensionVersionHandler(gmex).RunAsync(),
             _ => throw new ArgumentException($"Unknown command type {command.GetType()}"),
         };
     }

--- a/VSRAD.DebugServer/Handlers/GetMinimalExtensionVersionHandler.cs
+++ b/VSRAD.DebugServer/Handlers/GetMinimalExtensionVersionHandler.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using VSRAD.DebugServer.IPC.Responses;
+
+namespace VSRAD.DebugServer.Handlers
+{
+    class GetMinimalExtensionVersionHandler : IHandler
+    {
+        public GetMinimalExtensionVersionHandler(IPC.Commands.GetMinimalExtensionVersion _) { }
+
+        public Task<IResponse> RunAsync()
+            => Task.FromResult<IResponse>(new MinimalExtensionVersion {
+                MinExtensionVersion = Server.MIN_EXT_VERSION,
+                ServerVersion = typeof(GetMinimalExtensionVersionHandler).Assembly.GetName().Version.ToString(3)
+            });
+    }
+}

--- a/VSRAD.DebugServer/IPC/Commands.cs
+++ b/VSRAD.DebugServer/IPC/Commands.cs
@@ -11,7 +11,8 @@ namespace VSRAD.DebugServer.IPC.Commands
         FetchResultRange = 2,
         Deploy = 3,
         ListEnvironmentVariables = 4,
-        PutFile = 5
+        PutFile = 5,
+        GetSExtensionVersion = 6
     }
 #pragma warning restore CA1028
 
@@ -36,6 +37,7 @@ namespace VSRAD.DebugServer.IPC.Commands
                 case CommandType.Deploy: return Deploy.Deserialize(reader);
                 case CommandType.ListEnvironmentVariables: return ListEnvironmentVariables.Deserialize(reader);
                 case CommandType.PutFile: return PutFileCommand.Deserialize(reader);
+                case CommandType.GetSExtensionVersion: return GetMinimalExtensionVersion.Deserialize(reader);
             }
             throw new InvalidDataException($"Unexpected command type byte: {type}");
         }
@@ -51,6 +53,7 @@ namespace VSRAD.DebugServer.IPC.Commands
                 case Deploy _: type = CommandType.Deploy; break;
                 case ListEnvironmentVariables _: type = CommandType.ListEnvironmentVariables; break;
                 case PutFileCommand _: type = CommandType.PutFile; break;
+                case GetMinimalExtensionVersion _: type = CommandType.GetSExtensionVersion; break;
                 default: throw new ArgumentException($"Unable to serialize {command.GetType()}");
             }
             writer.Write((byte)type);
@@ -234,5 +237,14 @@ namespace VSRAD.DebugServer.IPC.Commands
         public static ListEnvironmentVariables Deserialize(IPCReader _) => new ListEnvironmentVariables();
 
         public void Serialize(IPCWriter _) { }
+    }
+
+    public sealed class GetMinimalExtensionVersion : ICommand
+    {
+        public override string ToString() => "GetMinimalExtensionVersion";
+
+        public void Serialize(IPCWriter writer) { }
+
+        public static GetMinimalExtensionVersion Deserialize(IPCReader _) => new GetMinimalExtensionVersion();
     }
 }

--- a/VSRAD.DebugServer/IPC/Commands.cs
+++ b/VSRAD.DebugServer/IPC/Commands.cs
@@ -12,7 +12,7 @@ namespace VSRAD.DebugServer.IPC.Commands
         Deploy = 3,
         ListEnvironmentVariables = 4,
         PutFile = 5,
-        GetSExtensionVersion = 6
+        GetExtensionVersion = 6
     }
 #pragma warning restore CA1028
 
@@ -37,7 +37,7 @@ namespace VSRAD.DebugServer.IPC.Commands
                 case CommandType.Deploy: return Deploy.Deserialize(reader);
                 case CommandType.ListEnvironmentVariables: return ListEnvironmentVariables.Deserialize(reader);
                 case CommandType.PutFile: return PutFileCommand.Deserialize(reader);
-                case CommandType.GetSExtensionVersion: return GetMinimalExtensionVersion.Deserialize(reader);
+                case CommandType.GetExtensionVersion: return GetMinimalExtensionVersion.Deserialize(reader);
             }
             throw new InvalidDataException($"Unexpected command type byte: {type}");
         }
@@ -53,7 +53,7 @@ namespace VSRAD.DebugServer.IPC.Commands
                 case Deploy _: type = CommandType.Deploy; break;
                 case ListEnvironmentVariables _: type = CommandType.ListEnvironmentVariables; break;
                 case PutFileCommand _: type = CommandType.PutFile; break;
-                case GetMinimalExtensionVersion _: type = CommandType.GetSExtensionVersion; break;
+                case GetMinimalExtensionVersion _: type = CommandType.GetExtensionVersion; break;
                 default: throw new ArgumentException($"Unable to serialize {command.GetType()}");
             }
             writer.Write((byte)type);

--- a/VSRAD.DebugServer/IPC/Responses.cs
+++ b/VSRAD.DebugServer/IPC/Responses.cs
@@ -11,7 +11,8 @@ namespace VSRAD.DebugServer.IPC.Responses
         MetadataFetched = 1,
         ResultRangeFetched = 2,
         EnvironmentVariablesListed = 3,
-        PutFile = 4
+        PutFile = 4,
+        MinimalExtensionVersion = 5
     }
 #pragma warning restore CA1028
 
@@ -32,6 +33,7 @@ namespace VSRAD.DebugServer.IPC.Responses
                 case ResponseType.ResultRangeFetched: return ResultRangeFetched.Deserialize(reader);
                 case ResponseType.EnvironmentVariablesListed: return EnvironmentVariablesListed.Deserialize(reader);
                 case ResponseType.PutFile: return PutFileResponse.Deserialize(reader);
+                case ResponseType.MinimalExtensionVersion: return MinimalExtensionVersion.Deserialize(reader);
             }
             throw new InvalidDataException($"Unexpected response type byte: {type}");
         }
@@ -46,6 +48,7 @@ namespace VSRAD.DebugServer.IPC.Responses
                 case ResultRangeFetched _: type = ResponseType.ResultRangeFetched; break;
                 case EnvironmentVariablesListed _: type = ResponseType.EnvironmentVariablesListed; break;
                 case PutFileResponse _: type = ResponseType.PutFile; break;
+                case MinimalExtensionVersion _: type = ResponseType.MinimalExtensionVersion; break;
                 default: throw new ArgumentException($"Unable to serialize {response.GetType()}");
             }
             writer.Write((byte)type);
@@ -194,6 +197,28 @@ namespace VSRAD.DebugServer.IPC.Responses
 
         public void Serialize(IPCWriter writer) =>
             writer.WriteLengthPrefixedDict(Variables);
+    }
+
+    public sealed class MinimalExtensionVersion : IResponse
+    {
+        public string MinExtensionVersion;
+
+        public string ServerVersion;
+
+        public override string ToString() =>
+            $"Minimal Extension Version: {MinExtensionVersion}{Environment.NewLine}Server Version: {ServerVersion}{Environment.NewLine}";
+
+        public static MinimalExtensionVersion Deserialize(IPCReader reader) => new MinimalExtensionVersion
+        {
+            MinExtensionVersion = reader.ReadString(),
+            ServerVersion = reader.ReadString()
+        };
+
+        public void Serialize(IPCWriter writer)
+        {
+            writer.Write(MinExtensionVersion);
+            writer.Write(ServerVersion);
+        }
     }
 
 #pragma warning disable CA1028 // Using byte for enum storage because it is transferred over the wire

--- a/VSRAD.DebugServer/Server.cs
+++ b/VSRAD.DebugServer/Server.cs
@@ -16,6 +16,8 @@ namespace VSRAD.DebugServer
         const uint ENABLE_QUICK_EDIT = 0x0040;
         const int STD_INPUT_HANDLE = -10;
 
+        public const string MIN_EXT_VERSION = "2021.12.8";
+
         [DllImport("kernel32.dll", SetLastError = true)]
         static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
         [DllImport("kernel32.dll", SetLastError = true)]

--- a/VSRAD.Package/Constants.cs
+++ b/VSRAD.Package/Constants.cs
@@ -66,5 +66,7 @@ namespace VSRAD.Package
 
         public const string ToolbarIconStripResourcePackUri = "pack://application:,,,/RadeonAsmDebugger;component/Resources/DebugVisualizerWindowCommand.png";
         public const string CurrentStatementIconResourcePackUri = "pack://application:,,,/RadeonAsmDebugger;component/Resources/CurrentStatement.png";
+
+        public const string MinimalRequiredServerVersion = "2021.3.3";
     };
 }

--- a/VSRAD.Package/Server/CommunicationChannel.cs
+++ b/VSRAD.Package/Server/CommunicationChannel.cs
@@ -193,7 +193,7 @@ namespace VSRAD.Package.Server
                 if (string.Compare(minimalExtVersion, _extensionVersion, comparisonType: StringComparison.OrdinalIgnoreCase) > 0)
                 {
                     ConnectionState = ClientState.Disconnected;
-                    throw new UnsupportedDebuggerVersionException(ConnectionOptions, minimalExtVersion, _extensionVersion);
+                    throw new UnsupportedDebuggerVersionException(ConnectionOptions, minimalExtVersion);
                 }
 
                 if (string.Compare(Constants.MinimalRequiredServerVersion, serverVersion, comparisonType: StringComparison.OrdinalIgnoreCase) > 0)


### PR DESCRIPTION
Resolves #324 

This PR provides new command - `GetMinimalExtensionVersion`. When establishing connection, extension sends this command and server returns minimal extension version that it needs as well as it's own version. Extension also knows minimal server version, so it compares acquired data and shows proper error message on version mismatch.

_Note:_ Any change in Server or Debugger that breaks compatibility should also update constants:

https://github.com/vsrad/radeon-asm-tools/blob/79b92545df50df7fc8e7f06835c9e406f9c99b6a/VSRAD.DebugServer/Server.cs#L19

https://github.com/vsrad/radeon-asm-tools/blob/79b92545df50df7fc8e7f06835c9e406f9c99b6a/VSRAD.Package/Constants.cs#L70