### PR TITLE
Proper extension version checking in Release configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,14 @@ where `port` is a TCP port number the server will listen on.
 
 ### Assembling a Release
 
-1. Right-click on `VSRAD.Build` in *Solution Explorer* and select *Set as StartUp Project*.
-2. Select *Release* in the *Solution Configurations* dropdown.
-3. Build the entire solution (*Build* -> *Build Solution*).
+Update extension and server versions if needed:
+
+1. `VSRAD.Package\source.extension.vsixmanifest`
+2. `VSRAD.Package\Properties\AssemblyInfo.cs`
+
+3. Right-click on `VSRAD.Build` in *Solution Explorer* and select *Set as StartUp Project*.
+4. Select *Release* in the *Solution Configurations* dropdown.
+5. Build the entire solution (*Build* -> *Build Solution*).
 
 The release build creates a directory (`Release`) with the installation script
 (`install.bat`), the extension package (`RadeonAsmDebugger.vsix`), and debug server

--- a/VSRAD.Package/Properties/AssemblyInfo.cs
+++ b/VSRAD.Package/Properties/AssemblyInfo.cs
@@ -34,8 +34,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2021.12.8")]
+[assembly: AssemblyFileVersion("2021.12.8")]
 
 
 

--- a/VSRAD.Package/Server/CommunicationChannel.cs
+++ b/VSRAD.Package/Server/CommunicationChannel.cs
@@ -100,10 +100,7 @@ namespace VSRAD.Package.Server
             _project = project;
             _project.RunWhenLoaded((options) =>
                 options.PropertyChanged += (s, e) => { if (e.PropertyName == nameof(options.ActiveProfile)) ForceDisconnect(); });
-            var match = _extensionVersionRegex.Match(typeof(IProject).Assembly.CodeBase);
-            if (!match.Success)
-                throw new Exception("Error while getting current extension version.");
-            _extensionVersion = new Version(match.Groups["version"].Value);
+            _extensionVersion = typeof(CommunicationChannel).Assembly.GetName().Version;
         }
 
         public Task<T> SendWithReplyAsync<T>(ICommand command) where T : IResponse =>


### PR DESCRIPTION
As for now, installed release version of VSRAD.Package will crash Visual Studio or extension will fail to initialize.

This is due to incorrect version checking of extension, introduced in #333. In this case, Debug and Release configuration actually behave differently. As introduced in [article](https://www.visualstudioextensibility.com/2016/07/11/the-four-versions-of-a-visual-studio-package/), we actually need to set the extension versions in _two_ locations:

1. `VSRAD.Package\source.extension.vsixmanifest`
2. `VSRAD.Package\Properties\AssemblyInfo.cs`

This PR introduces changes needed to fix current master branch Release behavior.