### PR TITLE
Fixed ResizeHalf scaling with phantom column

### DIFF
--- a/VSRAD.Package/DebugVisualizer/MouseMove/ScaleOperation.cs
+++ b/VSRAD.Package/DebugVisualizer/MouseMove/ScaleOperation.cs
@@ -40,7 +40,8 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
             bool leftedge = (e.X - hit.ColumnX) < (_tableState.ColumnWidth/2);
 
             _isNameColumn = (leftedge && hit.ColumnIndex == _tableState.GetFirstVisibleDataColumnIndex())
-                || hit.ColumnIndex < _tableState.GetFirstVisibleDataColumnIndex();
+                || (hit.ColumnIndex < _tableState.GetFirstVisibleDataColumnIndex()
+                    && hit.ColumnIndex != _tableState.PhantomColumnIndex);
             _operationStarted = false;
             _orgMouseX = Cursor.Position.X;
             _orgeX = e.X;

--- a/VSRAD.Package/DebugVisualizer/MouseMove/ScaleOperation.cs
+++ b/VSRAD.Package/DebugVisualizer/MouseMove/ScaleOperation.cs
@@ -17,6 +17,7 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
         private int _orgWidth;
         private int _orgMouseX;
         private int _orgeX;
+        private int _phantomX; // the start of the phantom column
         private int _orgNColumns; // number of visible columns before mouse cursor
         private int _orgSColumns; // number of fully scrolled columns
         private bool _lefthalf; // mouse is in left half of the data columns region
@@ -44,12 +45,12 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
                 || (hit.ColumnIndex < _tableState.GetFirstVisibleDataColumnIndex()
                     && hit.ColumnIndex != _tableState.PhantomColumnIndex);
             _phantomColumnVisible = _table.Columns[_tableState.PhantomColumnIndex].Displayed;
-            var phantomX = _phantomColumnVisible
+            _phantomX = _phantomColumnVisible
                                 ? _table.HitTest(_table.Width - 2, 1).ColumnX
                                      - _table.RowHeadersWidth - _table.Columns[_tableState.NameColumnIndex].Width
                                 : 0;
             var middle = _phantomColumnVisible
-                                ? (phantomX / (float)_tableState.GetDataRegionWidth()) / 2.0f
+                                ? _phantomX / (float)_tableState.GetDataRegionWidth() / 2.0f
                                 : 0.5;
             _operationStarted = false;
             _orgMouseX = Cursor.Position.X;
@@ -142,7 +143,8 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
                     int curWidth = (int)(s * _orgWidth);
                     curWidth = Math.Max(minWidth, curWidth);
                     s = (float)curWidth / _orgWidth;
-                    int curScroll = (int)(_orgScroll * s + _tableState.GetDataRegionWidth() * (s - 1));
+                    int curScroll = (int)(_orgScroll * s + (_phantomColumnVisible ? _phantomX
+                        : _tableState.GetDataRegionWidth()) * (s - 1));
                     if (_isNameColumn && _tableState.NameColumnScalingEnabled)
                         _tableState.ScaleNameColumn(curWidth);
                     else

--- a/VSRAD.Package/DebugVisualizer/MouseMove/ScaleOperation.cs
+++ b/VSRAD.Package/DebugVisualizer/MouseMove/ScaleOperation.cs
@@ -23,6 +23,7 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
         private float _orgSPixels; // number of scrolled pixels in first displayed column
 
         private bool _isNameColumn;
+        private bool _phantomColumnVisible;
 
         public ScaleOperation(DataGridView table, TableState state)
         {
@@ -42,6 +43,14 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
             _isNameColumn = (leftedge && hit.ColumnIndex == _tableState.GetFirstVisibleDataColumnIndex())
                 || (hit.ColumnIndex < _tableState.GetFirstVisibleDataColumnIndex()
                     && hit.ColumnIndex != _tableState.PhantomColumnIndex);
+            _phantomColumnVisible = _table.Columns[_tableState.PhantomColumnIndex].Displayed;
+            var phantomX = _phantomColumnVisible
+                                ? _table.HitTest(_table.Width - 2, 1).ColumnX
+                                     - _table.RowHeadersWidth - _table.Columns[_tableState.NameColumnIndex].Width
+                                : 0;
+            var middle = _phantomColumnVisible
+                                ? (phantomX / (float)_tableState.GetDataRegionWidth()) / 2.0f
+                                : 0.5;
             _operationStarted = false;
             _orgMouseX = Cursor.Position.X;
             _orgeX = e.X;
@@ -52,7 +61,7 @@ namespace VSRAD.Package.DebugVisualizer.MouseMove
             _orgNColumns = _tableState.CountVisibleDataColumns(hit.ColumnIndex, !leftedge);
             _orgSColumns = _orgScroll / _orgWidth;
             _orgSPixels = _orgScroll % _orgWidth;
-            _lefthalf = _tableState.GetNormalizedXCoordinate(e.X) < 0.5;
+            _lefthalf = _tableState.GetNormalizedXCoordinate(e.X) < middle;
 
             return true;
         }


### PR DESCRIPTION
This PR fixes `ResizeHalf` scaling mode when phantom column is visible (when data columns do not occupy the whole table)

The difference is most visible on following gif's:

## ❌ OLD / BROKEN

![scale_old](https://user-images.githubusercontent.com/39794543/200657357-b14b1bdb-77dc-413e-b02d-54676ed05100.gif)

## ✔️ NEW / FIXED

![scale_new](https://user-images.githubusercontent.com/39794543/200657386-0ffcf7ca-1a7f-4ad3-a80b-d3dfcf8308c8.gif)
