### PR TITLE
Aliases for Target Hosts

### DIFF
--- a/VSRAD.Package/Commands/ProfileDropdownCommand.cs
+++ b/VSRAD.Package/Commands/ProfileDropdownCommand.cs
@@ -11,6 +11,7 @@ using System.Windows;
 using VSRAD.Package.Options;
 using VSRAD.Package.ProjectSystem;
 using VSRAD.Package.ProjectSystem.Profiles;
+using VSRAD.Package.Utils;
 
 namespace VSRAD.Package.Commands
 {
@@ -95,13 +96,14 @@ namespace VSRAD.Package.Commands
             }
             else
             {
-                if (!Utils.HostItem.TryParseHost(selected, out var formattedHost, out var hostname, out var port))
+                var item = new HostItem(selected);
+                if (item == default(HostItem))
                     return;
 
-                _project.Options.TargetHosts.Add(formattedHost);
+                _project.Options.TargetHosts.Add(item.Formatted);
 
-                _project.Options.RemoteMachine = hostname;
-                _project.Options.Port = port;
+                _project.Options.RemoteMachine = item.Host;
+                _project.Options.Port = item.Port;
                 updatedProfile.General.RunActionsLocally = false;
             }
 

--- a/VSRAD.Package/Commands/ProfileDropdownCommand.cs
+++ b/VSRAD.Package/Commands/ProfileDropdownCommand.cs
@@ -81,8 +81,6 @@ namespace VSRAD.Package.Commands
             else
             {
                 currentHost = _project.Options.TargetHosts[0].Name;
-                // Display current host at the top of the list
-                //_project.Options.TargetHosts.Add(currentHost); TODO
             }
             Marshal.GetNativeVariantForObject(currentHost, variantOut);
         }
@@ -97,11 +95,17 @@ namespace VSRAD.Package.Commands
             }
             else
             {
-                var item = new HostItem(selected);
-                //if (item == default(HostItem) || !_project.Options.TargetHosts.Contains(item))
-                //{
-                //    return;
-                //}
+                var item = HostItem.TryParseHost(selected);
+                var tmpItem = default(HostItem);
+
+                if (item == default(HostItem)) // check maybe user entered existing alias
+                    tmpItem = _project.Options.TargetHosts.FirstOrDefault(h => h.Alias == selected);
+                else // maybe there is existing host but with alias
+                    tmpItem = _project.Options.TargetHosts
+                                              .FirstOrDefault(h => h.Host == item.Host && h.Port == item.Port);
+
+                if (tmpItem != default(HostItem)) item = tmpItem;
+                else if (item == default(HostItem)) return;
 
                 _project.Options.TargetHosts.Add(item);
 

--- a/VSRAD.Package/Commands/ProfileDropdownCommand.cs
+++ b/VSRAD.Package/Commands/ProfileDropdownCommand.cs
@@ -102,8 +102,8 @@ namespace VSRAD.Package.Commands
 
                 _project.Options.TargetHosts.Add(item);
 
-                _project.Options.RemoteMachine = item.Host;
-                _project.Options.Port = item.Port;
+                //_project.Options.RemoteMachine = item.Host;
+                //_project.Options.Port = item.Port;
                 updatedProfile.General.RunActionsLocally = false;
             }
 

--- a/VSRAD.Package/Commands/ProfileDropdownCommand.cs
+++ b/VSRAD.Package/Commands/ProfileDropdownCommand.cs
@@ -97,14 +97,14 @@ namespace VSRAD.Package.Commands
             }
             else
             {
-                var item = _project.Options.TargetHosts.FirstOrDefault(h => h.Name == selected);
-                if (item == default(HostItem))
-                    return;
+                var item = new HostItem(selected);
+                //if (item == default(HostItem) || !_project.Options.TargetHosts.Contains(item))
+                //{
+                //    return;
+                //}
 
                 _project.Options.TargetHosts.Add(item);
 
-                //_project.Options.RemoteMachine = item.Host;
-                //_project.Options.Port = item.Port;
                 updatedProfile.General.RunActionsLocally = false;
             }
 

--- a/VSRAD.Package/Commands/ProfileDropdownCommand.cs
+++ b/VSRAD.Package/Commands/ProfileDropdownCommand.cs
@@ -73,13 +73,14 @@ namespace VSRAD.Package.Commands
         private void GetCurrentTargetMachine(IntPtr variantOut)
         {
             string currentHost;
-            if (_project.Options.Profile.General.RunActionsLocally)
+            if (_project.Options.Profile.General.RunActionsLocally
+                || _project.Options.TargetHosts.Count == 0)
             {
                 currentHost = "Local";
             }
             else
             {
-                currentHost = _project.Options.Connection.ToString();
+                currentHost = _project.Options.TargetHosts[0].Name;
                 // Display current host at the top of the list
                 //_project.Options.TargetHosts.Add(currentHost); TODO
             }

--- a/VSRAD.Package/Commands/ProfileDropdownCommand.cs
+++ b/VSRAD.Package/Commands/ProfileDropdownCommand.cs
@@ -66,7 +66,7 @@ namespace VSRAD.Package.Commands
 
         private void ListTargetMachines(IntPtr variantOut)
         {
-            var displayItems = _project.Options.TargetHosts.Prepend("Local").Append("Edit...").ToArray();
+            var displayItems = _project.Options.TargetHosts.Select(h => h.Name).Prepend("Local").Append("Edit...").ToArray();
             Marshal.GetNativeVariantForObject(displayItems, variantOut);
         }
 
@@ -81,7 +81,7 @@ namespace VSRAD.Package.Commands
             {
                 currentHost = _project.Options.Connection.ToString();
                 // Display current host at the top of the list
-                _project.Options.TargetHosts.Add(currentHost);
+                //_project.Options.TargetHosts.Add(currentHost); TODO
             }
             Marshal.GetNativeVariantForObject(currentHost, variantOut);
         }
@@ -100,7 +100,7 @@ namespace VSRAD.Package.Commands
                 if (item == default(HostItem))
                     return;
 
-                _project.Options.TargetHosts.Add(item.Formatted);
+                _project.Options.TargetHosts.Add(item);
 
                 _project.Options.RemoteMachine = item.Host;
                 _project.Options.Port = item.Port;

--- a/VSRAD.Package/Commands/ProfileDropdownCommand.cs
+++ b/VSRAD.Package/Commands/ProfileDropdownCommand.cs
@@ -96,7 +96,7 @@ namespace VSRAD.Package.Commands
             }
             else
             {
-                var item = new HostItem(selected);
+                var item = _project.Options.TargetHosts.FirstOrDefault(h => h.Name == selected);
                 if (item == default(HostItem))
                     return;
 

--- a/VSRAD.Package/Commands/ProfileDropdownCommand.cs
+++ b/VSRAD.Package/Commands/ProfileDropdownCommand.cs
@@ -95,7 +95,7 @@ namespace VSRAD.Package.Commands
             }
             else
             {
-                if (!TargetHostsEditor.TryParseHost(selected, out var formattedHost, out var hostname, out var port))
+                if (!Utils.HostItem.TryParseHost(selected, out var formattedHost, out var hostname, out var port))
                     return;
 
                 _project.Options.TargetHosts.Add(formattedHost);

--- a/VSRAD.Package/Options/DefaultOptionValues.cs
+++ b/VSRAD.Package/Options/DefaultOptionValues.cs
@@ -7,7 +7,7 @@ namespace VSRAD.Package.Options
     {
         #region General
         public const string DeployDirectory = "";
-        public const string RemoteMachineAdredd = "127.0.0.1";
+        public const string RemoteMachineAdress = "127.0.0.1";
         public const int Port = 9339;
         public const string AdditionalSources = "";
         public const bool CopySources = true;

--- a/VSRAD.Package/Options/ProfileOptions.cs
+++ b/VSRAD.Package/Options/ProfileOptions.cs
@@ -127,26 +127,6 @@ namespace VSRAD.Package.Options
         }
     }
 
-    public readonly struct ServerConnectionOptions : IEquatable<ServerConnectionOptions>
-    {
-        public string RemoteMachine { get; }
-        public int Port { get; }
-
-        public ServerConnectionOptions(string remoteMachine = "127.0.0.1", int port = 9339)
-        {
-            RemoteMachine = remoteMachine;
-            Port = port;
-        }
-
-        public override string ToString() => $"{RemoteMachine}:{Port}";
-
-        public bool Equals(ServerConnectionOptions s) => RemoteMachine == s.RemoteMachine && Port == s.Port;
-        public override bool Equals(object o) => o is ServerConnectionOptions s && Equals(s);
-        public override int GetHashCode() => (RemoteMachine, Port).GetHashCode();
-        public static bool operator ==(ServerConnectionOptions left, ServerConnectionOptions right) => left.Equals(right);
-        public static bool operator !=(ServerConnectionOptions left, ServerConnectionOptions right) => !(left == right);
-    }
-
     public readonly struct ActionEnvironment : IEquatable<ActionEnvironment>
     {
         public string LocalWorkDir { get; }

--- a/VSRAD.Package/Options/ProjectOptions.cs
+++ b/VSRAD.Package/Options/ProjectOptions.cs
@@ -28,9 +28,9 @@ namespace VSRAD.Package.Options
         public DebugVisualizer.ColumnStylingOptions VisualizerColumnStyling { get; } =
             new DebugVisualizer.ColumnStylingOptions();
 
-        [JsonConverter(typeof(MruCollection<string>.Converter))]
-        public MruCollection<string> TargetHosts { get; } =
-            new MruCollection<string>();
+        [JsonConverter(typeof(MruCollection<HostItem>.Converter))]
+        public MruCollection<HostItem> TargetHosts { get; } =
+            new MruCollection<HostItem>();
 
         public ProjectOptions() { }
 

--- a/VSRAD.Package/Options/ProjectOptions.cs
+++ b/VSRAD.Package/Options/ProjectOptions.cs
@@ -48,7 +48,9 @@ namespace VSRAD.Package.Options
         public string ActiveProfile { get => _activeProfile; set { if (value != null) SetField(ref _activeProfile, value, raiseIfEqual: true); } }
 
         [JsonIgnore]
-        public ServerConnectionOptions Connection => TargetHosts[0].ConnectionOptions;
+        public ServerConnectionOptions Connection => TargetHosts.Count != 0
+                                                        ? TargetHosts[0].ConnectionOptions
+                                                        : default(ServerConnectionOptions);
 
         [JsonIgnore]
         public bool HasProfiles => Profiles.Count > 0;

--- a/VSRAD.Package/Options/ProjectOptions.cs
+++ b/VSRAD.Package/Options/ProjectOptions.cs
@@ -47,6 +47,8 @@ namespace VSRAD.Package.Options
         private string _activeProfile = "Default";
         public string ActiveProfile { get => _activeProfile; set { if (value != null) SetField(ref _activeProfile, value, raiseIfEqual: true); } }
 
+        // we can safely assume that TargetHosts[0] is the host we want, because
+        // TargetHosts order are updated according to MRU collection (see VSRAD.Package.Utils.MruCollection.cs)
         [JsonIgnore]
         public ServerConnectionOptions Connection => TargetHosts.Count != 0
                                                         ? TargetHosts[0].ConnectionOptions

--- a/VSRAD.Package/Options/ProjectOptions.cs
+++ b/VSRAD.Package/Options/ProjectOptions.cs
@@ -47,14 +47,8 @@ namespace VSRAD.Package.Options
         private string _activeProfile = "Default";
         public string ActiveProfile { get => _activeProfile; set { if (value != null) SetField(ref _activeProfile, value, raiseIfEqual: true); } }
 
-        private string _remoteMachine = "127.0.0.1";
-        public string RemoteMachine { get => _remoteMachine; set => SetField(ref _remoteMachine, value); }
-
-        private int _port = 9339;
-        public int Port { get => _port; set => SetField(ref _port, value); }
-
         [JsonIgnore]
-        public ServerConnectionOptions Connection => new ServerConnectionOptions(RemoteMachine, Port);
+        public ServerConnectionOptions Connection => TargetHosts[0].ConnectionOptions;
 
         [JsonIgnore]
         public bool HasProfiles => Profiles.Count > 0;

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
@@ -41,7 +41,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 
             if (json["TargetHosts"] != null)
                 foreach (var host in json["TargetHosts"].ToObject<List<string>>())
-                    options.TargetHosts.Add(host);
+                    options.TargetHosts.Add(new Utils.HostItem(host));
 
             options.ActiveProfile = activeProfile;
 

--- a/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/ProfileTransferManager.cs
@@ -41,7 +41,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 
             if (json["TargetHosts"] != null)
                 foreach (var host in json["TargetHosts"].ToObject<List<string>>())
-                    options.TargetHosts.Add(new Utils.HostItem(host));
+                    options.TargetHosts.Add(Utils.HostItem.TryParseHost(host));
 
             options.ActiveProfile = activeProfile;
 

--- a/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml
@@ -37,6 +37,21 @@
                         </Style>
                     </DataGridTextColumn.EditingElementStyle>
                 </DataGridTextColumn>
+                <DataGridTextColumn Header="Alias" Binding="{Binding Alias, UpdateSourceTrigger=PropertyChanged}" Width="*">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="VerticalAlignment" Value="Center" />
+                            <Setter Property="Padding" Value="6,0" />
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                    <DataGridTextColumn.EditingElementStyle>
+                        <Style TargetType="{x:Type TextBox}">
+                            <Setter Property="VerticalContentAlignment" Value="Center" />
+                            <Setter Property="Padding" Value="3,0" />
+                            <Setter Property="Height" Value="22" />
+                        </Style>
+                    </DataGridTextColumn.EditingElementStyle>
+                </DataGridTextColumn>
                 <DataGridTemplateColumn Width="36" MinWidth="36" MaxWidth="36">
                     <DataGridTemplateColumn.Header>
                         <Button Grid.Column="1" Content="➕" ToolTip="Add host" Width="22" Height="22" HorizontalAlignment="Center" Click="AddHost" />

--- a/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml
@@ -18,7 +18,7 @@
             <Button Content="Cancel" IsCancel="True" Click="HandleCancel" Width="61" Height="22" Margin="4,0,0,0" />
         </StackPanel>
         <DataGrid x:Name="HostGrid" ItemsSource="{Binding Hosts, ElementName=Root}" Margin="4" GridLinesVisibility="None" Focusable="True"
-                  RowEditEnding="ValidateHostAfterEdit" PreviewKeyDown="HandleDeleteKey"
+                  PreviewKeyDown="HandleDeleteKey"
                   AutoGenerateColumns="False" CanUserAddRows="False" CanUserReorderColumns="False" CanUserSortColumns="False" CanUserResizeRows="False" CanUserDeleteRows="False"
                   HeadersVisibility="Column" HorizontalScrollBarVisibility="Disabled" RowHeight="24">
             <DataGrid.Columns>

--- a/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml
+++ b/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml
@@ -37,6 +37,21 @@
                         </Style>
                     </DataGridTextColumn.EditingElementStyle>
                 </DataGridTextColumn>
+                <DataGridTextColumn Header="Port" Binding="{Binding Port, UpdateSourceTrigger=PropertyChanged}" Width="*">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="VerticalAlignment" Value="Center" />
+                            <Setter Property="Padding" Value="6,0" />
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                    <DataGridTextColumn.EditingElementStyle>
+                        <Style TargetType="{x:Type TextBox}">
+                            <Setter Property="VerticalContentAlignment" Value="Center" />
+                            <Setter Property="Padding" Value="3,0" />
+                            <Setter Property="Height" Value="22" />
+                        </Style>
+                    </DataGridTextColumn.EditingElementStyle>
+                </DataGridTextColumn>
                 <DataGridTextColumn Header="Alias" Binding="{Binding Alias, UpdateSourceTrigger=PropertyChanged}" Width="*">
                     <DataGridTextColumn.ElementStyle>
                         <Style TargetType="TextBlock">

--- a/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
@@ -17,10 +17,14 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             private string _host = "";
             public string Host { get => _host; set => SetField(ref _host, value); }
 
+            private string _alias = "";
+            public string Alias { get => _alias; set => SetField(ref _alias, value); }
+
             public bool UsedInActiveProfile { get; }
 
-            public HostItem(string host, bool usedInActiveProfile)
+            public HostItem(string host, bool usedInActiveProfile, string alias = "")
             {
+                Alias = alias;
                 Host = host;
                 UsedInActiveProfile = usedInActiveProfile;
             }

--- a/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
@@ -59,8 +59,8 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             var updatedProfile = (Options.ProfileOptions)_project.Options.Profile.Clone();
             if (Hosts.FirstOrDefault(h => h.UsedInActiveProfile) is HostItem hi)
             {
-                _project.Options.RemoteMachine = hi.Host;
-                _project.Options.Port = hi.Port;
+                //_project.Options.RemoteMachine = hi.Host;
+                //_project.Options.Port = hi.Port;
             }
             else
             {

--- a/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
@@ -29,7 +29,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 
         private void AddHost(object sender, RoutedEventArgs e)
         {
-            var item = new HostItem("", 9339); // TODO: move 9339 to Constants.cs
+            var item = new HostItem("", Options.DefaultOptionValues.Port);
             Hosts.Add(item);
 
             // Finish editing the current host before moving the focus away from it

--- a/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
@@ -56,10 +56,10 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             _project.Options.TargetHosts.AddRange(Hosts.Distinct());
 
             var updatedProfile = (Options.ProfileOptions)_project.Options.Profile.Clone();
-            if (Hosts.FirstOrDefault(h => h.UsedInActiveProfile) is HostItem hi && HostItem.TryParseHost(hi.Host, out _, out var hostname, out var port))
+            if (Hosts.FirstOrDefault(h => h.UsedInActiveProfile) is HostItem hi)
             {
-                _project.Options.RemoteMachine = hostname;
-                _project.Options.Port = port;
+                _project.Options.RemoteMachine = hi.Host;
+                _project.Options.Port = hi.Port;
             }
             else
             {

--- a/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
@@ -29,8 +29,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 
         private void AddHost(object sender, RoutedEventArgs e)
         {
-            var item = new HostItem("", usedInActiveProfile: false);
-            item.Port = 9339; // TODO: move to Constants.cs
+            var item = new HostItem("", 9339); // TODO: move 9339 to Constants.cs
             Hosts.Add(item);
 
             // Finish editing the current host before moving the focus away from it
@@ -53,33 +52,18 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 
         private void SaveChanges()
         {
+            var oldHost = _project.Options.TargetHosts.Count != 0
+                                           ? _project.Options.TargetHosts[0]
+                                           : null;
             _project.Options.TargetHosts.Clear();
             _project.Options.TargetHosts.AddRange(Hosts.Distinct());
 
             var updatedProfile = (Options.ProfileOptions)_project.Options.Profile.Clone();
-            if (Hosts.FirstOrDefault(h => h.UsedInActiveProfile) is HostItem hi)
-            {
-                //_project.Options.RemoteMachine = hi.Host;
-                //_project.Options.Port = hi.Port;
-            }
-            else
-            {
+            if (oldHost == null || !Hosts.Contains(oldHost))
                 updatedProfile.General.RunActionsLocally = true;
-            }
             _project.Options.UpdateActiveProfile(updatedProfile);
 
             _project.SaveOptions();
-        }
-
-        private void ValidateHostAfterEdit(object sender, DataGridRowEditEndingEventArgs e)
-        {
-//            var item = (HostItem)e.Row.DataContext;
-//            if (HostItem.TryParseHost(item.Host, out var formattedHost, out _, out _))
-//                item.Host = formattedHost;
-//            else
-//#pragma warning disable VSTHRD001 // Using BeginInvoke to delete item after all post-edit events fire
-//                Dispatcher.BeginInvoke((Action)(() => Hosts.Remove(item)), System.Windows.Threading.DispatcherPriority.Background);
-//#pragma warning restore VSTHRD001
         }
 
         private void HandleDeleteKey(object sender, KeyEventArgs e)

--- a/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
@@ -12,24 +12,6 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 {
     public sealed partial class TargetHostsEditor : DialogWindow
     {
-        public static bool TryParseHost(string input, out string formatted, out string hostname, out ushort port)
-        {
-            formatted = "";
-            hostname = "";
-            port = 0;
-
-            var hostnamePort = input.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
-            if (hostnamePort.Length == 0)
-                return false;
-
-            hostname = hostnamePort[0];
-            if (hostnamePort.Length < 2 || !ushort.TryParse(hostnamePort[1], out port))
-                port = 9339;
-
-            formatted = $"{hostname}:{port}";
-            return true;
-        }
-
         public ObservableCollection<HostItem> Hosts { get; }
         public ICommand DeleteHostCommand { get; }
 
@@ -75,7 +57,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
             _project.Options.TargetHosts.AddRange(Hosts.Select(h => h.Host).Distinct());
 
             var updatedProfile = (Options.ProfileOptions)_project.Options.Profile.Clone();
-            if (Hosts.FirstOrDefault(h => h.UsedInActiveProfile) is HostItem hi && TryParseHost(hi.Host, out _, out var hostname, out var port))
+            if (Hosts.FirstOrDefault(h => h.UsedInActiveProfile) is HostItem hi && HostItem.TryParseHost(hi.Host, out _, out var hostname, out var port))
             {
                 _project.Options.RemoteMachine = hostname;
                 _project.Options.Port = port;
@@ -92,7 +74,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
         private void ValidateHostAfterEdit(object sender, DataGridRowEditEndingEventArgs e)
         {
             var item = (HostItem)e.Row.DataContext;
-            if (TryParseHost(item.Host, out var formattedHost, out _, out _))
+            if (HostItem.TryParseHost(item.Host, out var formattedHost, out _, out _))
                 item.Host = formattedHost;
             else
 #pragma warning disable VSTHRD001 // Using BeginInvoke to delete item after all post-edit events fire

--- a/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
@@ -21,8 +21,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
         public TargetHostsEditor(IProject project)
         {
             _project = project;
-            Hosts = new ObservableCollection<HostItem>(project.Options.TargetHosts.Select(h =>
-                new HostItem(h, usedInActiveProfile: !project.Options.Profile.General.RunActionsLocally && project.Options.Connection.ToString() == h)));
+            Hosts = new ObservableCollection<HostItem>(project.Options.TargetHosts);
             DeleteHostCommand = new WpfDelegateCommand(DeleteHost);
 
             InitializeComponent();
@@ -54,7 +53,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
         private void SaveChanges()
         {
             _project.Options.TargetHosts.Clear();
-            _project.Options.TargetHosts.AddRange(Hosts.Select(h => h.Host).Distinct());
+            _project.Options.TargetHosts.AddRange(Hosts.Distinct());
 
             var updatedProfile = (Options.ProfileOptions)_project.Options.Profile.Clone();
             if (Hosts.FirstOrDefault(h => h.UsedInActiveProfile) is HostItem hi && HostItem.TryParseHost(hi.Host, out _, out var hostname, out var port))
@@ -73,13 +72,13 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 
         private void ValidateHostAfterEdit(object sender, DataGridRowEditEndingEventArgs e)
         {
-            var item = (HostItem)e.Row.DataContext;
-            if (HostItem.TryParseHost(item.Host, out var formattedHost, out _, out _))
-                item.Host = formattedHost;
-            else
-#pragma warning disable VSTHRD001 // Using BeginInvoke to delete item after all post-edit events fire
-                Dispatcher.BeginInvoke((Action)(() => Hosts.Remove(item)), System.Windows.Threading.DispatcherPriority.Background);
-#pragma warning restore VSTHRD001
+//            var item = (HostItem)e.Row.DataContext;
+//            if (HostItem.TryParseHost(item.Host, out var formattedHost, out _, out _))
+//                item.Host = formattedHost;
+//            else
+//#pragma warning disable VSTHRD001 // Using BeginInvoke to delete item after all post-edit events fire
+//                Dispatcher.BeginInvoke((Action)(() => Hosts.Remove(item)), System.Windows.Threading.DispatcherPriority.Background);
+//#pragma warning restore VSTHRD001
         }
 
         private void HandleDeleteKey(object sender, KeyEventArgs e)
@@ -130,7 +129,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 
             for (int i = 0; i < Hosts.Count; ++i)
             {
-                if (Hosts[i].Host != _project.Options.TargetHosts[i])
+                if (Hosts[i] != _project.Options.TargetHosts[i])
                     return true;
             }
 

--- a/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
@@ -12,24 +12,6 @@ namespace VSRAD.Package.ProjectSystem.Profiles
 {
     public sealed partial class TargetHostsEditor : DialogWindow
     {
-        public sealed class HostItem : DefaultNotifyPropertyChanged
-        {
-            private string _host = "";
-            public string Host { get => _host; set => SetField(ref _host, value); }
-
-            private string _alias = "";
-            public string Alias { get => _alias; set => SetField(ref _alias, value); }
-
-            public bool UsedInActiveProfile { get; }
-
-            public HostItem(string host, bool usedInActiveProfile, string alias = "")
-            {
-                Alias = alias;
-                Host = host;
-                UsedInActiveProfile = usedInActiveProfile;
-            }
-        }
-
         public static bool TryParseHost(string input, out string formatted, out string hostname, out ushort port)
         {
             formatted = "";

--- a/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Profiles/TargetHostsEditor.xaml.cs
@@ -30,6 +30,7 @@ namespace VSRAD.Package.ProjectSystem.Profiles
         private void AddHost(object sender, RoutedEventArgs e)
         {
             var item = new HostItem("", usedInActiveProfile: false);
+            item.Port = 9339; // TODO: move to Constants.cs
             Hosts.Add(item);
 
             // Finish editing the current host before moving the focus away from it

--- a/VSRAD.Package/Server/CommunicationChannel.cs
+++ b/VSRAD.Package/Server/CommunicationChannel.cs
@@ -11,6 +11,7 @@ using VSRAD.DebugServer.IPC.Commands;
 using VSRAD.DebugServer.IPC.Responses;
 using VSRAD.Package.Options;
 using VSRAD.Package.ProjectSystem;
+using VSRAD.Package.Utils;
 using Task = System.Threading.Tasks.Task;
 
 namespace VSRAD.Package.Server

--- a/VSRAD.Package/Utils/TargetHosts.cs
+++ b/VSRAD.Package/Utils/TargetHosts.cs
@@ -30,12 +30,12 @@ namespace VSRAD.Package.Utils
             Alias = alias;
         }
 
-        public HostItem(string input)
+        public HostItem(string input) // TODO make TryParseHost return HostItem
         {
             if (TryParseHost(input, out var _, out var host, out var port))
             {
                 Host = host;
-                Port = port;;
+                Port = port;
             }
         }
 

--- a/VSRAD.Package/Utils/TargetHosts.cs
+++ b/VSRAD.Package/Utils/TargetHosts.cs
@@ -62,7 +62,7 @@ namespace VSRAD.Package.Utils
 
             hostname = hostnamePort[0];
             if (hostnamePort.Length < 2 || !ushort.TryParse(hostnamePort[1], out port))
-                port = 9339;
+                port = Options.DefaultOptionValues.Port;
 
             formatted = $"{hostname}:{port}";
             return true;
@@ -74,7 +74,8 @@ namespace VSRAD.Package.Utils
         public string RemoteMachine { get; }
         public int Port { get; }
 
-        public ServerConnectionOptions(string remoteMachine = "127.0.0.1", int port = 9339)
+        public ServerConnectionOptions(string remoteMachine = Options.DefaultOptionValues.RemoteMachineAdress,
+                                                int port = Options.DefaultOptionValues.Port)
         {
             RemoteMachine = remoteMachine;
             Port = port;

--- a/VSRAD.Package/Utils/TargetHosts.cs
+++ b/VSRAD.Package/Utils/TargetHosts.cs
@@ -21,6 +21,10 @@ namespace VSRAD.Package.Utils
 
         public string Formatted => $"{Host}:{Port}";
 
+        public string Name => string.IsNullOrWhiteSpace(Alias)
+                                ? Formatted
+                                : Alias;
+
         public HostItem(string host, bool usedInActiveProfile, string alias = "")
         {
             Alias = alias;

--- a/VSRAD.Package/Utils/TargetHosts.cs
+++ b/VSRAD.Package/Utils/TargetHosts.cs
@@ -11,16 +11,31 @@ namespace VSRAD.Package.Utils
         private string _host = "";
         public string Host { get => _host; set => SetField(ref _host, value); }
 
+        private ushort _port = 0;
+        public ushort Port { get => _port; set => SetField(ref _port, value); }
+
         private string _alias = "";
         public string Alias { get => _alias; set => SetField(ref _alias, value); }
 
         public bool UsedInActiveProfile { get; }
+
+        public string Formatted => $"{Host}:{Port}";
 
         public HostItem(string host, bool usedInActiveProfile, string alias = "")
         {
             Alias = alias;
             Host = host;
             UsedInActiveProfile = usedInActiveProfile;
+        }
+
+        public HostItem(string input)
+        {
+            if (TryParseHost(input, out var _, out var host, out var port))
+            {
+                Host = host;
+                Port = port;
+                UsedInActiveProfile = false;
+            }
         }
 
         public ServerConnectionOptions ConnectionOptions

--- a/VSRAD.Package/Utils/TargetHosts.cs
+++ b/VSRAD.Package/Utils/TargetHosts.cs
@@ -30,42 +30,19 @@ namespace VSRAD.Package.Utils
             Alias = alias;
         }
 
-        public HostItem(string input) // TODO make TryParseHost return HostItem
-        {
-            if (TryParseHost(input, out var _, out var host, out var port))
-            {
-                Host = host;
-                Port = port;
-            }
-        }
-
         [JsonIgnore]
-        public ServerConnectionOptions ConnectionOptions
-        {
-            get {
-                if (TryParseHost(Host, out var _, out var hostname, out var port))
-                    return new ServerConnectionOptions(hostname, port);
-                else
-                    return default;
-            }
-        }
+        public ServerConnectionOptions ConnectionOptions => new ServerConnectionOptions(Host, Port);
 
-        public static bool TryParseHost(string input, out string formatted, out string hostname, out ushort port)
+        public static HostItem TryParseHost(string input)
         {
-            formatted = "";
-            hostname = "";
-            port = 0;
-
             var hostnamePort = input.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
-            if (hostnamePort.Length == 0)
-                return false;
+            if (hostnamePort.Length < 2)
+                return default(HostItem);
 
-            hostname = hostnamePort[0];
-            if (hostnamePort.Length < 2 || !ushort.TryParse(hostnamePort[1], out port))
+            var hostname = hostnamePort[0];
+            if (!ushort.TryParse(hostnamePort[1], out var port))
                 port = Options.DefaultOptionValues.Port;
-
-            formatted = $"{hostname}:{port}";
-            return true;
+            return new HostItem(hostname, port);
         }
     }
 

--- a/VSRAD.Package/Utils/TargetHosts.cs
+++ b/VSRAD.Package/Utils/TargetHosts.cs
@@ -14,8 +14,6 @@ namespace VSRAD.Package.Utils
         private string _alias = "";
         public string Alias { get => _alias; set => SetField(ref _alias, value); }
 
-        public bool UsedInActiveProfile { get; }
-
         [JsonIgnore]
         public string Formatted => $"{Host}:{Port}";
 
@@ -25,11 +23,11 @@ namespace VSRAD.Package.Utils
                                 : Alias;
 
         [JsonConstructor]
-        public HostItem(string host, bool usedInActiveProfile, string alias = "")
+        public HostItem(string host, ushort port, string alias = "")
         {
-            Alias = alias;
             Host = host;
-            UsedInActiveProfile = usedInActiveProfile;
+            Port = port;
+            Alias = alias;
         }
 
         public HostItem(string input)
@@ -37,8 +35,7 @@ namespace VSRAD.Package.Utils
             if (TryParseHost(input, out var _, out var host, out var port))
             {
                 Host = host;
-                Port = port;
-                UsedInActiveProfile = false;
+                Port = port;;
             }
         }
 

--- a/VSRAD.Package/Utils/TargetHosts.cs
+++ b/VSRAD.Package/Utils/TargetHosts.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VSRAD.Package.Utils
+{
+    public sealed class HostItem : DefaultNotifyPropertyChanged
+    {
+        private string _host = "";
+        public string Host { get => _host; set => SetField(ref _host, value); }
+
+        private string _alias = "";
+        public string Alias { get => _alias; set => SetField(ref _alias, value); }
+
+        public bool UsedInActiveProfile { get; }
+
+        public HostItem(string host, bool usedInActiveProfile, string alias = "")
+        {
+            Alias = alias;
+            Host = host;
+            UsedInActiveProfile = usedInActiveProfile;
+        }
+    }
+}

--- a/VSRAD.Package/Utils/TargetHosts.cs
+++ b/VSRAD.Package/Utils/TargetHosts.cs
@@ -22,5 +22,53 @@ namespace VSRAD.Package.Utils
             Host = host;
             UsedInActiveProfile = usedInActiveProfile;
         }
+
+        public ServerConnectionOptions ConnectionOptions
+        {
+            get {
+                if (TryParseHost(Host, out var _, out var hostname, out var port))
+                    return new ServerConnectionOptions(hostname, port);
+                else
+                    return default;
+            }
+        }
+
+        public static bool TryParseHost(string input, out string formatted, out string hostname, out ushort port)
+        {
+            formatted = "";
+            hostname = "";
+            port = 0;
+
+            var hostnamePort = input.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+            if (hostnamePort.Length == 0)
+                return false;
+
+            hostname = hostnamePort[0];
+            if (hostnamePort.Length < 2 || !ushort.TryParse(hostnamePort[1], out port))
+                port = 9339;
+
+            formatted = $"{hostname}:{port}";
+            return true;
+        }
+    }
+
+    public readonly struct ServerConnectionOptions : IEquatable<ServerConnectionOptions>
+    {
+        public string RemoteMachine { get; }
+        public int Port { get; }
+
+        public ServerConnectionOptions(string remoteMachine = "127.0.0.1", int port = 9339)
+        {
+            RemoteMachine = remoteMachine;
+            Port = port;
+        }
+
+        public override string ToString() => $"{RemoteMachine}:{Port}";
+
+        public bool Equals(ServerConnectionOptions s) => RemoteMachine == s.RemoteMachine && Port == s.Port;
+        public override bool Equals(object o) => o is ServerConnectionOptions s && Equals(s);
+        public override int GetHashCode() => (RemoteMachine, Port).GetHashCode();
+        public static bool operator ==(ServerConnectionOptions left, ServerConnectionOptions right) => left.Equals(right);
+        public static bool operator !=(ServerConnectionOptions left, ServerConnectionOptions right) => !(left == right);
     }
 }

--- a/VSRAD.Package/Utils/TargetHosts.cs
+++ b/VSRAD.Package/Utils/TargetHosts.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Newtonsoft.Json;
+using System;
 
 namespace VSRAD.Package.Utils
 {
@@ -19,12 +16,15 @@ namespace VSRAD.Package.Utils
 
         public bool UsedInActiveProfile { get; }
 
+        [JsonIgnore]
         public string Formatted => $"{Host}:{Port}";
 
+        [JsonIgnore]
         public string Name => string.IsNullOrWhiteSpace(Alias)
                                 ? Formatted
                                 : Alias;
 
+        [JsonConstructor]
         public HostItem(string host, bool usedInActiveProfile, string alias = "")
         {
             Alias = alias;
@@ -42,6 +42,7 @@ namespace VSRAD.Package.Utils
             }
         }
 
+        [JsonIgnore]
         public ServerConnectionOptions ConnectionOptions
         {
             get {

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -249,6 +249,7 @@
     <Compile Include="Utils\CollectionExtensions.cs" />
     <Compile Include="Utils\MruCollection.cs" />
     <Compile Include="Utils\OleCommandText.cs" />
+    <Compile Include="Utils\TargetHosts.cs" />
     <Compile Include="Utils\VsEditor.cs" />
     <Compile Include="Utils\VsStatusBarWriter.cs" />
     <Compile Include="Utils\WpfConverters.cs" />


### PR DESCRIPTION
Resolves #332 

Reworked Target Hosts edition dialog (see image). Now host and port are separate fields (latter will be set to default `9339` when new host is added), and also we have optional `Alias` field. If set to non-empty, this host will be listed by its alias in dropdown.

User still can manually enter new host to the hosts dropdown in format `ip:port`. User input is carefully handled - if there is such host, but wit alias, alias will be used. If user just enters known alias, corresponding host will be used.

The last, but not least, this PR contains a work on refactoring the logic of storing and using current target host. Before, there were a lot of duplication of essentially same info (string `ip:port`, string `ip` and ushort `port`, `HostItem`, `ServerConnectionOptions`...), now it is standardized and much easier to understand and extend (f.e. add an alias). Also, `RemoteMachine` and `Port` are gone from project config, since this info is already stored in `TargetHosts`, which works like MRU collection.

![image](https://user-images.githubusercontent.com/39794543/199023284-a6a5eebf-ec58-414d-804d-674d1e4857cf.png)
