### PR TITLE
test implementation of includes paths for syntax

### DIFF
--- a/VSRAD.Syntax/Core/Parser/Asm1Parser.cs
+++ b/VSRAD.Syntax/Core/Parser/Asm1Parser.cs
@@ -11,6 +11,7 @@ using VSRAD.Syntax.Core.Tokens;
 using VSRAD.Syntax.Helpers;
 using VSRAD.Syntax.Options.Instructions;
 using VSRAD.SyntaxParser;
+using VSRAD.Syntax.Options;
 
 namespace VSRAD.Syntax.Core.Parser
 {
@@ -23,12 +24,13 @@ namespace VSRAD.Syntax.Core.Parser
             var serviceProvider = ServiceProvider.GlobalProvider;
             var documentFactory = serviceProvider.GetMefService<IDocumentFactory>();
             var instructionListManager = serviceProvider.GetMefService<IInstructionListManager>();
+            var options = serviceProvider.GetMefService<OptionsProvider>();
 
-            return new Asm1Parser(documentFactory, instructionListManager);
+            return new Asm1Parser(documentFactory, instructionListManager, options.IncludePaths);
         });
 
-        private Asm1Parser(IDocumentFactory documentFactory, IInstructionListManager instructionListManager) 
-            : base(documentFactory, instructionListManager, AsmType.RadAsm) { }
+        private Asm1Parser(IDocumentFactory documentFactory, IInstructionListManager instructionListManager, IReadOnlyList<string> includes) 
+            : base(documentFactory, instructionListManager, includes, AsmType.RadAsm) { }
 
         public override Task<IParserResult> RunAsync(IDocument document, ITextSnapshot version,
             ITokenizerCollection<TrackingToken> trackingTokens, CancellationToken cancellation)

--- a/VSRAD.Syntax/Core/Parser/Asm2Parser.cs
+++ b/VSRAD.Syntax/Core/Parser/Asm2Parser.cs
@@ -11,6 +11,7 @@ using VSRAD.Syntax.Core.Tokens;
 using VSRAD.Syntax.Helpers;
 using VSRAD.Syntax.Options.Instructions;
 using VSRAD.SyntaxParser;
+using VSRAD.Syntax.Options;
 
 namespace VSRAD.Syntax.Core.Parser
 {
@@ -23,12 +24,13 @@ namespace VSRAD.Syntax.Core.Parser
             var serviceProvider = ServiceProvider.GlobalProvider;
             var documentFactory = serviceProvider.GetMefService<IDocumentFactory>();
             var instructionListManager = serviceProvider.GetMefService<IInstructionListManager>();
+            var options = serviceProvider.GetMefService<OptionsProvider>();
 
-            return new Asm2Parser(documentFactory, instructionListManager);
+            return new Asm2Parser(documentFactory, instructionListManager, options.IncludePaths);
         });
 
-        private Asm2Parser(IDocumentFactory documentFactory, IInstructionListManager instructionListManager) 
-            : base(documentFactory, instructionListManager, AsmType.RadAsm2) { }
+        private Asm2Parser(IDocumentFactory documentFactory, IInstructionListManager instructionListManager, IReadOnlyList<string> includes) 
+            : base(documentFactory, instructionListManager, includes, AsmType.RadAsm2) { }
 
         public override Task<IParserResult> RunAsync(IDocument document, ITextSnapshot version,
             ITokenizerCollection<TrackingToken> trackingTokens, CancellationToken cancellation)

--- a/VSRAD.Syntax/Options/GeneralOptionProvider.cs
+++ b/VSRAD.Syntax/Options/GeneralOptionProvider.cs
@@ -31,6 +31,7 @@ namespace VSRAD.Syntax.Options
             Asm1FileExtensions = Constants.DefaultFileExtensionAsm1;
             Asm2FileExtensions = Constants.DefaultFileExtensionAsm2;
             InstructionsPaths = GetDefaultInstructionDirectoryPath();
+            IncludePaths = new List<string>();
             Asm1InstructionSet = string.Empty;
             Asm2InstructionSet = string.Empty;
             AutocompleteInstructions = false;
@@ -50,6 +51,7 @@ namespace VSRAD.Syntax.Options
         public IReadOnlyList<string> Asm1FileExtensions;
         public IReadOnlyList<string> Asm2FileExtensions;
         public string InstructionsPaths;
+        public IReadOnlyList<string> IncludePaths;
         public string Asm1InstructionSet;
         public string Asm2InstructionSet;
         public bool AutocompleteInstructions;

--- a/VSRAD.Syntax/Options/GeneralOptions.cs
+++ b/VSRAD.Syntax/Options/GeneralOptions.cs
@@ -80,12 +80,22 @@ namespace VSRAD.Syntax.Options
 
         [Category("Instructions")]
         [DisplayName("Instruction folder paths")]
-        [Description("List of folder path separated by semicolon wit assembly instructions with .radasm file extension")]
+        [Description("List of folder paths separated by semicolon with assembly instructions with .radasm file extension")]
         [Editor(typeof(FolderPathsEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string InstructionsPaths
         {
             get => _optionsProvider.InstructionsPaths;
             set => _optionsProvider.InstructionsPaths = value;
+        }
+
+        [Category("Instructions")]
+        [DisplayName("Include paths")]
+        [Description("List of folder paths separated by semicolon that contains sources to be included")]
+        [Editor(typeof(FolderPathsEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string IncludePaths
+        {
+            get => ConvertExtensionsTo(_optionsProvider.IncludePaths);
+            set => _optionsProvider.IncludePaths = ConvertExtensionsFrom(value);
         }
 
         [Category("Instructions")]
@@ -156,6 +166,10 @@ namespace VSRAD.Syntax.Options
             InstructionsPaths = userSettingsStore.PropertyExists(InstructionCollectionName, nameof(InstructionsPaths))
                 ? userSettingsStore.GetString(InstructionCollectionName, nameof(InstructionsPaths))
                 : OptionsProvider.GetDefaultInstructionDirectoryPath();
+
+            IncludePaths = userSettingsStore.PropertyExists(InstructionCollectionName, nameof(IncludePaths))
+                ? userSettingsStore.GetString(InstructionCollectionName, nameof(IncludePaths))
+                : string.Empty;
         }
 
         public override async Task SaveAsync()
@@ -173,6 +187,11 @@ namespace VSRAD.Syntax.Options
                 StringComparison.OrdinalIgnoreCase))
             {
                 userSettingsStore.SetString(InstructionCollectionName, nameof(InstructionsPaths), InstructionsPaths);
+            }
+
+            if (!string.IsNullOrEmpty(IncludePaths))
+            {
+                userSettingsStore.SetString(InstructionCollectionName, nameof(IncludePaths), IncludePaths);
             }
         }
 


### PR DESCRIPTION
This PR adds new property to "Options->RadeonAsm options->General->Instructions" `Include paths`.

This field accepts semicolon-separated list of folders that will be included to the current project.