### PR TITLE
NDRange3D refactor

### DIFF
--- a/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
+++ b/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
@@ -50,7 +50,7 @@ namespace VSRAD.Package.DebugVisualizer
         public uint DimZ { get => _dimZ; set { SetField(ref _dimZ, value); RaisePropertyChanged(nameof(MaximumZ)); } }
 
         // OneWay bindings in XAML do not work on these properties for some reason, hence the empty setters
-        public uint MaximumX { get => _projectOptions.VisualizerOptions.NDRange3D ? DimX - 1 : uint.MaxValue; set { } }
+        public uint MaximumX { get => _projectOptions.VisualizerOptions.NDRange3D ? DimX - 1 : DimX * DimY * DimZ - 1; set { } }
         public uint MaximumY { get => DimY - 1; set { } }
         public uint MaximumZ { get => DimZ - 1; set { } }
 
@@ -78,7 +78,21 @@ namespace VSRAD.Package.DebugVisualizer
                         SetOptionsFromDispatchParams();
                     break;
                 case nameof(Options.VisualizerOptions.NDRange3D):
-                    RaisePropertyChanged(nameof(MaximumX));
+                    if (!_projectOptions.VisualizerOptions.NDRange3D)
+                    {
+                        RaisePropertyChanged(nameof(MaximumX));
+                        X = X + Y * DimX + Z * DimX * DimY;
+                        Y = 1;
+                        Z = 1;
+                    }
+                    else
+                    {
+                        var x = X;
+                        X = X % DimX;
+                        Y = x % (DimX * DimY) / DimZ;
+                        Z = x / DimX / DimY;
+                        RaisePropertyChanged(nameof(MaximumX));
+                    }
                     if (_updateOptions) Update();
                     break;
                 case nameof(Options.DebuggerOptions.WaveSize):

--- a/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
+++ b/VSRAD.Package/DebugVisualizer/GroupIndexSelector.cs
@@ -102,19 +102,17 @@ namespace VSRAD.Package.DebugVisualizer
         {
             _updateOptions = false;
 
-            _projectOptions.VisualizerOptions.NDRange3D = _currentDispatchParams.NDRange3D;
+            //_projectOptions.VisualizerOptions.NDRange3D = _currentDispatchParams.NDRange3D; not sure about this
             _projectOptions.DebuggerOptions.WaveSize = _currentDispatchParams.WaveSize;
 
             DimX = _currentDispatchParams.DimX;
             DimY = _currentDispatchParams.DimY;
             DimZ = _currentDispatchParams.DimZ;
 
-            _projectOptions.DebuggerOptions.NGroups = _currentDispatchParams.NDRange3D
-                ? _currentDispatchParams.DimX * _currentDispatchParams.DimY * _currentDispatchParams.DimZ
-                : _currentDispatchParams.DimX;
-            _projectOptions.DebuggerOptions.GroupSize = _currentDispatchParams.NDRange3D
-                ? _currentDispatchParams.GroupSizeX * _currentDispatchParams.GroupSizeY * _currentDispatchParams.GroupSizeZ
-                : _currentDispatchParams.GroupSizeX;
+            _projectOptions.DebuggerOptions.NGroups =
+                _currentDispatchParams.DimX * _currentDispatchParams.DimY * _currentDispatchParams.DimZ;
+            _projectOptions.DebuggerOptions.GroupSize =
+                _currentDispatchParams.GroupSizeX * _currentDispatchParams.GroupSizeY * _currentDispatchParams.GroupSizeZ;
 
             _updateOptions = true;
             Update();

--- a/VSRAD.Package/Server/BreakStateDispatchParameters.cs
+++ b/VSRAD.Package/Server/BreakStateDispatchParameters.cs
@@ -18,7 +18,6 @@ namespace VSRAD.Package.Server
         public uint DimX { get; }
         public uint DimY { get; }
         public uint DimZ { get; }
-        public bool NDRange3D { get; }
         public string StatusString { get; }
 
         private BreakStateDispatchParameters(uint waveSize, uint gridX, uint gridY, uint gridZ, uint groupX, uint groupY, uint groupZ, string statusString)
@@ -31,9 +30,8 @@ namespace VSRAD.Package.Server
             GridSizeY = Math.Max(1, gridY);
             GridSizeZ = Math.Max(1, gridZ);
             DimX = gridX / GroupSizeX;
-            DimY = gridY > 1 ? gridY / GroupSizeY : 0;
-            DimZ = gridZ > 1 ? gridZ / GroupSizeZ : 0;
-            NDRange3D = gridY > 1 || gridZ > 1;
+            DimY = gridY / GroupSizeY;
+            DimZ = gridZ / GroupSizeZ;
             StatusString = statusString;
         }
 


### PR DESCRIPTION
This PR provides refactoring for `NDRange3D` feature.

Changes:

* Removed `NDRange3D` from dispatch parameters
Looks like we did not had a good reason for it to be there, as the only real use of that was caused by setting `DimY` and `DimZ` to 0 in `BreakStateDispatchParameters` instead of 1, which is incorrect in the first place and also refactored.
* That means that calculation of `GroupSize` and `NGroups` no longer depends on the state of `NDRange3D` as 1-dimentional indexing is equivalent to 3-dimentional when `DimY` and `DimZ` are set to 1's.
* As a pleasant bonus - now 3D and 1D group coordinates are converted vice versa when user toggles `3D NDRange` (see attached gif)

![group_coords](https://user-images.githubusercontent.com/39794543/189470386-a3695398-500b-4da7-9c9a-c46b8c060ea9.gif)