### PR TITLE
Packed Int/UInt types

### DIFF
--- a/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
@@ -7,7 +7,7 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
 {
     public sealed class TypeContextMenu : IContextMenu
     {
-        public delegate void TypeChanged(int rowIndex, VariableInfo type);
+        public delegate void TypeChanged(int rowIndex, VariableType type);
         public delegate void AVGPRStateChanged(int rowIndex, bool state);
         public delegate void InsertRow(int rowIndex, bool after);
         public delegate void AddWatchRange(string name, int from, int to);
@@ -24,22 +24,22 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
 
             var typeItems = new MenuItem[]
             {
-                new MenuItem("Hex", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex, 32))),
+                new MenuItem("Hex", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Hex, 32))),
                 new MenuItem("Int", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Int, 32))),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Int, 16))),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Int,  8)))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Int, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Int, 16))),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Int,  8)))
                 }),
                 new MenuItem("UInt", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Uint, 32))),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Uint, 16))),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Uint,  8)))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Uint, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Uint, 16))),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Uint,  8)))
                 }),
-                new MenuItem("Float", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 32))),
-                new MenuItem("Bin", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 32))),
-                new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 16)))
+                new MenuItem("Float", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Float, 32))),
+                new MenuItem("Bin", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Bin, 32))),
+                new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Float, 16)))
             };
 
             var fgColor = new MenuItem("Font Color", new[]

--- a/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
@@ -22,11 +22,6 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
         {
             _table = table;
 
-            //var typeItems = Array.Empty<MenuItem>(); // TODO: manually add corresponding values
-
-            //var typeItems = ((VariableType[])Enum.GetValues(typeof(VariableType)))
-            //    .Select(type => new MenuItem(type.ToString(), (s, e) => typeChanged(_currentRow, type)));
-
             var typeItems = new MenuItem[]
             {
                 new MenuItem("Hex", new MenuItem[]
@@ -54,9 +49,9 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
                 }),
                 new MenuItem("Bin", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 32 })),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 16 })),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 8  }))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Bin, Size = 32 })),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Bin, Size = 16 })),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Bin, Size = 8  }))
                 }),
                 new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Half, Size = 0 }))
             };
@@ -126,7 +121,6 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
                 item.Checked = false;
 
             var selectedWatch = VisualizerTable.GetRowWatchState(_table.Rows[hit.RowIndex]);
-            //_menu.MenuItems[(int)selectedWatch.Info.Type].Checked = true;
             _avgprButton.Enabled = _currentRow != 0 || !_table.ShowSystemRow;
             _avgprButton.Checked = selectedWatch.IsAVGPR;
 

--- a/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
@@ -22,10 +22,44 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
         {
             _table = table;
 
-            var typeItems = Array.Empty<MenuItem>(); // TODO: manually add corresponding values
+            //var typeItems = Array.Empty<MenuItem>(); // TODO: manually add corresponding values
 
             //var typeItems = ((VariableType[])Enum.GetValues(typeof(VariableType)))
             //    .Select(type => new MenuItem(type.ToString(), (s, e) => typeChanged(_currentRow, type)));
+
+            var typeItems = new MenuItem[]
+            {
+                new MenuItem("Hex", new MenuItem[]
+                {
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Hex, Size = 32 })),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Hex, Size = 16 })),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Hex, Size = 8  }))
+                }),
+                new MenuItem("Int", new MenuItem[]
+                {
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Int, Size = 32 })),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Int, Size = 16 })),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Int, Size = 8  }))
+                }),
+                new MenuItem("UInt", new MenuItem[]
+                {
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Uint, Size = 32 })),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Uint, Size = 16 })),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Uint, Size = 8  }))
+                }),
+                new MenuItem("Float", new MenuItem[]
+                {
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 32 })),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 16 }))
+                }),
+                new MenuItem("Bin", new MenuItem[]
+                {
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 32 })),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 16 })),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 8  }))
+                }),
+                new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Half, Size = 0 }))
+            };
 
             var fgColor = new MenuItem("Font Color", new[]
             {
@@ -92,7 +126,7 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
                 item.Checked = false;
 
             var selectedWatch = VisualizerTable.GetRowWatchState(_table.Rows[hit.RowIndex]);
-            _menu.MenuItems[(int)selectedWatch.Info.Type].Checked = true;
+            //_menu.MenuItems[(int)selectedWatch.Info.Type].Checked = true;
             _avgprButton.Enabled = _currentRow != 0 || !_table.ShowSystemRow;
             _avgprButton.Checked = selectedWatch.IsAVGPR;
 

--- a/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
@@ -7,7 +7,7 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
 {
     public sealed class TypeContextMenu : IContextMenu
     {
-        public delegate void TypeChanged(int rowIndex, VariableType type);
+        public delegate void TypeChanged(int rowIndex, VariableInfo type);
         public delegate void AVGPRStateChanged(int rowIndex, bool state);
         public delegate void InsertRow(int rowIndex, bool after);
         public delegate void AddWatchRange(string name, int from, int to);
@@ -22,8 +22,10 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
         {
             _table = table;
 
-            var typeItems = ((VariableType[])Enum.GetValues(typeof(VariableType)))
-                .Select(type => new MenuItem(type.ToString(), (s, e) => typeChanged(_currentRow, type)));
+            var typeItems = Array.Empty<MenuItem>(); // TODO: manually add corresponding values
+
+            //var typeItems = ((VariableType[])Enum.GetValues(typeof(VariableType)))
+            //    .Select(type => new MenuItem(type.ToString(), (s, e) => typeChanged(_currentRow, type)));
 
             var fgColor = new MenuItem("Font Color", new[]
             {
@@ -90,7 +92,7 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
                 item.Checked = false;
 
             var selectedWatch = VisualizerTable.GetRowWatchState(_table.Rows[hit.RowIndex]);
-            _menu.MenuItems[(int)selectedWatch.Type].Checked = true;
+            _menu.MenuItems[(int)selectedWatch.Info.Type].Checked = true;
             _avgprButton.Enabled = _currentRow != 0 || !_table.ShowSystemRow;
             _avgprButton.Checked = selectedWatch.IsAVGPR;
 

--- a/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
@@ -49,12 +49,13 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
                 //    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 32))),
                 //    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 16)))
                 //}),
-                new MenuItem("Bin", new MenuItem[]
-                {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 32))),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 16))),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin,  8)))
-                }),
+                new MenuItem("Bin", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 32))),
+                //new MenuItem("Bin", new MenuItem[]
+                //{
+                //    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 32))),
+                //    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 16))),
+                //    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin,  8)))
+                //}),
                 new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Half, 0)))
             };
 

--- a/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
@@ -24,12 +24,13 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
 
             var typeItems = new MenuItem[]
             {
-                new MenuItem("Hex", new MenuItem[]
-                {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex, 32))),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex, 16))),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex,  8)))
-                }),
+                new MenuItem("Hex", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex, 32))),
+                //new MenuItem("Hex", new MenuItem[]
+                //{
+                //    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex, 32))),
+                //    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex, 16))),
+                //    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex,  8)))
+                //}),
                 new MenuItem("Int", new MenuItem[]
                 {
                     new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Int, 32))),
@@ -42,11 +43,12 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
                     new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Uint, 16))),
                     new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Uint,  8)))
                 }),
-                new MenuItem("Float", new MenuItem[]
-                {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 32))),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 16)))
-                }),
+                new MenuItem("Float", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 32))),
+                //new MenuItem("Float", new MenuItem[]
+                //{
+                //    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 32))),
+                //    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 16)))
+                //}),
                 new MenuItem("Bin", new MenuItem[]
                 {
                     new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 32))),

--- a/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
@@ -25,12 +25,6 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
             var typeItems = new MenuItem[]
             {
                 new MenuItem("Hex", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex, 32))),
-                //new MenuItem("Hex", new MenuItem[]
-                //{
-                //    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex, 32))),
-                //    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex, 16))),
-                //    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex,  8)))
-                //}),
                 new MenuItem("Int", new MenuItem[]
                 {
                     new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Int, 32))),
@@ -44,19 +38,8 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
                     new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Uint,  8)))
                 }),
                 new MenuItem("Float", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 32))),
-                //new MenuItem("Float", new MenuItem[]
-                //{
-                //    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 32))),
-                //    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 16)))
-                //}),
                 new MenuItem("Bin", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 32))),
-                //new MenuItem("Bin", new MenuItem[]
-                //{
-                //    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 32))),
-                //    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 16))),
-                //    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin,  8)))
-                //}),
-                new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Half, 0)))
+                new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 16)))
             };
 
             var fgColor = new MenuItem("Font Color", new[]

--- a/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
@@ -24,22 +24,22 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
 
             var typeItems = new MenuItem[]
             {
-                new MenuItem("Hex", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Hex, 32))),
+                new MenuItem("Hex", (s, e) => typeChanged(_currentRow, new VariableType(VariableCategory.Hex, 32))),
                 new MenuItem("Int", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Int, 32))),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Int, 16))),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Int,  8)))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableType(VariableCategory.Int, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableType(VariableCategory.Int, 16))),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableType(VariableCategory.Int,  8)))
                 }),
                 new MenuItem("UInt", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Uint, 32))),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Uint, 16))),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Uint,  8)))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableType(VariableCategory.Uint, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableType(VariableCategory.Uint, 16))),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableType(VariableCategory.Uint,  8)))
                 }),
-                new MenuItem("Float", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Float, 32))),
-                new MenuItem("Bin", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Bin, 32))),
-                new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableType(VariableRepresentation.Float, 16)))
+                new MenuItem("Float", (s, e) => typeChanged(_currentRow, new VariableType(VariableCategory.Float, 32))),
+                new MenuItem("Bin", (s, e) => typeChanged(_currentRow, new VariableType(VariableCategory.Bin, 32))),
+                new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableType(VariableCategory.Float, 16)))
             };
 
             var fgColor = new MenuItem("Font Color", new[]

--- a/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
+++ b/VSRAD.Package/DebugVisualizer/ContextMenus/TypeContextMenu.cs
@@ -26,34 +26,34 @@ namespace VSRAD.Package.DebugVisualizer.ContextMenus
             {
                 new MenuItem("Hex", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Hex, Size = 32 })),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Hex, Size = 16 })),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Hex, Size = 8  }))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex, 16))),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Hex,  8)))
                 }),
                 new MenuItem("Int", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Int, Size = 32 })),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Int, Size = 16 })),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Int, Size = 8  }))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Int, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Int, 16))),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Int,  8)))
                 }),
                 new MenuItem("UInt", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Uint, Size = 32 })),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Uint, Size = 16 })),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Uint, Size = 8  }))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Uint, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Uint, 16))),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Uint,  8)))
                 }),
                 new MenuItem("Float", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 32 })),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Float, Size = 16 }))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Float, 16)))
                 }),
                 new MenuItem("Bin", new MenuItem[]
                 {
-                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Bin, Size = 32 })),
-                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Bin, Size = 16 })),
-                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Bin, Size = 8  }))
+                    new MenuItem("32", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 32))),
+                    new MenuItem("16", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin, 16))),
+                    new MenuItem("8" , (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Bin,  8)))
                 }),
-                new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableInfo { Type = VariableType.Half, Size = 0 }))
+                new MenuItem("Half", (s, e) => typeChanged(_currentRow, new VariableInfo(VariableType.Half, 0)))
             };
 
             var fgColor = new MenuItem("Font Color", new[]

--- a/VSRAD.Package/DebugVisualizer/CustomTableGraphics.cs
+++ b/VSRAD.Package/DebugVisualizer/CustomTableGraphics.cs
@@ -31,7 +31,7 @@ namespace VSRAD.Package.DebugVisualizer
                     | DataGridViewPaintParts.Border
                     | DataGridViewPaintParts.Focus
                     | DataGridViewPaintParts.SelectionBackground
-                    | DataGridViewPaintParts.ContentForeground
+                    //| DataGridViewPaintParts.ContentForeground // not needed because we are using custom string painter below
                 );
 
             if (!selectedWatch.IsEmpty)

--- a/VSRAD.Package/DebugVisualizer/CustomTableGraphics.cs
+++ b/VSRAD.Package/DebugVisualizer/CustomTableGraphics.cs
@@ -37,7 +37,7 @@ namespace VSRAD.Package.DebugVisualizer
             if (!selectedWatch.IsEmpty)
             {
                 var typeTextPos = new PointF((float)e.RowBounds.Left + 7, (float)e.RowBounds.Top + 4);
-                e.Graphics.DrawString(selectedWatch.Type.ShortName(),
+                e.Graphics.DrawString(selectedWatch.Info.ShortName(),
                     _table.RowHeadersDefaultCellStyle.Font,
                     new SolidBrush(_table.RowHeadersDefaultCellStyle.ForeColor),
                     typeTextPos);

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerContext.cs
@@ -24,8 +24,8 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
         private string _selectedWatch;
         public string SelectedWatch { get => _selectedWatch; set => SetField(ref _selectedWatch, value); }
 
-        private VariableInfo _selectedType;
-        public VariableInfo SelectedType { get => _selectedType; set => SetField(ref _selectedType, value); }
+        private VariableType _selectedType;
+        public VariableType SelectedType { get => _selectedType; set => SetField(ref _selectedType, value); }
 
         private bool _useHeatMap = false;
         public bool UseHeatMap { get => _useHeatMap; set => SetField(ref _useHeatMap, value); }

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerContext.cs
@@ -24,8 +24,8 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
         private string _selectedWatch;
         public string SelectedWatch { get => _selectedWatch; set => SetField(ref _selectedWatch, value); }
 
-        private VariableType _selectedType;
-        public VariableType SelectedType { get => _selectedType; set => SetField(ref _selectedType, value); }
+        private VariableInfo _selectedType;
+        public VariableInfo SelectedType { get => _selectedType; set => SetField(ref _selectedType, value); }
 
         private bool _useHeatMap = false;
         public bool UseHeatMap { get => _useHeatMap; set => SetField(ref _useHeatMap, value); }

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerHeaderControl.xaml
@@ -15,7 +15,7 @@
             </ResourceDictionary.MergedDictionaries>
             <ObjectDataProvider x:Key="VarableType" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
                 <ObjectDataProvider.MethodParameters>
-                    <x:Type TypeName="viz:VariableType"/>
+                    <x:Type TypeName="viz:VariableRepresentation"/>
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
         </ResourceDictionary>

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerHeaderControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerHeaderControl.xaml
@@ -15,7 +15,7 @@
             </ResourceDictionary.MergedDictionaries>
             <ObjectDataProvider x:Key="VarableType" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
                 <ObjectDataProvider.MethodParameters>
-                    <x:Type TypeName="viz:VariableRepresentation"/>
+                    <x:Type TypeName="viz:VariableCategory"/>
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
         </ResourceDictionary>

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
@@ -34,118 +34,12 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
 
         public float GetRelativeValue(int row, int column, int word = 0)
         {
-            // TODO: reimplement for VariableInfo
-            return 0.0f;
-            //switch (_type)
-            //{
-            //    case VariableType.Uint:
-            //    case VariableType.Hex:
-            //    case VariableType.Bin:
-            //        return ((float)(_view[row, column] - _minValue.uintValue)) / (_maxValue.uintValue - _minValue.uintValue);
-            //    case VariableType.Int:
-            //        return ((float)((int)_view[row, column] - _minValue.intValue)) / (_maxValue.intValue - _minValue.intValue);
-            //    case VariableType.Float:
-            //        var floatValue = BitConverter.ToSingle(BitConverter.GetBytes(_view[row, column]), 0);
-            //        return (floatValue - _minValue.floatValue) / (_maxValue.floatValue - _minValue.floatValue);
-            //    case VariableType.Half:
-            //        floatValue = Half.ToFloat(BitConverter.ToUInt16(BitConverter.GetBytes(_view[row, column]), startIndex: word * 2));
-            //        return (floatValue - _minValue.floatValue) / (_maxValue.floatValue - _minValue.floatValue);
-            //}
-            //throw new NotImplementedException();
+            throw new NotImplementedException("Current watch representation do not work with Slice Visualizer");
         }
 
         private static void GetMinMaxValues(SliceWatchView view, VariableType info, out TypedWatchValue min, out TypedWatchValue max)
         {
-            min = new TypedWatchValue { floatValue = float.MinValue };
-            max = new TypedWatchValue { floatValue = float.MaxValue };
-            return;
-            // TODO: reimplement for VariableInfo
-            //switch (type)
-            //{
-            //    case VariableType.Uint:
-            //    case VariableType.Hex:
-            //    case VariableType.Bin:
-            //        uint umin =  uint.MaxValue;
-            //        uint umax = uint.MinValue;
-            //        for (int row = 0; row < view.RowCount; ++row)
-            //        {
-            //            for (int col = 0; col < view.ColumnCount; ++col)
-            //            {
-            //                uint value = view[row, col];
-            //                if (value < umin)
-            //                    umin = value;
-            //                if (value > umax)
-            //                    umax = value;
-            //            }
-            //        }
-            //        min = new TypedWatchValue { uintValue = umin };
-            //        max = new TypedWatchValue { uintValue = umax };
-            //        return;
-            //    case VariableType.Int:
-            //        int imin = int.MaxValue;
-            //        int imax = int.MinValue;
-            //        for (int row = 0; row < view.RowCount; ++row)
-            //        {
-            //            for (int col = 0; col < view.ColumnCount; ++col)
-            //            {
-            //                int value = (int)view[row, col];
-            //                if (value < imin)
-            //                    imin = value;
-            //                if (value > imax)
-            //                    imax = value;
-            //            }
-            //        }
-            //        min = new TypedWatchValue { intValue = imin };
-            //        max = new TypedWatchValue { intValue = imax };
-            //        return;
-            //    case VariableType.Float:
-            //        float fmin = float.MaxValue;
-            //        float fmax = float.MinValue;
-            //        for (int row = 0; row < view.RowCount; ++row)
-            //        {
-            //            for (int col = 0; col < view.ColumnCount; ++col)
-            //            {
-            //                float value = BitConverter.ToSingle(BitConverter.GetBytes(view[row, col]), 0);
-            //                if (float.IsNaN(value))
-            //                    continue;
-            //                if (value < fmin)
-            //                    fmin = value;
-            //                if (value > fmax)
-            //                    fmax = value;
-            //            }
-            //        }
-            //        min = new TypedWatchValue { floatValue = fmin };
-            //        max = new TypedWatchValue { floatValue = fmax };
-            //        return;
-            //    case VariableType.Half:
-            //        fmin = float.MaxValue;
-            //        fmax = float.MinValue;
-            //        for (int row = 0; row < view.RowCount; ++row)
-            //        {
-            //            for (int col = 0; col < view.ColumnCount; ++col)
-            //            {
-            //                byte[] bytes = BitConverter.GetBytes(view[row, col]);
-            //                float firstHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 0));
-            //                float secondHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 2));
-            //                if (!float.IsNaN(firstHalf))
-            //                {
-            //                    if (firstHalf < fmin)
-            //                        fmin = firstHalf;
-            //                    if (firstHalf > fmax)
-            //                        fmax = firstHalf;
-            //                }
-            //                if (!float.IsNaN(secondHalf))
-            //                {
-            //                    if (secondHalf < fmin)
-            //                        fmin = secondHalf;
-            //                    if (secondHalf > fmax)
-            //                        fmax = secondHalf;
-            //                }
-            //            }
-            //        }
-            //        min = new TypedWatchValue { floatValue = fmin };
-            //        max = new TypedWatchValue { floatValue = fmax };
-            //        return;
+            throw new NotImplementedException("Current watch representation do not work with Slice Visualizer");
         }
 
         [StructLayout(LayoutKind.Explicit)]

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
@@ -10,14 +10,14 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
         public int RowCount => _view.RowCount;
         public int ColumnCount => _view.ColumnCount;
 
-        public bool IsSingleWordValue => _type == VariableType.Half;
+        public bool IsSingleWordValue => _type.Type == VariableType.Half;
 
         private readonly SliceWatchView _view;
-        private readonly VariableType _type;
+        private readonly VariableInfo _type;
         private readonly TypedWatchValue _minValue;
         private readonly TypedWatchValue _maxValue;
 
-        public TypedSliceWatchView(SliceWatchView view, VariableType type)
+        public TypedSliceWatchView(SliceWatchView view, VariableInfo type)
         {
             _view = view;
             _type = type;
@@ -34,114 +34,118 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
 
         public float GetRelativeValue(int row, int column, int word = 0)
         {
-            switch (_type)
-            {
-                case VariableType.Uint:
-                case VariableType.Hex:
-                case VariableType.Bin:
-                    return ((float)(_view[row, column] - _minValue.uintValue)) / (_maxValue.uintValue - _minValue.uintValue);
-                case VariableType.Int:
-                    return ((float)((int)_view[row, column] - _minValue.intValue)) / (_maxValue.intValue - _minValue.intValue);
-                case VariableType.Float:
-                    var floatValue = BitConverter.ToSingle(BitConverter.GetBytes(_view[row, column]), 0);
-                    return (floatValue - _minValue.floatValue) / (_maxValue.floatValue - _minValue.floatValue);
-                case VariableType.Half:
-                    floatValue = Half.ToFloat(BitConverter.ToUInt16(BitConverter.GetBytes(_view[row, column]), startIndex: word * 2));
-                    return (floatValue - _minValue.floatValue) / (_maxValue.floatValue - _minValue.floatValue);
-            }
-            throw new NotImplementedException();
+            // TODO: reimplement for VariableInfo
+            return 0.0f;
+            //switch (_type)
+            //{
+            //    case VariableType.Uint:
+            //    case VariableType.Hex:
+            //    case VariableType.Bin:
+            //        return ((float)(_view[row, column] - _minValue.uintValue)) / (_maxValue.uintValue - _minValue.uintValue);
+            //    case VariableType.Int:
+            //        return ((float)((int)_view[row, column] - _minValue.intValue)) / (_maxValue.intValue - _minValue.intValue);
+            //    case VariableType.Float:
+            //        var floatValue = BitConverter.ToSingle(BitConverter.GetBytes(_view[row, column]), 0);
+            //        return (floatValue - _minValue.floatValue) / (_maxValue.floatValue - _minValue.floatValue);
+            //    case VariableType.Half:
+            //        floatValue = Half.ToFloat(BitConverter.ToUInt16(BitConverter.GetBytes(_view[row, column]), startIndex: word * 2));
+            //        return (floatValue - _minValue.floatValue) / (_maxValue.floatValue - _minValue.floatValue);
+            //}
+            //throw new NotImplementedException();
         }
 
-        private static void GetMinMaxValues(SliceWatchView view, VariableType type, out TypedWatchValue min, out TypedWatchValue max)
+        private static void GetMinMaxValues(SliceWatchView view, VariableInfo info, out TypedWatchValue min, out TypedWatchValue max)
         {
-            switch (type)
-            {
-                case VariableType.Uint:
-                case VariableType.Hex:
-                case VariableType.Bin:
-                    uint umin =  uint.MaxValue;
-                    uint umax = uint.MinValue;
-                    for (int row = 0; row < view.RowCount; ++row)
-                    {
-                        for (int col = 0; col < view.ColumnCount; ++col)
-                        {
-                            uint value = view[row, col];
-                            if (value < umin)
-                                umin = value;
-                            if (value > umax)
-                                umax = value;
-                        }
-                    }
-                    min = new TypedWatchValue { uintValue = umin };
-                    max = new TypedWatchValue { uintValue = umax };
-                    return;
-                case VariableType.Int:
-                    int imin = int.MaxValue;
-                    int imax = int.MinValue;
-                    for (int row = 0; row < view.RowCount; ++row)
-                    {
-                        for (int col = 0; col < view.ColumnCount; ++col)
-                        {
-                            int value = (int)view[row, col];
-                            if (value < imin)
-                                imin = value;
-                            if (value > imax)
-                                imax = value;
-                        }
-                    }
-                    min = new TypedWatchValue { intValue = imin };
-                    max = new TypedWatchValue { intValue = imax };
-                    return;
-                case VariableType.Float:
-                    float fmin = float.MaxValue;
-                    float fmax = float.MinValue;
-                    for (int row = 0; row < view.RowCount; ++row)
-                    {
-                        for (int col = 0; col < view.ColumnCount; ++col)
-                        {
-                            float value = BitConverter.ToSingle(BitConverter.GetBytes(view[row, col]), 0);
-                            if (float.IsNaN(value))
-                                continue;
-                            if (value < fmin)
-                                fmin = value;
-                            if (value > fmax)
-                                fmax = value;
-                        }
-                    }
-                    min = new TypedWatchValue { floatValue = fmin };
-                    max = new TypedWatchValue { floatValue = fmax };
-                    return;
-                case VariableType.Half:
-                    fmin = float.MaxValue;
-                    fmax = float.MinValue;
-                    for (int row = 0; row < view.RowCount; ++row)
-                    {
-                        for (int col = 0; col < view.ColumnCount; ++col)
-                        {
-                            byte[] bytes = BitConverter.GetBytes(view[row, col]);
-                            float firstHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 0));
-                            float secondHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 2));
-                            if (!float.IsNaN(firstHalf))
-                            {
-                                if (firstHalf < fmin)
-                                    fmin = firstHalf;
-                                if (firstHalf > fmax)
-                                    fmax = firstHalf;
-                            }
-                            if (!float.IsNaN(secondHalf))
-                            {
-                                if (secondHalf < fmin)
-                                    fmin = secondHalf;
-                                if (secondHalf > fmax)
-                                    fmax = secondHalf;
-                            }
-                        }
-                    }
-                    min = new TypedWatchValue { floatValue = fmin };
-                    max = new TypedWatchValue { floatValue = fmax };
-                    return;
-            }
-            throw new NotImplementedException();
+            min = new TypedWatchValue { floatValue = float.MinValue };
+            max = new TypedWatchValue { floatValue = float.MaxValue };
+            return;
+            // TODO: reimplement for VariableInfo
+            //switch (type)
+            //{
+            //    case VariableType.Uint:
+            //    case VariableType.Hex:
+            //    case VariableType.Bin:
+            //        uint umin =  uint.MaxValue;
+            //        uint umax = uint.MinValue;
+            //        for (int row = 0; row < view.RowCount; ++row)
+            //        {
+            //            for (int col = 0; col < view.ColumnCount; ++col)
+            //            {
+            //                uint value = view[row, col];
+            //                if (value < umin)
+            //                    umin = value;
+            //                if (value > umax)
+            //                    umax = value;
+            //            }
+            //        }
+            //        min = new TypedWatchValue { uintValue = umin };
+            //        max = new TypedWatchValue { uintValue = umax };
+            //        return;
+            //    case VariableType.Int:
+            //        int imin = int.MaxValue;
+            //        int imax = int.MinValue;
+            //        for (int row = 0; row < view.RowCount; ++row)
+            //        {
+            //            for (int col = 0; col < view.ColumnCount; ++col)
+            //            {
+            //                int value = (int)view[row, col];
+            //                if (value < imin)
+            //                    imin = value;
+            //                if (value > imax)
+            //                    imax = value;
+            //            }
+            //        }
+            //        min = new TypedWatchValue { intValue = imin };
+            //        max = new TypedWatchValue { intValue = imax };
+            //        return;
+            //    case VariableType.Float:
+            //        float fmin = float.MaxValue;
+            //        float fmax = float.MinValue;
+            //        for (int row = 0; row < view.RowCount; ++row)
+            //        {
+            //            for (int col = 0; col < view.ColumnCount; ++col)
+            //            {
+            //                float value = BitConverter.ToSingle(BitConverter.GetBytes(view[row, col]), 0);
+            //                if (float.IsNaN(value))
+            //                    continue;
+            //                if (value < fmin)
+            //                    fmin = value;
+            //                if (value > fmax)
+            //                    fmax = value;
+            //            }
+            //        }
+            //        min = new TypedWatchValue { floatValue = fmin };
+            //        max = new TypedWatchValue { floatValue = fmax };
+            //        return;
+            //    case VariableType.Half:
+            //        fmin = float.MaxValue;
+            //        fmax = float.MinValue;
+            //        for (int row = 0; row < view.RowCount; ++row)
+            //        {
+            //            for (int col = 0; col < view.ColumnCount; ++col)
+            //            {
+            //                byte[] bytes = BitConverter.GetBytes(view[row, col]);
+            //                float firstHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 0));
+            //                float secondHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 2));
+            //                if (!float.IsNaN(firstHalf))
+            //                {
+            //                    if (firstHalf < fmin)
+            //                        fmin = firstHalf;
+            //                    if (firstHalf > fmax)
+            //                        fmax = firstHalf;
+            //                }
+            //                if (!float.IsNaN(secondHalf))
+            //                {
+            //                    if (secondHalf < fmin)
+            //                        fmin = secondHalf;
+            //                    if (secondHalf > fmax)
+            //                        fmax = secondHalf;
+            //                }
+            //            }
+            //        }
+            //        min = new TypedWatchValue { floatValue = fmin };
+            //        max = new TypedWatchValue { floatValue = fmax };
+            //        return;
         }
 
         [StructLayout(LayoutKind.Explicit)]

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
@@ -10,14 +10,14 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
         public int RowCount => _view.RowCount;
         public int ColumnCount => _view.ColumnCount;
 
-        public bool IsSingleWordValue => _type.Type == VariableType.Float && _type.Size == 16;
+        public bool IsSingleWordValue => _type.Repr == VariableRepresentation.Float && _type.Size == 16;
 
         private readonly SliceWatchView _view;
-        private readonly VariableInfo _type;
+        private readonly VariableType _type;
         private readonly TypedWatchValue _minValue;
         private readonly TypedWatchValue _maxValue;
 
-        public TypedSliceWatchView(SliceWatchView view, VariableInfo type)
+        public TypedSliceWatchView(SliceWatchView view, VariableType type)
         {
             _view = view;
             _type = type;
@@ -54,7 +54,7 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
             //throw new NotImplementedException();
         }
 
-        private static void GetMinMaxValues(SliceWatchView view, VariableInfo info, out TypedWatchValue min, out TypedWatchValue max)
+        private static void GetMinMaxValues(SliceWatchView view, VariableType info, out TypedWatchValue min, out TypedWatchValue max)
         {
             min = new TypedWatchValue { floatValue = float.MinValue };
             max = new TypedWatchValue { floatValue = float.MaxValue };

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
@@ -10,7 +10,7 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
         public int RowCount => _view.RowCount;
         public int ColumnCount => _view.ColumnCount;
 
-        public bool IsSingleWordValue => _type.Repr == VariableRepresentation.Float && _type.Size == 16;
+        public bool IsSingleWordValue => _type.Category == VariableCategory.Float && _type.Size == 16;
 
         private readonly SliceWatchView _view;
         private readonly VariableType _type;

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/TypedSliceWatchView.cs
@@ -10,7 +10,7 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
         public int RowCount => _view.RowCount;
         public int ColumnCount => _view.ColumnCount;
 
-        public bool IsSingleWordValue => _type.Type == VariableType.Half;
+        public bool IsSingleWordValue => _type.Type == VariableType.Float && _type.Size == 16;
 
         private readonly SliceWatchView _view;
         private readonly VariableInfo _type;

--- a/VSRAD.Package/DebugVisualizer/VariableType.cs
+++ b/VSRAD.Package/DebugVisualizer/VariableType.cs
@@ -43,13 +43,13 @@ namespace VSRAD.Package.DebugVisualizer
             switch (info.Type)
             {
                 case VariableType.Bin:
-                    return "B" + info.Size.ToString();
+                    return "B"; //+ info.Size.ToString();
                 case VariableType.Float:
-                    return "F" + info.Size.ToString();
+                    return "F"; //+ info.Size.ToString();
                 case VariableType.Half:
                     return "h"; // we dont use size for half's
                 case VariableType.Hex:
-                    return "H" + info.Size.ToString();
+                    return "H"; //+ info.Size.ToString();
                 case VariableType.Int:
                     return "I" + info.Size.ToString();
                 case VariableType.Uint:
@@ -64,13 +64,13 @@ namespace VSRAD.Package.DebugVisualizer
             switch (shortName[0])
             {
                 case 'B':
-                    return new VariableInfo(VariableType.Bin, int.Parse(shortName.Substring(1)));
+                    return new VariableInfo(VariableType.Bin, 32);//int.Parse(shortName.Substring(1)));
                 case 'F':
-                    return new VariableInfo(VariableType.Float, int.Parse(shortName.Substring(1)));
+                    return new VariableInfo(VariableType.Float, 32);//int.Parse(shortName.Substring(1)));
                 case 'h':
                     return new VariableInfo(VariableType.Half, 0); // we dont use size for half's
                 case 'H':
-                    return new VariableInfo(VariableType.Hex, int.Parse(shortName.Substring(1)));
+                    return new VariableInfo(VariableType.Hex, 32); //int.Parse(shortName.Substring(1)));
                 case 'I':
                     return new VariableInfo(VariableType.Int, int.Parse(shortName.Substring(1)));
                 default:

--- a/VSRAD.Package/DebugVisualizer/VariableType.cs
+++ b/VSRAD.Package/DebugVisualizer/VariableType.cs
@@ -1,5 +1,9 @@
-﻿namespace VSRAD.Package.DebugVisualizer
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace VSRAD.Package.DebugVisualizer
 {
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum VariableType
     {
 #pragma warning disable CA1720 // Identifier contains type name
@@ -7,10 +11,17 @@
 #pragma warning restore CA1720 // Identifier contains type name
     };
 
-    public struct VariableInfo : System.IEquatable<VariableInfo>
+    public readonly struct VariableInfo : System.IEquatable<VariableInfo>
     {
-        public VariableType Type;
-        public int Size;
+        [JsonConstructor]
+        public VariableInfo(VariableType type, int size)
+        {
+            Type = type;
+            Size = size;
+        }
+
+        public readonly VariableType Type;
+        public readonly int Size;
 
         public bool Equals(VariableInfo other) =>
             other.Type == Type && other.Size == Size;
@@ -53,17 +64,17 @@
             switch (shortName[0])
             {
                 case 'B':
-                    return new VariableInfo { Type = VariableType.Bin,   Size = int.Parse(shortName.Substring(1)) };
+                    return new VariableInfo(VariableType.Bin, int.Parse(shortName.Substring(1)));
                 case 'F':
-                    return new VariableInfo { Type = VariableType.Float, Size = int.Parse(shortName.Substring(1)) };
+                    return new VariableInfo(VariableType.Float, int.Parse(shortName.Substring(1)));
                 case 'h':
-                    return new VariableInfo { Type = VariableType.Half,  Size = 0 /*we dont use size for half's*/ };
+                    return new VariableInfo(VariableType.Half, 0); // we dont use size for half's
                 case 'H':
-                    return new VariableInfo { Type = VariableType.Hex,   Size = int.Parse(shortName.Substring(1)) };
+                    return new VariableInfo(VariableType.Hex, int.Parse(shortName.Substring(1)));
                 case 'I':
-                    return new VariableInfo { Type = VariableType.Int,   Size = int.Parse(shortName.Substring(1)) };
+                    return new VariableInfo(VariableType.Int, int.Parse(shortName.Substring(1)));
                 default:
-                    return new VariableInfo { Type = VariableType.Uint,  Size = int.Parse(shortName.Substring(1)) };
+                    return new VariableInfo(VariableType.Uint, int.Parse(shortName.Substring(1)));
             }
         }
     }

--- a/VSRAD.Package/DebugVisualizer/VariableType.cs
+++ b/VSRAD.Package/DebugVisualizer/VariableType.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Converters;
 namespace VSRAD.Package.DebugVisualizer
 {
     [JsonConverter(typeof(StringEnumConverter))]
-    public enum VariableRepresentation
+    public enum VariableCategory
     {
 #pragma warning disable CA1720 // Identifier contains type name
         Hex, Float, Uint, Int, Bin
@@ -14,22 +14,22 @@ namespace VSRAD.Package.DebugVisualizer
     public readonly struct VariableType : System.IEquatable<VariableType>
     {
         [JsonConstructor]
-        public VariableType(VariableRepresentation type, int size)
+        public VariableType(VariableCategory type, int size)
         {
-            Repr = type;
+            Category = type;
             Size = size;
         }
 
-        public readonly VariableRepresentation Repr;
+        public readonly VariableCategory Category;
         public readonly int Size;
 
         public bool Equals(VariableType other) =>
-            other.Repr == Repr && other.Size == Size;
+            other.Category == Category && other.Size == Size;
 
         public override bool Equals(object obj) =>
             obj is VariableType other && Equals(other);
 
-        public override int GetHashCode() => (Repr, Size).GetHashCode();
+        public override int GetHashCode() => (Category, Size).GetHashCode();
 
         public static bool operator ==(VariableType left, VariableType right) => left.Equals(right);
 
@@ -40,20 +40,20 @@ namespace VSRAD.Package.DebugVisualizer
     {
         public static string ShortName(this VariableType info)
         {
-            switch (info.Repr)
+            switch (info.Category)
             {
-                case VariableRepresentation.Bin:
+                case VariableCategory.Bin:
                     return "B";
-                case VariableRepresentation.Float:
+                case VariableCategory.Float:
                     if (info.Size == 32)
                         return "F";
                     else
                         return "h"; // half
-                case VariableRepresentation.Hex:
+                case VariableCategory.Hex:
                     return "H";
-                case VariableRepresentation.Int:
+                case VariableCategory.Int:
                     return "I" + info.Size.ToString();
-                case VariableRepresentation.Uint:
+                case VariableCategory.Uint:
                     return "U" + info.Size.ToString();
                 default:
                     return string.Empty;
@@ -65,17 +65,17 @@ namespace VSRAD.Package.DebugVisualizer
             switch (shortName[0])
             {
                 case 'B':
-                    return new VariableType(VariableRepresentation.Bin, 32);
+                    return new VariableType(VariableCategory.Bin, 32);
                 case 'F':
-                    return new VariableType(VariableRepresentation.Float, 32);
+                    return new VariableType(VariableCategory.Float, 32);
                 case 'h':
-                    return new VariableType(VariableRepresentation.Float, 16);
+                    return new VariableType(VariableCategory.Float, 16);
                 case 'H':
-                    return new VariableType(VariableRepresentation.Hex, 32);
+                    return new VariableType(VariableCategory.Hex, 32);
                 case 'I':
-                    return new VariableType(VariableRepresentation.Int, int.Parse(shortName.Substring(1)));
+                    return new VariableType(VariableCategory.Int, int.Parse(shortName.Substring(1)));
                 default:
-                    return new VariableType(VariableRepresentation.Uint, int.Parse(shortName.Substring(1)));
+                    return new VariableType(VariableCategory.Uint, int.Parse(shortName.Substring(1)));
             }
         }
     }

--- a/VSRAD.Package/DebugVisualizer/VariableType.cs
+++ b/VSRAD.Package/DebugVisualizer/VariableType.cs
@@ -4,78 +4,78 @@ using Newtonsoft.Json.Converters;
 namespace VSRAD.Package.DebugVisualizer
 {
     [JsonConverter(typeof(StringEnumConverter))]
-    public enum VariableType
+    public enum VariableRepresentation
     {
 #pragma warning disable CA1720 // Identifier contains type name
         Hex, Float, Uint, Int, Bin
 #pragma warning restore CA1720 // Identifier contains type name
     };
 
-    public readonly struct VariableInfo : System.IEquatable<VariableInfo>
+    public readonly struct VariableType : System.IEquatable<VariableType>
     {
         [JsonConstructor]
-        public VariableInfo(VariableType type, int size)
+        public VariableType(VariableRepresentation type, int size)
         {
-            Type = type;
+            Repr = type;
             Size = size;
         }
 
-        public readonly VariableType Type;
+        public readonly VariableRepresentation Repr;
         public readonly int Size;
 
-        public bool Equals(VariableInfo other) =>
-            other.Type == Type && other.Size == Size;
+        public bool Equals(VariableType other) =>
+            other.Repr == Repr && other.Size == Size;
 
         public override bool Equals(object obj) =>
-            obj is VariableInfo other && Equals(other);
+            obj is VariableType other && Equals(other);
 
-        public override int GetHashCode() => (Type, Size).GetHashCode();
+        public override int GetHashCode() => (Repr, Size).GetHashCode();
 
-        public static bool operator ==(VariableInfo left, VariableInfo right) => left.Equals(right);
+        public static bool operator ==(VariableType left, VariableType right) => left.Equals(right);
 
-        public static bool operator !=(VariableInfo left, VariableInfo right) => !(left == right);
+        public static bool operator !=(VariableType left, VariableType right) => !(left == right);
     }
 
     public static class VariableTypeUtils
     {
-        public static string ShortName(this VariableInfo info)
+        public static string ShortName(this VariableType info)
         {
-            switch (info.Type)
+            switch (info.Repr)
             {
-                case VariableType.Bin:
+                case VariableRepresentation.Bin:
                     return "B";
-                case VariableType.Float:
+                case VariableRepresentation.Float:
                     if (info.Size == 32)
                         return "F";
                     else
                         return "h"; // half
-                case VariableType.Hex:
+                case VariableRepresentation.Hex:
                     return "H";
-                case VariableType.Int:
+                case VariableRepresentation.Int:
                     return "I" + info.Size.ToString();
-                case VariableType.Uint:
+                case VariableRepresentation.Uint:
                     return "U" + info.Size.ToString();
                 default:
                     return string.Empty;
             }
         }
 
-        public static VariableInfo TypeFromShortName(string shortName)
+        public static VariableType TypeFromShortName(string shortName)
         {
             switch (shortName[0])
             {
                 case 'B':
-                    return new VariableInfo(VariableType.Bin, 32);
+                    return new VariableType(VariableRepresentation.Bin, 32);
                 case 'F':
-                    return new VariableInfo(VariableType.Float, 32);
+                    return new VariableType(VariableRepresentation.Float, 32);
                 case 'h':
-                    return new VariableInfo(VariableType.Float, 16);
+                    return new VariableType(VariableRepresentation.Float, 16);
                 case 'H':
-                    return new VariableInfo(VariableType.Hex, 32);
+                    return new VariableType(VariableRepresentation.Hex, 32);
                 case 'I':
-                    return new VariableInfo(VariableType.Int, int.Parse(shortName.Substring(1)));
+                    return new VariableType(VariableRepresentation.Int, int.Parse(shortName.Substring(1)));
                 default:
-                    return new VariableInfo(VariableType.Uint, int.Parse(shortName.Substring(1)));
+                    return new VariableType(VariableRepresentation.Uint, int.Parse(shortName.Substring(1)));
             }
         }
     }

--- a/VSRAD.Package/DebugVisualizer/VariableType.cs
+++ b/VSRAD.Package/DebugVisualizer/VariableType.cs
@@ -7,7 +7,7 @@ namespace VSRAD.Package.DebugVisualizer
     public enum VariableType
     {
 #pragma warning disable CA1720 // Identifier contains type name
-        Hex, Float, Uint, Int, Half, Bin
+        Hex, Float, Uint, Int, Bin
 #pragma warning restore CA1720 // Identifier contains type name
     };
 
@@ -43,13 +43,14 @@ namespace VSRAD.Package.DebugVisualizer
             switch (info.Type)
             {
                 case VariableType.Bin:
-                    return "B"; //+ info.Size.ToString();
+                    return "B";
                 case VariableType.Float:
-                    return "F"; //+ info.Size.ToString();
-                case VariableType.Half:
-                    return "h"; // we dont use size for half's
+                    if (info.Size == 32)
+                        return "F";
+                    else
+                        return "h"; // half
                 case VariableType.Hex:
-                    return "H"; //+ info.Size.ToString();
+                    return "H";
                 case VariableType.Int:
                     return "I" + info.Size.ToString();
                 case VariableType.Uint:
@@ -64,13 +65,13 @@ namespace VSRAD.Package.DebugVisualizer
             switch (shortName[0])
             {
                 case 'B':
-                    return new VariableInfo(VariableType.Bin, 32);//int.Parse(shortName.Substring(1)));
+                    return new VariableInfo(VariableType.Bin, 32);
                 case 'F':
-                    return new VariableInfo(VariableType.Float, 32);//int.Parse(shortName.Substring(1)));
+                    return new VariableInfo(VariableType.Float, 32);
                 case 'h':
-                    return new VariableInfo(VariableType.Half, 0); // we dont use size for half's
+                    return new VariableInfo(VariableType.Float, 16);
                 case 'H':
-                    return new VariableInfo(VariableType.Hex, 32); //int.Parse(shortName.Substring(1)));
+                    return new VariableInfo(VariableType.Hex, 32);
                 case 'I':
                     return new VariableInfo(VariableType.Int, int.Parse(shortName.Substring(1)));
                 default:

--- a/VSRAD.Package/DebugVisualizer/VariableType.cs
+++ b/VSRAD.Package/DebugVisualizer/VariableType.cs
@@ -7,45 +7,63 @@
 #pragma warning restore CA1720 // Identifier contains type name
     };
 
+    public struct VariableInfo : System.IEquatable<VariableInfo>
+    {
+        public VariableType Type;
+        public int Size;
+
+        public bool Equals(VariableInfo other) =>
+            other.Type == Type && other.Size == Size;
+
+        public override bool Equals(object obj) =>
+            obj is VariableInfo other && Equals(other);
+
+        public override int GetHashCode() => (Type, Size).GetHashCode();
+
+        public static bool operator ==(VariableInfo left, VariableInfo right) => left.Equals(right);
+
+        public static bool operator !=(VariableInfo left, VariableInfo right) => !(left == right);
+    }
+
     public static class VariableTypeUtils
     {
-        public static string ShortName(this VariableType type)
+        public static string ShortName(this VariableInfo info)
         {
-            switch (type)
+            switch (info.Type)
             {
                 case VariableType.Bin:
-                    return "B";
+                    return "B" + info.Size.ToString();
                 case VariableType.Float:
-                    return "F";
+                    return "F" + info.Size.ToString();
                 case VariableType.Half:
-                    return "h";
+                    return "h"; // we dont use size for half's
                 case VariableType.Hex:
-                    return "H";
+                    return "H" + info.Size.ToString();
                 case VariableType.Int:
-                    return "I";
+                    return "I" + info.Size.ToString();
                 case VariableType.Uint:
-                    return "U";
+                    return "U" + info.Size.ToString();
                 default:
                     return string.Empty;
             }
         }
 
-        public static VariableType TypeFromShortName(string shortName)
+        public static VariableInfo TypeFromShortName(string shortName)
         {
-            switch (shortName)
+            switch (shortName[0])
             {
-                case "B":
-                    return VariableType.Bin;
-                case "F":
-                    return VariableType.Float;
-                case "h":
-                    return VariableType.Half;
-                case "H":
-                    return VariableType.Hex;
-                case "I":
-                    return VariableType.Int;
+                case 'B':
+                    return new VariableInfo { Type = VariableType.Bin,   Size = int.Parse(shortName.Substring(1)) };
+                case 'F':
+                    return new VariableInfo { Type = VariableType.Float, Size = int.Parse(shortName.Substring(1)) };
+                case 'h':
+                    return new VariableInfo { Type = VariableType.Half,  Size = 0 /*we dont use size for half's*/ };
+                case 'H':
+                    return new VariableInfo { Type = VariableType.Hex,   Size = int.Parse(shortName.Substring(1)) };
+                case 'I':
+                    return new VariableInfo { Type = VariableType.Int,   Size = int.Parse(shortName.Substring(1)) };
                 default:
-                    return VariableType.Uint;
+                    return new VariableInfo { Type = VariableType.Uint,  Size = int.Parse(shortName.Substring(1)) };
             }
         }
     }

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -110,7 +110,7 @@ To switch to manual grid size selection, right-click on the space next to the Gr
         {
             RefreshDataStyling();
             _table.Rows.Clear();
-            _table.AppendVariableRow(new Watch("System", new VariableInfo { Type = VariableType.Hex, Size = 32 }, isAVGPR: false), canBeRemoved: false);
+            _table.AppendVariableRow(new Watch("System", new VariableInfo(VariableType.Hex, 32), isAVGPR: false), canBeRemoved: false);
             _table.ShowSystemRow = _context.Options.VisualizerOptions.ShowSystemVariable;
             _table.AlignmentChanged(
                     _context.Options.VisualizerAppearance.NameColumnAlignment,
@@ -174,7 +174,7 @@ To switch to manual grid size selection, right-click on the space next to the Gr
         private void AddWatch(string watchName)
         {
             _table.RemoveNewWatchRow();
-            _table.AppendVariableRow(new Watch(watchName, new VariableInfo { Type = VariableType.Int, Size = 32 }, isAVGPR: false));
+            _table.AppendVariableRow(new Watch(watchName, new VariableInfo(VariableType.Int, 32), isAVGPR: false));
             _table.PrepareNewWatchRow();
             _context.Options.DebuggerOptions.Watches.Clear();
             _context.Options.DebuggerOptions.Watches.AddRange(_table.GetCurrentWatchState());

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -110,7 +110,7 @@ To switch to manual grid size selection, right-click on the space next to the Gr
         {
             RefreshDataStyling();
             _table.Rows.Clear();
-            _table.AppendVariableRow(new Watch("System", VariableType.Hex, isAVGPR: false), canBeRemoved: false);
+            _table.AppendVariableRow(new Watch("System", new VariableInfo { Type = VariableType.Hex, Size = 32 }, isAVGPR: false), canBeRemoved: false);
             _table.ShowSystemRow = _context.Options.VisualizerOptions.ShowSystemVariable;
             _table.AlignmentChanged(
                     _context.Options.VisualizerAppearance.NameColumnAlignment,
@@ -169,6 +169,15 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                         SetRowContentsFromBreakState(row);
                     break;
             }
+        }
+
+        private void AddWatch(string watchName)
+        {
+            _table.RemoveNewWatchRow();
+            _table.AppendVariableRow(new Watch(watchName, new VariableInfo { Type = VariableType.Int, Size = 32 }, isAVGPR: false));
+            _table.PrepareNewWatchRow();
+            _context.Options.DebuggerOptions.Watches.Clear();
+            _context.Options.DebuggerOptions.Watches.AddRange(_table.GetCurrentWatchState());
         }
 
         private void SetRowContentsFromBreakState(System.Windows.Forms.DataGridViewRow row)

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -110,7 +110,7 @@ To switch to manual grid size selection, right-click on the space next to the Gr
         {
             RefreshDataStyling();
             _table.Rows.Clear();
-            _table.AppendVariableRow(new Watch("System", new VariableType(VariableRepresentation.Hex, 32), isAVGPR: false), canBeRemoved: false);
+            _table.AppendVariableRow(new Watch("System", new VariableType(VariableCategory.Hex, 32), isAVGPR: false), canBeRemoved: false);
             _table.ShowSystemRow = _context.Options.VisualizerOptions.ShowSystemVariable;
             _table.AlignmentChanged(
                     _context.Options.VisualizerAppearance.NameColumnAlignment,

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -110,7 +110,7 @@ To switch to manual grid size selection, right-click on the space next to the Gr
         {
             RefreshDataStyling();
             _table.Rows.Clear();
-            _table.AppendVariableRow(new Watch("System", new VariableInfo(VariableType.Hex, 32), isAVGPR: false), canBeRemoved: false);
+            _table.AppendVariableRow(new Watch("System", new VariableType(VariableRepresentation.Hex, 32), isAVGPR: false), canBeRemoved: false);
             _table.ShowSystemRow = _context.Options.VisualizerOptions.ShowSystemVariable;
             _table.AlignmentChanged(
                     _context.Options.VisualizerAppearance.NameColumnAlignment,

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -171,15 +171,6 @@ To switch to manual grid size selection, right-click on the space next to the Gr
             }
         }
 
-        private void AddWatch(string watchName)
-        {
-            _table.RemoveNewWatchRow();
-            _table.AppendVariableRow(new Watch(watchName, new VariableInfo(VariableType.Int, 32), isAVGPR: false));
-            _table.PrepareNewWatchRow();
-            _context.Options.DebuggerOptions.Watches.Clear();
-            _context.Options.DebuggerOptions.Watches.AddRange(_table.GetCurrentWatchState());
-        }
-
         private void SetRowContentsFromBreakState(System.Windows.Forms.DataGridViewRow row)
         {
             if (_context.BreakData == null)

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -105,7 +105,7 @@ namespace VSRAD.Package.DebugVisualizer
         public void AddWatch(string watchName)
         {
             RemoveNewWatchRow();
-            AppendVariableRow(new Watch(watchName, new VariableInfo(VariableType.Int, 32), isAVGPR: false));
+            AppendVariableRow(new Watch(watchName, new VariableType(VariableRepresentation.Int, 32), isAVGPR: false));
             PrepareNewWatchRow();
             RaiseWatchStateChanged();
         }
@@ -162,7 +162,7 @@ namespace VSRAD.Package.DebugVisualizer
             ProcessInsertKey(Keys.Control | Keys.C);
         }
 
-        private void VariableTypeChanged(int rowIndex, VariableInfo type)
+        private void VariableTypeChanged(int rowIndex, VariableType type)
         {
             var changedRows = _selectionController.GetClickTargetRows(rowIndex);
             foreach (var row in changedRows)
@@ -218,7 +218,7 @@ namespace VSRAD.Package.DebugVisualizer
             var index = after ? rowIndex + 1 : rowIndex;
             Rows.Insert(index);
             Rows[index].Cells[NameColumnIndex].Value = " ";
-            Rows[index].HeaderCell.Value = VariableType.Hex.ToString();
+            Rows[index].HeaderCell.Value = VariableRepresentation.Hex.ToString();
             Rows[index].HeaderCell.Tag = false; // avgpr
             RaiseWatchStateChanged(new[] { Rows[index] });
         }
@@ -302,7 +302,7 @@ namespace VSRAD.Package.DebugVisualizer
                     var scrollingOffset = HorizontalScrollingOffset;
                     if (!string.IsNullOrWhiteSpace(rowWatchName))
                         Rows[e.RowIndex].Cells[NameColumnIndex].Value = rowWatchName.Trim();
-                    Rows[e.RowIndex].HeaderCell.Value = new VariableInfo(VariableType.Hex, 32).ShortName();
+                    Rows[e.RowIndex].HeaderCell.Value = new VariableType(VariableRepresentation.Hex, 32).ShortName();
                     Rows[e.RowIndex].HeaderCell.Tag = IsAVGPR(rowWatchName); // avgpr
                     RowStyling.UpdateRowHighlight(row, _fontAndColor.FontAndColorState, _getValidWatches());
                     LockWatchRowForEditing(row);

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -105,7 +105,7 @@ namespace VSRAD.Package.DebugVisualizer
         public void AddWatch(string watchName)
         {
             RemoveNewWatchRow();
-            AppendVariableRow(new Watch(watchName, new VariableType(VariableRepresentation.Int, 32), isAVGPR: false));
+            AppendVariableRow(new Watch(watchName, new VariableType(VariableCategory.Int, 32), isAVGPR: false));
             PrepareNewWatchRow();
             RaiseWatchStateChanged();
         }
@@ -218,7 +218,7 @@ namespace VSRAD.Package.DebugVisualizer
             var index = after ? rowIndex + 1 : rowIndex;
             Rows.Insert(index);
             Rows[index].Cells[NameColumnIndex].Value = " ";
-            Rows[index].HeaderCell.Value = VariableRepresentation.Hex.ToString();
+            Rows[index].HeaderCell.Value = VariableCategory.Hex.ToString();
             Rows[index].HeaderCell.Tag = false; // avgpr
             RaiseWatchStateChanged(new[] { Rows[index] });
         }
@@ -302,7 +302,7 @@ namespace VSRAD.Package.DebugVisualizer
                     var scrollingOffset = HorizontalScrollingOffset;
                     if (!string.IsNullOrWhiteSpace(rowWatchName))
                         Rows[e.RowIndex].Cells[NameColumnIndex].Value = rowWatchName.Trim();
-                    Rows[e.RowIndex].HeaderCell.Value = new VariableType(VariableRepresentation.Hex, 32).ShortName();
+                    Rows[e.RowIndex].HeaderCell.Value = new VariableType(VariableCategory.Hex, 32).ShortName();
                     Rows[e.RowIndex].HeaderCell.Tag = IsAVGPR(rowWatchName); // avgpr
                     RowStyling.UpdateRowHighlight(row, _fontAndColor.FontAndColorState, _getValidWatches());
                     LockWatchRowForEditing(row);

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -105,7 +105,7 @@ namespace VSRAD.Package.DebugVisualizer
         public void AddWatch(string watchName)
         {
             RemoveNewWatchRow();
-            AppendVariableRow(new Watch(watchName, VariableType.Int, isAVGPR: false));
+            AppendVariableRow(new Watch(watchName, new VariableInfo(VariableType.Int, 32), isAVGPR: false));
             PrepareNewWatchRow();
             RaiseWatchStateChanged();
         }

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -56,7 +56,7 @@ namespace VSRAD.Package.DebugVisualizer
             _computedStyling = new ComputedColumnStyling();
             _getValidWatches = getValidWatches;
 
-            RowHeadersWidth = 30;
+            RowHeadersWidth = 35;
             RowHeadersWidthSizeMode = DataGridViewRowHeadersWidthSizeMode.DisableResizing;
             ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
             RowHeadersVisible = true;

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -302,7 +302,7 @@ namespace VSRAD.Package.DebugVisualizer
                     var scrollingOffset = HorizontalScrollingOffset;
                     if (!string.IsNullOrWhiteSpace(rowWatchName))
                         Rows[e.RowIndex].Cells[NameColumnIndex].Value = rowWatchName.Trim();
-                    Rows[e.RowIndex].HeaderCell.Value = new VariableInfo { Type = VariableType.Hex, Size = 32 }.ShortName();
+                    Rows[e.RowIndex].HeaderCell.Value = new VariableInfo(VariableType.Hex, 32).ShortName();
                     Rows[e.RowIndex].HeaderCell.Tag = IsAVGPR(rowWatchName); // avgpr
                     RowStyling.UpdateRowHighlight(row, _fontAndColor.FontAndColorState, _getValidWatches());
                     LockWatchRowForEditing(row);

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -162,7 +162,7 @@ namespace VSRAD.Package.DebugVisualizer
             ProcessInsertKey(Keys.Control | Keys.C);
         }
 
-        private void VariableTypeChanged(int rowIndex, VariableType type)
+        private void VariableTypeChanged(int rowIndex, VariableInfo type)
         {
             var changedRows = _selectionController.GetClickTargetRows(rowIndex);
             foreach (var row in changedRows)
@@ -227,7 +227,7 @@ namespace VSRAD.Package.DebugVisualizer
         {
             var index = Rows.Add();
             Rows[index].Cells[NameColumnIndex].Value = watch.Name;
-            Rows[index].HeaderCell.Value = watch.Type.ShortName();
+            Rows[index].HeaderCell.Value = watch.Info.ShortName();
             Rows[index].HeaderCell.Tag = watch.IsAVGPR;
             Rows[index].DefaultCellStyle.BackColor = _fontAndColor.FontAndColorState.HighlightBackground[(int)DataHighlightColor.Inactive];
 
@@ -302,7 +302,7 @@ namespace VSRAD.Package.DebugVisualizer
                     var scrollingOffset = HorizontalScrollingOffset;
                     if (!string.IsNullOrWhiteSpace(rowWatchName))
                         Rows[e.RowIndex].Cells[NameColumnIndex].Value = rowWatchName.Trim();
-                    Rows[e.RowIndex].HeaderCell.Value = VariableType.Hex.ShortName();
+                    Rows[e.RowIndex].HeaderCell.Value = new VariableInfo { Type = VariableType.Hex, Size = 32 }.ShortName();
                     Rows[e.RowIndex].HeaderCell.Tag = IsAVGPR(rowWatchName); // avgpr
                     RowStyling.UpdateRowHighlight(row, _fontAndColor.FontAndColorState, _getValidWatches());
                     LockWatchRowForEditing(row);

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -56,7 +56,7 @@ namespace VSRAD.Package.DebugVisualizer
             _computedStyling = new ComputedColumnStyling();
             _getValidWatches = getValidWatches;
 
-            RowHeadersWidth = 35;
+            RowHeadersWidth = 45;
             RowHeadersWidthSizeMode = DataGridViewRowHeadersWidthSizeMode.DisableResizing;
             ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
             RowHeadersVisible = true;

--- a/VSRAD.Package/DebugVisualizer/Watch.cs
+++ b/VSRAD.Package/DebugVisualizer/Watch.cs
@@ -7,8 +7,8 @@ namespace VSRAD.Package.DebugVisualizer
     {
         public string Name { get; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
-        public VariableType Type { get; }
+        //[JsonConverter(typeof(StringEnumConverter))]
+        public VariableInfo Info { get; }
 
         public bool IsAVGPR { get; }
 
@@ -16,16 +16,16 @@ namespace VSRAD.Package.DebugVisualizer
         public bool IsEmpty => string.IsNullOrWhiteSpace(Name);
 
         [JsonConstructor]
-        public Watch(string name, VariableType type, bool isAVGPR)
+        public Watch(string name, VariableInfo type, bool isAVGPR)
         {
             Name = name;
-            Type = type;
+            Info = type;
             IsAVGPR = isAVGPR;
         }
 
-        public bool Equals(Watch w) => Name == w.Name && Type == w.Type && IsAVGPR == w.IsAVGPR;
+        public bool Equals(Watch w) => Name == w.Name && Info == w.Info && IsAVGPR == w.IsAVGPR;
         public override bool Equals(object o) => o is Watch w && Equals(w);
-        public override int GetHashCode() => (Name, Type, IsAVGPR).GetHashCode();
+        public override int GetHashCode() => (Name, Info, IsAVGPR).GetHashCode();
         public static bool operator ==(Watch left, Watch right) => left.Equals(right);
         public static bool operator !=(Watch left, Watch right) => !(left == right);
     }

--- a/VSRAD.Package/DebugVisualizer/Watch.cs
+++ b/VSRAD.Package/DebugVisualizer/Watch.cs
@@ -8,7 +8,7 @@ namespace VSRAD.Package.DebugVisualizer
         public string Name { get; }
 
         //[JsonConverter(typeof(StringEnumConverter))]
-        public VariableInfo Info { get; }
+        public VariableType Info { get; }
 
         public bool IsAVGPR { get; }
 
@@ -16,7 +16,7 @@ namespace VSRAD.Package.DebugVisualizer
         public bool IsEmpty => string.IsNullOrWhiteSpace(Name);
 
         [JsonConstructor]
-        public Watch(string name, VariableInfo type, bool isAVGPR)
+        public Watch(string name, VariableType type, bool isAVGPR)
         {
             Name = name;
             Info = type;

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -86,7 +86,7 @@ namespace VSRAD.Package.Options
             while (reader.Read() && reader.TokenType != JsonToken.EndArray)
             {
                 if (reader.TokenType == JsonToken.String)
-                    watches.Add(new Watch((string)reader.Value, new VariableInfo { Type = VariableType.Hex, Size = 32 }, isAVGPR: false));
+                    watches.Add(new Watch((string)reader.Value, new VariableInfo(VariableType.Hex, 32), isAVGPR: false));
                 else if (reader.TokenType == JsonToken.StartObject)
                     watches.Add(JObject.Load(reader).ToObject<Watch>());
             }

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -97,11 +97,23 @@ namespace VSRAD.Package.Options
                     var name = reader.Value.ToString();
 
                     if (!reader.Read()) continue;
-                    if (reader.TokenType != JsonToken.PropertyName || reader.Value.ToString() != "Info") continue;
+                    if (reader.TokenType != JsonToken.PropertyName) continue;
 
-                    if (!reader.Read()) continue;
-                    if (reader.TokenType != JsonToken.StartObject) continue;
-                    var info = JObject.Load(reader).ToObject<VariableInfo>();
+                    VariableInfo info;
+
+                    if (reader.Value.ToString() == "Info")
+                    {
+                        if (!reader.Read()) continue;
+                        if (reader.TokenType != JsonToken.StartObject) continue;
+                        info = JObject.Load(reader).ToObject<VariableInfo>();
+                    }
+                    else
+                    {
+                        if (reader.Value.ToString() != "Type") continue;
+                        if (!reader.Read()) continue;
+                        if (reader.TokenType != JsonToken.String) continue;
+                        info = new VariableInfo((VariableType)Enum.Parse(typeof(VariableType), reader.Value.ToString()), 32);
+                    }
 
                     if (!reader.Read()) continue;
                     if (reader.TokenType != JsonToken.PropertyName || reader.Value.ToString() != "IsAVGPR") continue;

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -86,7 +86,7 @@ namespace VSRAD.Package.Options
             while (reader.Read() && reader.TokenType != JsonToken.EndArray)
             {
                 if (reader.TokenType == JsonToken.String)
-                    watches.Add(new Watch((string)reader.Value, new VariableInfo(VariableType.Hex, 32), isAVGPR: false));
+                    watches.Add(new Watch((string)reader.Value, new VariableType(VariableRepresentation.Hex, 32), isAVGPR: false));
                 else if (reader.TokenType == JsonToken.StartObject)
                 {
                     if (!reader.Read()) continue;
@@ -99,20 +99,20 @@ namespace VSRAD.Package.Options
                     if (!reader.Read()) continue;
                     if (reader.TokenType != JsonToken.PropertyName) continue;
 
-                    VariableInfo info;
+                    VariableType info;
 
                     if (reader.Value.ToString() == "Info")
                     {
                         if (!reader.Read()) continue;
                         if (reader.TokenType != JsonToken.StartObject) continue;
-                        info = JObject.Load(reader).ToObject<VariableInfo>();
+                        info = JObject.Load(reader).ToObject<VariableType>();
                     }
                     else
                     {
                         if (reader.Value.ToString() != "Type") continue;
                         if (!reader.Read()) continue;
                         if (reader.TokenType != JsonToken.String) continue;
-                        info = new VariableInfo((VariableType)Enum.Parse(typeof(VariableType), reader.Value.ToString()), 32);
+                        info = new VariableType((VariableRepresentation)Enum.Parse(typeof(VariableRepresentation), reader.Value.ToString()), 32);
                     }
 
                     if (!reader.Read()) continue;

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -86,7 +86,7 @@ namespace VSRAD.Package.Options
             while (reader.Read() && reader.TokenType != JsonToken.EndArray)
             {
                 if (reader.TokenType == JsonToken.String)
-                    watches.Add(new Watch((string)reader.Value, new VariableType(VariableRepresentation.Hex, 32), isAVGPR: false));
+                    watches.Add(new Watch((string)reader.Value, new VariableType(VariableCategory.Hex, 32), isAVGPR: false));
                 else if (reader.TokenType == JsonToken.StartObject)
                 {
                     if (!reader.Read()) continue;
@@ -112,7 +112,7 @@ namespace VSRAD.Package.Options
                         if (reader.Value.ToString() != "Type") continue;
                         if (!reader.Read()) continue;
                         if (reader.TokenType != JsonToken.String) continue;
-                        info = new VariableType((VariableRepresentation)Enum.Parse(typeof(VariableRepresentation), reader.Value.ToString()), 32);
+                        info = new VariableType((VariableCategory)Enum.Parse(typeof(VariableCategory), reader.Value.ToString()), 32);
                     }
 
                     if (!reader.Read()) continue;

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -86,7 +86,7 @@ namespace VSRAD.Package.Options
             while (reader.Read() && reader.TokenType != JsonToken.EndArray)
             {
                 if (reader.TokenType == JsonToken.String)
-                    watches.Add(new Watch((string)reader.Value, VariableType.Hex, isAVGPR: false));
+                    watches.Add(new Watch((string)reader.Value, new VariableInfo { Type = VariableType.Hex, Size = 32 }, isAVGPR: false));
                 else if (reader.TokenType == JsonToken.StartObject)
                     watches.Add(JObject.Load(reader).ToObject<Watch>());
             }

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -88,7 +88,30 @@ namespace VSRAD.Package.Options
                 if (reader.TokenType == JsonToken.String)
                     watches.Add(new Watch((string)reader.Value, new VariableInfo(VariableType.Hex, 32), isAVGPR: false));
                 else if (reader.TokenType == JsonToken.StartObject)
-                    watches.Add(JObject.Load(reader).ToObject<Watch>());
+                {
+                    if (!reader.Read()) continue;
+                    if (reader.TokenType != JsonToken.PropertyName || reader.Value.ToString() != "Name") continue;
+
+                    if (!reader.Read()) continue;
+                    if (reader.TokenType != JsonToken.String) continue;
+                    var name = reader.Value.ToString();
+
+                    if (!reader.Read()) continue;
+                    if (reader.TokenType != JsonToken.PropertyName || reader.Value.ToString() != "Info") continue;
+
+                    if (!reader.Read()) continue;
+                    if (reader.TokenType != JsonToken.StartObject) continue;
+                    var info = JObject.Load(reader).ToObject<VariableInfo>();
+
+                    if (!reader.Read()) continue;
+                    if (reader.TokenType != JsonToken.PropertyName || reader.Value.ToString() != "IsAVGPR") continue;
+
+                    if (!reader.Read()) continue;
+                    if (reader.TokenType != JsonToken.Boolean) continue;
+                    var isAVGPR = (bool)reader.Value;
+
+                    watches.Add(new Watch(name, info, isAVGPR));
+                }
             }
 
             return watches;

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -32,7 +32,7 @@ namespace VSRAD.Package.Utils
             {
                 case VariableType.Hex:
                     var hex = data.ToString("x");
-                    if (varInfo.Size != 32) hex = hex.Substring(8 - (varInfo.Size / 4), varInfo.Size / 4);
+                    if (varInfo.Size != 32) hex = hex.Substring(8 - (varInfo.Size / 4), varInfo.Size / 4); // TODO: doesnt work with short representations (0x0)
                     if (string.IsNullOrEmpty(hex)) hex = "0";
                     if (leadingZeroes)
                         hex = hex.PadLeft(varInfo.Size / 4, '0');

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -31,9 +31,10 @@ namespace VSRAD.Package.Utils
             switch (varInfo.Type)
             {
                 case VariableType.Hex:
-                    var hex = data.ToString("x");
+                    var hex = data.ToString("x").Substring(0, varInfo.Size / 4);
+                    if (string.IsNullOrEmpty(hex)) hex = "0";
                     if (leadingZeroes)
-                        hex = hex.PadLeft(8, '0');
+                        hex = hex.PadLeft(varInfo.Size / 4, '0');
                     if (binHexSeparator != 0)
                         hex = InsertNumberSeparators(hex, binHexSeparator);
                     return "0x" + hex;

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -8,6 +8,7 @@ namespace VSRAD.Package.Utils
     {
         private static string InsertNumberSeparators(string str, uint sep)
         {
+            if (sep == 0) return str;
             var sb = new StringBuilder();
             // If leading zeroes option is turned off we want separators
             // to be between N characters starting from last one, not the
@@ -52,26 +53,34 @@ namespace VSRAD.Package.Utils
                     switch (varInfo.Size)
                     {
                         case 32:
-                            return intSeparator == 0 ? data.ToString() : InsertNumberSeparators(data.ToString(), intSeparator);
+                            return InsertNumberSeparators(data.ToString(), intSeparator);
                         case 16:
-                            var res16 = BitConverter.ToUInt16(uIntBytes, 0);
-                            return intSeparator == 0 ? res16.ToString() : InsertNumberSeparators(res16.ToString(), intSeparator);
+                            var res16_1 = InsertNumberSeparators(BitConverter.ToUInt16(uIntBytes, 2).ToString(), intSeparator);
+                            var res16_2 = InsertNumberSeparators(BitConverter.ToUInt16(uIntBytes, 0).ToString(), intSeparator);
+                            return $"{res16_1}; {res16_2}";
                         default: // 8
-                            var res8 = uIntBytes[3].ToString(); // little endian
-                            return intSeparator == 0 ? res8.ToString() : InsertNumberSeparators(res8.ToString(), intSeparator);
+                            var res8_1 = InsertNumberSeparators(uIntBytes[3].ToString(), intSeparator);
+                            var res8_2 = InsertNumberSeparators(uIntBytes[2].ToString(), intSeparator);
+                            var res8_3 = InsertNumberSeparators(uIntBytes[1].ToString(), intSeparator);
+                            var res8_4 = InsertNumberSeparators(uIntBytes[0].ToString(), intSeparator);
+                            return $"{res8_1}; {res8_2}; {res8_3}; {res8_4}";
                     }
                 case VariableType.Int:
                     var intBytes = BitConverter.GetBytes(data);
                     switch (varInfo.Size)
                     {
                         case 32:
-                            return intSeparator == 0 ? ((int)data).ToString() : InsertNumberSeparators(((int)data).ToString(), intSeparator);
+                            return InsertNumberSeparators(((int)data).ToString(), intSeparator);
                         case 16:
-                            var res16 = BitConverter.ToInt16(intBytes, 0);
-                            return intSeparator == 0 ? res16.ToString() : InsertNumberSeparators(res16.ToString(), intSeparator);
+                            var res16_1 = InsertNumberSeparators(BitConverter.ToInt16(intBytes, 2).ToString(), intSeparator);
+                            var res16_2 = InsertNumberSeparators(BitConverter.ToInt16(intBytes, 0).ToString(), intSeparator);
+                            return $"{res16_1}; {res16_2}";
                         default: // 8
-                            var res8 = ((sbyte)intBytes[3]).ToString(); // little endian
-                            return intSeparator == 0 ? res8.ToString() : InsertNumberSeparators(res8.ToString(), intSeparator);
+                            var res8_1 = InsertNumberSeparators(((sbyte)intBytes[3]).ToString(), intSeparator);
+                            var res8_2 = InsertNumberSeparators(((sbyte)intBytes[2]).ToString(), intSeparator);
+                            var res8_3 = InsertNumberSeparators(((sbyte)intBytes[1]).ToString(), intSeparator);
+                            var res8_4 = InsertNumberSeparators(((sbyte)intBytes[0]).ToString(), intSeparator);
+                            return $"{res8_1}; {res8_2}; {res8_3}; {res8_4}";
                     }
                 case VariableType.Half:
                     byte[] bytes = BitConverter.GetBytes(data);

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -39,7 +39,13 @@ namespace VSRAD.Package.Utils
                         hex = InsertNumberSeparators(hex, binHexSeparator);
                     return "0x" + hex;
                 case VariableType.Float:
-                    return BitConverter.ToSingle(BitConverter.GetBytes(data), 0).ToString();
+                    switch (varInfo.Size)
+                    {
+                        case 16:
+                            return Half.ToFloat(BitConverter.ToUInt16(BitConverter.GetBytes(data), 0)).ToString();
+                        default: // 32
+                            return BitConverter.ToSingle(BitConverter.GetBytes(data), 0).ToString();
+                    }
                 case VariableType.Uint:
                     return intSeparator == 0 ? data.ToString() : InsertNumberSeparators(data.ToString(), intSeparator);
                 case VariableType.Int:

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -44,7 +44,10 @@ namespace VSRAD.Package.Utils
                     switch (varInfo.Size)
                     {
                         case 16:
-                            return Half.ToFloat(BitConverter.ToUInt16(BitConverter.GetBytes(data), 0)).ToString();
+                            byte[] bytes = BitConverter.GetBytes(data);
+                            float firstHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 0));
+                            float secondHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 2));
+                            return $"{firstHalf}; {secondHalf}";
                         default: // 32
                             return BitConverter.ToSingle(BitConverter.GetBytes(data), 0).ToString();
                     }
@@ -82,11 +85,6 @@ namespace VSRAD.Package.Utils
                             var res8_4 = InsertNumberSeparators(((sbyte)intBytes[0]).ToString(), intSeparator);
                             return $"{res8_1}; {res8_2}; {res8_3}; {res8_4}";
                     }
-                case VariableType.Half:
-                    byte[] bytes = BitConverter.GetBytes(data);
-                    float firstHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 0));
-                    float secondHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 2));
-                    return $"{firstHalf}; {secondHalf}";
                 case VariableType.Bin:
                     var bin = Convert.ToString(data, 2).PadLeft(32, '0');
                     if (varInfo.Size != 32) bin = bin.Substring(32 - varInfo.Size, varInfo.Size);

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -29,9 +29,9 @@ namespace VSRAD.Package.Utils
 
         public static string FormatDword(VariableType varInfo, uint data, uint binHexSeparator, uint intSeparator, bool leadingZeroes)
         {
-            switch (varInfo.Repr)
+            switch (varInfo.Category)
             {
-                case VariableRepresentation.Hex:
+                case VariableCategory.Hex:
                     var hex = data.ToString("x");
                     if (varInfo.Size != 32) hex = hex.Substring(8 - (varInfo.Size / 4), varInfo.Size / 4); // TODO: doesnt work with short representations (0x0)
                     if (string.IsNullOrEmpty(hex)) hex = "0";
@@ -40,7 +40,7 @@ namespace VSRAD.Package.Utils
                     if (binHexSeparator != 0)
                         hex = InsertNumberSeparators(hex, binHexSeparator);
                     return "0x" + hex;
-                case VariableRepresentation.Float:
+                case VariableCategory.Float:
                     switch (varInfo.Size)
                     {
                         case 16:
@@ -51,7 +51,7 @@ namespace VSRAD.Package.Utils
                         default: // 32
                             return BitConverter.ToSingle(BitConverter.GetBytes(data), 0).ToString();
                     }
-                case VariableRepresentation.Uint:
+                case VariableCategory.Uint:
                     var uIntBytes = BitConverter.GetBytes(data);
                     switch (varInfo.Size)
                     {
@@ -68,7 +68,7 @@ namespace VSRAD.Package.Utils
                             var res8_4 = InsertNumberSeparators(uIntBytes[0].ToString(), intSeparator);
                             return $"{res8_1}; {res8_2}; {res8_3}; {res8_4}";
                     }
-                case VariableRepresentation.Int:
+                case VariableCategory.Int:
                     var intBytes = BitConverter.GetBytes(data);
                     switch (varInfo.Size)
                     {
@@ -85,7 +85,7 @@ namespace VSRAD.Package.Utils
                             var res8_4 = InsertNumberSeparators(((sbyte)intBytes[0]).ToString(), intSeparator);
                             return $"{res8_1}; {res8_2}; {res8_3}; {res8_4}";
                     }
-                case VariableRepresentation.Bin:
+                case VariableCategory.Bin:
                     var bin = Convert.ToString(data, 2).PadLeft(32, '0');
                     if (varInfo.Size != 32) bin = bin.Substring(32 - varInfo.Size, varInfo.Size);
                     if (string.IsNullOrEmpty(bin)) bin = "0";

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -47,7 +47,18 @@ namespace VSRAD.Package.Utils
                             return BitConverter.ToSingle(BitConverter.GetBytes(data), 0).ToString();
                     }
                 case VariableType.Uint:
-                    return intSeparator == 0 ? data.ToString() : InsertNumberSeparators(data.ToString(), intSeparator);
+                    var uIntBytes = BitConverter.GetBytes(data);
+                    switch (varInfo.Size)
+                    {
+                        case 32:
+                            return intSeparator == 0 ? data.ToString() : InsertNumberSeparators(data.ToString(), intSeparator);
+                        case 16:
+                            var res16 = BitConverter.ToUInt16(uIntBytes, 0);
+                            return intSeparator == 0 ? res16.ToString() : InsertNumberSeparators(res16.ToString(), intSeparator);
+                        default: // 8
+                            var res8 = uIntBytes[0].ToString();
+                            return intSeparator == 0 ? res8.ToString() : InsertNumberSeparators(res8.ToString(), intSeparator);
+                    }
                 case VariableType.Int:
                     return intSeparator == 0 ? ((int)data).ToString() : InsertNumberSeparators(((int)data).ToString(), intSeparator);
                 case VariableType.Half:

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -27,11 +27,11 @@ namespace VSRAD.Package.Utils
             return sb.ToString();
         }
 
-        public static string FormatDword(VariableInfo varInfo, uint data, uint binHexSeparator, uint intSeparator, bool leadingZeroes)
+        public static string FormatDword(VariableType varInfo, uint data, uint binHexSeparator, uint intSeparator, bool leadingZeroes)
         {
-            switch (varInfo.Type)
+            switch (varInfo.Repr)
             {
-                case VariableType.Hex:
+                case VariableRepresentation.Hex:
                     var hex = data.ToString("x");
                     if (varInfo.Size != 32) hex = hex.Substring(8 - (varInfo.Size / 4), varInfo.Size / 4); // TODO: doesnt work with short representations (0x0)
                     if (string.IsNullOrEmpty(hex)) hex = "0";
@@ -40,7 +40,7 @@ namespace VSRAD.Package.Utils
                     if (binHexSeparator != 0)
                         hex = InsertNumberSeparators(hex, binHexSeparator);
                     return "0x" + hex;
-                case VariableType.Float:
+                case VariableRepresentation.Float:
                     switch (varInfo.Size)
                     {
                         case 16:
@@ -51,7 +51,7 @@ namespace VSRAD.Package.Utils
                         default: // 32
                             return BitConverter.ToSingle(BitConverter.GetBytes(data), 0).ToString();
                     }
-                case VariableType.Uint:
+                case VariableRepresentation.Uint:
                     var uIntBytes = BitConverter.GetBytes(data);
                     switch (varInfo.Size)
                     {
@@ -68,7 +68,7 @@ namespace VSRAD.Package.Utils
                             var res8_4 = InsertNumberSeparators(uIntBytes[0].ToString(), intSeparator);
                             return $"{res8_1}; {res8_2}; {res8_3}; {res8_4}";
                     }
-                case VariableType.Int:
+                case VariableRepresentation.Int:
                     var intBytes = BitConverter.GetBytes(data);
                     switch (varInfo.Size)
                     {
@@ -85,7 +85,7 @@ namespace VSRAD.Package.Utils
                             var res8_4 = InsertNumberSeparators(((sbyte)intBytes[0]).ToString(), intSeparator);
                             return $"{res8_1}; {res8_2}; {res8_3}; {res8_4}";
                     }
-                case VariableType.Bin:
+                case VariableRepresentation.Bin:
                     var bin = Convert.ToString(data, 2).PadLeft(32, '0');
                     if (varInfo.Size != 32) bin = bin.Substring(32 - varInfo.Size, varInfo.Size);
                     if (string.IsNullOrEmpty(bin)) bin = "0";

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -26,9 +26,9 @@ namespace VSRAD.Package.Utils
             return sb.ToString();
         }
 
-        public static string FormatDword(VariableType variableType, uint data, uint binHexSeparator, uint intSeparator, bool leadingZeroes)
+        public static string FormatDword(VariableInfo varInfo, uint data, uint binHexSeparator, uint intSeparator, bool leadingZeroes)
         {
-            switch (variableType)
+            switch (varInfo.Type)
             {
                 case VariableType.Hex:
                     var hex = data.ToString("x");

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -79,8 +79,10 @@ namespace VSRAD.Package.Utils
                     return $"{firstHalf}; {secondHalf}";
                 case VariableType.Bin:
                     var bin = Convert.ToString(data, 2);
+                    if (varInfo.Size != 32) bin = bin.Substring(0, varInfo.Size);
+                    if (string.IsNullOrEmpty(bin)) bin = "0";
                     if (leadingZeroes)
-                        bin = bin.PadLeft(32, '0');
+                        bin = bin.PadLeft(varInfo.Size, '0');
                     if (binHexSeparator != 0)
                         bin = InsertNumberSeparators(bin, binHexSeparator);
                     return "0b" + bin;

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -48,8 +48,10 @@ namespace VSRAD.Package.Utils
                             float firstHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 0));
                             float secondHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 2));
                             return $"{firstHalf}; {secondHalf}";
-                        default: // 32
+                        case 32:
                             return BitConverter.ToSingle(BitConverter.GetBytes(data), 0).ToString();
+                        default:
+                            throw new NotImplementedException($"Unknown size: {varInfo.Size}");
                     }
                 case VariableCategory.Uint:
                     var uIntBytes = BitConverter.GetBytes(data);
@@ -61,12 +63,14 @@ namespace VSRAD.Package.Utils
                             var res16_1 = InsertNumberSeparators(BitConverter.ToUInt16(uIntBytes, 2).ToString(), intSeparator);
                             var res16_2 = InsertNumberSeparators(BitConverter.ToUInt16(uIntBytes, 0).ToString(), intSeparator);
                             return $"{res16_1}; {res16_2}";
-                        default: // 8
+                        case 8:
                             var res8_1 = InsertNumberSeparators(uIntBytes[3].ToString(), intSeparator);
                             var res8_2 = InsertNumberSeparators(uIntBytes[2].ToString(), intSeparator);
                             var res8_3 = InsertNumberSeparators(uIntBytes[1].ToString(), intSeparator);
                             var res8_4 = InsertNumberSeparators(uIntBytes[0].ToString(), intSeparator);
                             return $"{res8_1}; {res8_2}; {res8_3}; {res8_4}";
+                        default:
+                            throw new NotImplementedException($"Unknown size: {varInfo.Size}");
                     }
                 case VariableCategory.Int:
                     var intBytes = BitConverter.GetBytes(data);
@@ -78,12 +82,14 @@ namespace VSRAD.Package.Utils
                             var res16_1 = InsertNumberSeparators(BitConverter.ToInt16(intBytes, 2).ToString(), intSeparator);
                             var res16_2 = InsertNumberSeparators(BitConverter.ToInt16(intBytes, 0).ToString(), intSeparator);
                             return $"{res16_1}; {res16_2}";
-                        default: // 8
+                        case 8:
                             var res8_1 = InsertNumberSeparators(((sbyte)intBytes[3]).ToString(), intSeparator);
                             var res8_2 = InsertNumberSeparators(((sbyte)intBytes[2]).ToString(), intSeparator);
                             var res8_3 = InsertNumberSeparators(((sbyte)intBytes[1]).ToString(), intSeparator);
                             var res8_4 = InsertNumberSeparators(((sbyte)intBytes[0]).ToString(), intSeparator);
                             return $"{res8_1}; {res8_2}; {res8_3}; {res8_4}";
+                        default:
+                            throw new NotImplementedException($"Unknown size: {varInfo.Size}");
                     }
                 case VariableCategory.Bin:
                     var bin = Convert.ToString(data, 2).PadLeft(32, '0');

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -79,11 +79,11 @@ namespace VSRAD.Package.Utils
                     float secondHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 2));
                     return $"{firstHalf}; {secondHalf}";
                 case VariableType.Bin:
-                    var bin = Convert.ToString(data, 2);
+                    var bin = Convert.ToString(data, 2).PadLeft(32, '0');
                     if (varInfo.Size != 32) bin = bin.Substring(32 - varInfo.Size, varInfo.Size);
                     if (string.IsNullOrEmpty(bin)) bin = "0";
-                    if (leadingZeroes)
-                        bin = bin.PadLeft(varInfo.Size, '0');
+                    if (!leadingZeroes)
+                        bin = bin.TrimStart('0');
                     if (binHexSeparator != 0)
                         bin = InsertNumberSeparators(bin, binHexSeparator);
                     return "0b" + bin;

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -56,11 +56,22 @@ namespace VSRAD.Package.Utils
                             var res16 = BitConverter.ToUInt16(uIntBytes, 0);
                             return intSeparator == 0 ? res16.ToString() : InsertNumberSeparators(res16.ToString(), intSeparator);
                         default: // 8
-                            var res8 = uIntBytes[0].ToString();
+                            var res8 = uIntBytes[3].ToString(); // little endian
                             return intSeparator == 0 ? res8.ToString() : InsertNumberSeparators(res8.ToString(), intSeparator);
                     }
                 case VariableType.Int:
-                    return intSeparator == 0 ? ((int)data).ToString() : InsertNumberSeparators(((int)data).ToString(), intSeparator);
+                    var intBytes = BitConverter.GetBytes(data);
+                    switch (varInfo.Size)
+                    {
+                        case 32:
+                            return intSeparator == 0 ? ((int)data).ToString() : InsertNumberSeparators(((int)data).ToString(), intSeparator);
+                        case 16:
+                            var res16 = BitConverter.ToInt16(intBytes, 0);
+                            return intSeparator == 0 ? res16.ToString() : InsertNumberSeparators(res16.ToString(), intSeparator);
+                        default: // 8
+                            var res8 = ((sbyte)intBytes[3]).ToString(); // little endian
+                            return intSeparator == 0 ? res8.ToString() : InsertNumberSeparators(res8.ToString(), intSeparator);
+                    }
                 case VariableType.Half:
                     byte[] bytes = BitConverter.GetBytes(data);
                     float firstHalf = Half.ToFloat(BitConverter.ToUInt16(bytes, 0));

--- a/VSRAD.Package/Utils/DataFormatter.cs
+++ b/VSRAD.Package/Utils/DataFormatter.cs
@@ -31,7 +31,8 @@ namespace VSRAD.Package.Utils
             switch (varInfo.Type)
             {
                 case VariableType.Hex:
-                    var hex = data.ToString("x").Substring(0, varInfo.Size / 4);
+                    var hex = data.ToString("x");
+                    if (varInfo.Size != 32) hex = hex.Substring(8 - (varInfo.Size / 4), varInfo.Size / 4);
                     if (string.IsNullOrEmpty(hex)) hex = "0";
                     if (leadingZeroes)
                         hex = hex.PadLeft(varInfo.Size / 4, '0');
@@ -79,7 +80,7 @@ namespace VSRAD.Package.Utils
                     return $"{firstHalf}; {secondHalf}";
                 case VariableType.Bin:
                     var bin = Convert.ToString(data, 2);
-                    if (varInfo.Size != 32) bin = bin.Substring(0, varInfo.Size);
+                    if (varInfo.Size != 32) bin = bin.Substring(32 - varInfo.Size, varInfo.Size);
                     if (string.IsNullOrEmpty(bin)) bin = "0";
                     if (leadingZeroes)
                         bin = bin.PadLeft(varInfo.Size, '0');

--- a/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace VSRAD.PackageTests.DebugVisualizer
+{
+    public class DataFormattingTests
+    {
+        private static uint[] _data = new uint[]
+        {
+            0x_dead_beef,
+            0x_c0ffee_00,
+            0x_00_0ff1ce,
+            0x_c001_f00d,
+            0x_abba_abba,
+            0x_0600d_bed,
+            0x_added_bee,
+            0x_caba66e_0,
+            0x_dead_7ace,
+            0x_000_ba6e1
+        };
+
+        [Fact]
+        public void FormatDwordTests()
+        {
+
+        }
+    }
+}

--- a/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
@@ -94,20 +94,20 @@ namespace VSRAD.PackageTests.DebugVisualizer
         public static IEnumerable<object[]> ProvideTestData =>
             new List<object[]>
             {
-                new object[] { new VariableInfo(VariableType.Hex, 32),  0, true,  Hex32LZs     },
-                new object[] { new VariableInfo(VariableType.Hex, 32),  3, true,  Hex32LZsSep3 },
-                new object[] { new VariableInfo(VariableType.Hex, 32),  0, false, Hex32        },
-                new object[] { new VariableInfo(VariableType.Uint, 32), 0, false, UInt32       },
-                new object[] { new VariableInfo(VariableType.Uint, 16), 0, false, UInt16       },
-                new object[] { new VariableInfo(VariableType.Uint, 8),  0, false, UInt8        },
-                new object[] { new VariableInfo(VariableType.Int, 32),  0, false, Int32        },
-                new object[] { new VariableInfo(VariableType.Int, 16),  0, false, Int16        },
-                new object[] { new VariableInfo(VariableType.Int, 8),   0, false, Int8         },
-                new object[] { new VariableInfo(VariableType.Int, 16),  3, false, Int16Sep3    },
+                new object[] { new VariableType(VariableRepresentation.Hex, 32),  0, true,  Hex32LZs     },
+                new object[] { new VariableType(VariableRepresentation.Hex, 32),  3, true,  Hex32LZsSep3 },
+                new object[] { new VariableType(VariableRepresentation.Hex, 32),  0, false, Hex32        },
+                new object[] { new VariableType(VariableRepresentation.Uint, 32), 0, false, UInt32       },
+                new object[] { new VariableType(VariableRepresentation.Uint, 16), 0, false, UInt16       },
+                new object[] { new VariableType(VariableRepresentation.Uint, 8),  0, false, UInt8        },
+                new object[] { new VariableType(VariableRepresentation.Int, 32),  0, false, Int32        },
+                new object[] { new VariableType(VariableRepresentation.Int, 16),  0, false, Int16        },
+                new object[] { new VariableType(VariableRepresentation.Int, 8),   0, false, Int8         },
+                new object[] { new VariableType(VariableRepresentation.Int, 16),  3, false, Int16Sep3    },
             };
 
         [Theory, MemberData(nameof(ProvideTestData))]
-        public void FormatDwordTests(VariableInfo info, uint separator,
+        public void FormatDwordTests(VariableType info, uint separator,
             bool leadingZeros, string[] expected) =>
                 Assert.Equal(_data.Select(d => DataFormatter.FormatDword(info, d, separator,
                     separator, leadingZeros)), expected);

--- a/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
@@ -94,16 +94,16 @@ namespace VSRAD.PackageTests.DebugVisualizer
         public static IEnumerable<object[]> ProvideTestData =>
             new List<object[]>
             {
-                new object[] { new VariableType(VariableRepresentation.Hex, 32),  0, true,  Hex32LZs     },
-                new object[] { new VariableType(VariableRepresentation.Hex, 32),  3, true,  Hex32LZsSep3 },
-                new object[] { new VariableType(VariableRepresentation.Hex, 32),  0, false, Hex32        },
-                new object[] { new VariableType(VariableRepresentation.Uint, 32), 0, false, UInt32       },
-                new object[] { new VariableType(VariableRepresentation.Uint, 16), 0, false, UInt16       },
-                new object[] { new VariableType(VariableRepresentation.Uint, 8),  0, false, UInt8        },
-                new object[] { new VariableType(VariableRepresentation.Int, 32),  0, false, Int32        },
-                new object[] { new VariableType(VariableRepresentation.Int, 16),  0, false, Int16        },
-                new object[] { new VariableType(VariableRepresentation.Int, 8),   0, false, Int8         },
-                new object[] { new VariableType(VariableRepresentation.Int, 16),  3, false, Int16Sep3    },
+                new object[] { new VariableType(VariableCategory.Hex, 32),  0, true,  Hex32LZs     },
+                new object[] { new VariableType(VariableCategory.Hex, 32),  3, true,  Hex32LZsSep3 },
+                new object[] { new VariableType(VariableCategory.Hex, 32),  0, false, Hex32        },
+                new object[] { new VariableType(VariableCategory.Uint, 32), 0, false, UInt32       },
+                new object[] { new VariableType(VariableCategory.Uint, 16), 0, false, UInt16       },
+                new object[] { new VariableType(VariableCategory.Uint, 8),  0, false, UInt8        },
+                new object[] { new VariableType(VariableCategory.Int, 32),  0, false, Int32        },
+                new object[] { new VariableType(VariableCategory.Int, 16),  0, false, Int16        },
+                new object[] { new VariableType(VariableCategory.Int, 8),   0, false, Int8         },
+                new object[] { new VariableType(VariableCategory.Int, 16),  3, false, Int16Sep3    },
             };
 
         [Theory, MemberData(nameof(ProvideTestData))]

--- a/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
@@ -94,22 +94,22 @@ namespace VSRAD.PackageTests.DebugVisualizer
         public static IEnumerable<object[]> ProvideTestData =>
             new List<object[]>
             {
-                new object[] { new VariableInfo(VariableType.Hex, 32),  0, 0, true,  Hex32LZs     },
-                new object[] { new VariableInfo(VariableType.Hex, 32),  3, 0, true,  Hex32LZsSep3 },
-                new object[] { new VariableInfo(VariableType.Hex, 32),  0, 0, false, Hex32        },
-                new object[] { new VariableInfo(VariableType.Uint, 32), 0, 0, false, UInt32       },
-                new object[] { new VariableInfo(VariableType.Uint, 16), 0, 0, false, UInt16       },
-                new object[] { new VariableInfo(VariableType.Uint, 8),  0, 0, false, UInt8        },
-                new object[] { new VariableInfo(VariableType.Int, 32),  0, 0, false, Int32        },
-                new object[] { new VariableInfo(VariableType.Int, 16),  0, 0, false, Int16        },
-                new object[] { new VariableInfo(VariableType.Int, 8),   0, 0, false, Int8         },
-                new object[] { new VariableInfo(VariableType.Int, 16),  0, 3, false, Int16Sep3    },
+                new object[] { new VariableInfo(VariableType.Hex, 32),  0, true,  Hex32LZs     },
+                new object[] { new VariableInfo(VariableType.Hex, 32),  3, true,  Hex32LZsSep3 },
+                new object[] { new VariableInfo(VariableType.Hex, 32),  0, false, Hex32        },
+                new object[] { new VariableInfo(VariableType.Uint, 32), 0, false, UInt32       },
+                new object[] { new VariableInfo(VariableType.Uint, 16), 0, false, UInt16       },
+                new object[] { new VariableInfo(VariableType.Uint, 8),  0, false, UInt8        },
+                new object[] { new VariableInfo(VariableType.Int, 32),  0, false, Int32        },
+                new object[] { new VariableInfo(VariableType.Int, 16),  0, false, Int16        },
+                new object[] { new VariableInfo(VariableType.Int, 8),   0, false, Int8         },
+                new object[] { new VariableInfo(VariableType.Int, 16),  3, false, Int16Sep3    },
             };
 
         [Theory, MemberData(nameof(ProvideTestData))]
-        public void FormatDwordTests(VariableInfo info, uint binHexSeparator, uint intSeparator,
+        public void FormatDwordTests(VariableInfo info, uint separator,
             bool leadingZeros, string[] expected) =>
-                Assert.Equal(_data.Select(d => DataFormatter.FormatDword(info, d, binHexSeparator,
-                    intSeparator, leadingZeros)), expected);
+                Assert.Equal(_data.Select(d => DataFormatter.FormatDword(info, d, separator,
+                    separator, leadingZeros)), expected);
     }
 }

--- a/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
@@ -26,20 +26,64 @@ namespace VSRAD.PackageTests.DebugVisualizer
             0x_000_ba6e1
         };
 
-        static readonly string[] ExpectedHex32 = new string[]
+        static readonly string[] Hex32LZs = new string[]
         {
             "0xdeadbeef", "0xc0ffee00", "0x000ff1ce", "0xc001f00d", "0xabbaabba",
             "0x0600dbed", "0xaddedbee", "0xcaba66e0", "0xdead7ace", "0x000ba6e1"
         };
 
+        static readonly string[] Hex32LZsSep3 = new string[]
+        {
+            "0xde adb eef", "0xc0 ffe e00", "0x00 0ff 1ce", "0xc0 01f 00d", "0xab baa bba",
+            "0x06 00d bed", "0xad ded bee", "0xca ba6 6e0", "0xde ad7 ace", "0x00 0ba 6e1"
+        };
+
+        static readonly string[] Hex32 = new string[]
+        {
+            "0xdeadbeef", "0xc0ffee00", "0xff1ce",    "0xc001f00d", "0xabbaabba",
+            "0x600dbed",  "0xaddedbee", "0xcaba66e0", "0xdead7ace", "0xba6e1"
+        };
+
+        /* TODO:
+         * would be nice to test all possible formats using the above approach
+         * in the scope of #346 i'll focus on newly added packed integer types
+         */
+
+        static readonly string[] UInt32 = new string[]
+        {
+            "3735928559", "3237998080", "1044942",    "3221352461", "2881137594",
+            "100719597",  "2917063662", "3401213664", "3735911118", "763617"
+        };
+
+        static readonly string[] UInt16 = new string[]
+        {
+            "57005; 48879", "49407; 60928", "15; 61902", "49153; 61453", "43962; 43962",
+            "1536; 56301", "44510; 56302", "51898; 26336", "57005; 31438", "11; 42721"
+        };
+
+        static readonly string[] UInt8 = new string[]
+        {
+            "222; 173; 190; 239", "192; 255; 238; 0", "0; 15; 241; 206",
+            "192; 1; 240; 13", "171; 186; 171; 186", "6; 0; 219; 237",
+            "173; 222; 219; 238", "202; 186; 102; 224", "222; 173; 122; 206",
+            "0; 11; 166; 225"
+        };
+
         public static IEnumerable<object[]> ProvideTestData =>
             new List<object[]>
             {
-                new object[] { new VariableInfo(VariableType.Hex, 32), ExpectedHex32 },
+                new object[] { new VariableInfo(VariableType.Hex, 32),  0, 0, true,  Hex32LZs     },
+                new object[] { new VariableInfo(VariableType.Hex, 32),  3, 0, true,  Hex32LZsSep3 },
+                new object[] { new VariableInfo(VariableType.Hex, 32),  0, 0, false, Hex32        },
+                new object[] { new VariableInfo(VariableType.Uint, 32), 0, 0, false, UInt32       },
+                new object[] { new VariableInfo(VariableType.Uint, 16), 0, 0, false, UInt16       },
+                new object[] { new VariableInfo(VariableType.Uint, 8),  0, 0, false, UInt8        },
             };
 
         [Theory, MemberData(nameof(ProvideTestData))]
-        public void FormatDwordTests(VariableInfo info, string[] expected) =>
-            Assert.Equal(_data.Select(d => DataFormatter.FormatDword(info, d, 0, 0, true)), expected);
+        public void FormatDwordTests(VariableInfo info, uint binHexSeparator, uint intSeparator,
+            bool leadingZeros, string[] expected) =>
+                Assert.Equal(_data.Select(d => DataFormatter.FormatDword(info, d, binHexSeparator,
+                    intSeparator, leadingZeros)), expected);
     }
 }

--- a/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
@@ -69,6 +69,26 @@ namespace VSRAD.PackageTests.DebugVisualizer
             "0; 11; 166; 225"
         };
 
+        static readonly string[] Int32 = new string[]
+        {
+            "-559038737", "-1056969216", "1044942", "-1073614835", "-1413829702",
+            "100719597", "-1377903634", "-893753632", "-559056178", "763617"
+        };
+
+        static readonly string[] Int16 = new string[]
+        {
+            "-8531; -16657", "-16129; -4608", "15; -3634", "-16383; -4083", "-21574; -21574",
+            "1536; -9235", "-21026; -9234", "-13638; 26336", "-8531; 31438", "11; -22815"
+        };
+
+        static readonly string[] Int8 = new string[]
+        {
+            "-34; -83; -66; -17", "-64; -1; -18; 0", "0; 15; -15; -50",
+            "-64; 1; -16; 13", "-85; -70; -85; -70", "6; 0; -37; -19",
+            "-83; -34; -37; -18", "-54; -70; 102; -32", "-34; -83; 122; -50",
+            "0; 11; -90; -31"
+        };
+
         public static IEnumerable<object[]> ProvideTestData =>
             new List<object[]>
             {
@@ -78,6 +98,9 @@ namespace VSRAD.PackageTests.DebugVisualizer
                 new object[] { new VariableInfo(VariableType.Uint, 32), 0, 0, false, UInt32       },
                 new object[] { new VariableInfo(VariableType.Uint, 16), 0, 0, false, UInt16       },
                 new object[] { new VariableInfo(VariableType.Uint, 8),  0, 0, false, UInt8        },
+                new object[] { new VariableInfo(VariableType.Int, 32),  0, 0, false, Int32        },
+                new object[] { new VariableInfo(VariableType.Int, 16),  0, 0, false, Int16        },
+                new object[] { new VariableInfo(VariableType.Int, 8),   0, 0, false, Int8         },
             };
 
         [Theory, MemberData(nameof(ProvideTestData))]

--- a/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
@@ -3,7 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using VSRAD.Package.DebugVisualizer;
+using VSRAD.Package.Utils;
 using Xunit;
+using Xunit.Extensions;
 
 namespace VSRAD.PackageTests.DebugVisualizer
 {
@@ -23,10 +26,20 @@ namespace VSRAD.PackageTests.DebugVisualizer
             0x_000_ba6e1
         };
 
-        [Fact]
-        public void FormatDwordTests()
+        static readonly string[] ExpectedHex32 = new string[]
         {
+            "0xdeadbeef", "0xc0ffee00", "0x000ff1ce", "0xc001f00d", "0xabbaabba",
+            "0x0600dbed", "0xaddedbee", "0xcaba66e0", "0xdead7ace", "0x000ba6e1"
+        };
 
-        }
+        public static IEnumerable<object[]> ProvideTestData =>
+            new List<object[]>
+            {
+                new object[] { new VariableInfo(VariableType.Hex, 32), ExpectedHex32 },
+            };
+
+        [Theory, MemberData(nameof(ProvideTestData))]
+        public void FormatDwordTests(VariableInfo info, string[] expected) =>
+            Assert.Equal(_data.Select(d => DataFormatter.FormatDword(info, d, 0, 0, true)), expected);
     }
 }

--- a/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/DataFormattingTests.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using VSRAD.Package.DebugVisualizer;
 using VSRAD.Package.Utils;
 using Xunit;
-using Xunit.Extensions;
 
 namespace VSRAD.PackageTests.DebugVisualizer
 {
@@ -89,6 +85,12 @@ namespace VSRAD.PackageTests.DebugVisualizer
             "0; 11; -90; -31"
         };
 
+        static readonly string[] Int16Sep3 = new string[]
+        {
+            "-8 531; -16 657", "-16 129; -4 608", "15; -3 634", "-16 383; -4 083", "-21 574; -21 574",
+            "1 536; -9 235", "-21 026; -9 234", "-13 638; 26 336", "-8 531; 31 438", "11; -22 815"
+        };
+
         public static IEnumerable<object[]> ProvideTestData =>
             new List<object[]>
             {
@@ -101,6 +103,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
                 new object[] { new VariableInfo(VariableType.Int, 32),  0, 0, false, Int32        },
                 new object[] { new VariableInfo(VariableType.Int, 16),  0, 0, false, Int16        },
                 new object[] { new VariableInfo(VariableType.Int, 8),   0, 0, false, Int8         },
+                new object[] { new VariableInfo(VariableType.Int, 16),  0, 3, false, Int16Sep3    },
             };
 
         [Theory, MemberData(nameof(ProvideTestData))]

--- a/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
@@ -40,9 +40,9 @@ namespace VSRAD.PackageTests.ProjectSystem
             project.Options.Profile.General.LocalWorkDir = "local/dir";
             project.Options.Profile.General.RemoteWorkDir = "/periphery/votw";
             project.Options.Profile.Actions.Add(new ActionProfileOptions { Name = "Debug" });
-            project.Options.DebuggerOptions.Watches.Add(new Watch("a", new VariableType(VariableRepresentation.Hex, 32), false));
-            project.Options.DebuggerOptions.Watches.Add(new Watch("c", new VariableType(VariableRepresentation.Hex, 32), false));
-            project.Options.DebuggerOptions.Watches.Add(new Watch("tide", new VariableType(VariableRepresentation.Hex, 32), false));
+            project.Options.DebuggerOptions.Watches.Add(new Watch("a", new VariableType(VariableCategory.Hex, 32), false));
+            project.Options.DebuggerOptions.Watches.Add(new Watch("c", new VariableType(VariableCategory.Hex, 32), false));
+            project.Options.DebuggerOptions.Watches.Add(new Watch("tide", new VariableType(VariableCategory.Hex, 32), false));
 
             var readDebugDataStep = new ReadDebugDataStep { BinaryOutput = false, OutputOffset = 1 };
             readDebugDataStep.OutputFile.CheckTimestamp = true;

--- a/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
@@ -40,9 +40,9 @@ namespace VSRAD.PackageTests.ProjectSystem
             project.Options.Profile.General.LocalWorkDir = "local/dir";
             project.Options.Profile.General.RemoteWorkDir = "/periphery/votw";
             project.Options.Profile.Actions.Add(new ActionProfileOptions { Name = "Debug" });
-            project.Options.DebuggerOptions.Watches.Add(new Watch("a", VariableType.Hex, false));
-            project.Options.DebuggerOptions.Watches.Add(new Watch("c", VariableType.Hex, false));
-            project.Options.DebuggerOptions.Watches.Add(new Watch("tide", VariableType.Hex, false));
+            project.Options.DebuggerOptions.Watches.Add(new Watch("a", new VariableInfo(VariableType.Hex, 32), false));
+            project.Options.DebuggerOptions.Watches.Add(new Watch("c", new VariableInfo(VariableType.Hex, 32), false));
+            project.Options.DebuggerOptions.Watches.Add(new Watch("tide", new VariableInfo(VariableType.Hex, 32), false));
 
             var readDebugDataStep = new ReadDebugDataStep { BinaryOutput = false, OutputOffset = 1 };
             readDebugDataStep.OutputFile.CheckTimestamp = true;

--- a/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
@@ -40,9 +40,9 @@ namespace VSRAD.PackageTests.ProjectSystem
             project.Options.Profile.General.LocalWorkDir = "local/dir";
             project.Options.Profile.General.RemoteWorkDir = "/periphery/votw";
             project.Options.Profile.Actions.Add(new ActionProfileOptions { Name = "Debug" });
-            project.Options.DebuggerOptions.Watches.Add(new Watch("a", new VariableInfo(VariableType.Hex, 32), false));
-            project.Options.DebuggerOptions.Watches.Add(new Watch("c", new VariableInfo(VariableType.Hex, 32), false));
-            project.Options.DebuggerOptions.Watches.Add(new Watch("tide", new VariableInfo(VariableType.Hex, 32), false));
+            project.Options.DebuggerOptions.Watches.Add(new Watch("a", new VariableType(VariableRepresentation.Hex, 32), false));
+            project.Options.DebuggerOptions.Watches.Add(new Watch("c", new VariableType(VariableRepresentation.Hex, 32), false));
+            project.Options.DebuggerOptions.Watches.Add(new Watch("tide", new VariableType(VariableRepresentation.Hex, 32), false));
 
             var readDebugDataStep = new ReadDebugDataStep { BinaryOutput = false, OutputOffset = 1 };
             readDebugDataStep.OutputFile.CheckTimestamp = true;

--- a/VSRAD.PackageTests/ProjectSystem/Profiles/ObsoleteFormatProfileImportTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Profiles/ObsoleteFormatProfileImportTests.cs
@@ -26,9 +26,9 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             var imported = ProjectOptions.Read(_userOptionsPath, _profOptionsPath, _obsoleteConfPath);
 
             Assert.Collection(imported.DebuggerOptions.Watches,
-                w1 => Assert.Equal(new Watch("v0", new VariableType(VariableRepresentation.Hex, 32), false), w1),
-                w2 => Assert.Equal(new Watch(" ", new VariableType(VariableRepresentation.Uint, 32), false), w2),
-                w3 => Assert.Equal(new Watch("v2", new VariableType(VariableRepresentation.Float, 32), false), w3));
+                w1 => Assert.Equal(new Watch("v0", new VariableType(VariableCategory.Hex, 32), false), w1),
+                w2 => Assert.Equal(new Watch(" ", new VariableType(VariableCategory.Uint, 32), false), w2),
+                w3 => Assert.Equal(new Watch("v2", new VariableType(VariableCategory.Float, 32), false), w3));
 
             Assert.Equal(42u, imported.DebuggerOptions.Counter);
             Assert.Equal((uint)0x313313, imported.VisualizerOptions.MagicNumber);

--- a/VSRAD.PackageTests/ProjectSystem/Profiles/ObsoleteFormatProfileImportTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Profiles/ObsoleteFormatProfileImportTests.cs
@@ -26,9 +26,9 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             var imported = ProjectOptions.Read(_userOptionsPath, _profOptionsPath, _obsoleteConfPath);
 
             Assert.Collection(imported.DebuggerOptions.Watches,
-                w1 => Assert.Equal(new Watch("v0", VariableType.Hex, false), w1),
-                w2 => Assert.Equal(new Watch(" ", VariableType.Uint, false), w2),
-                w3 => Assert.Equal(new Watch("v2", VariableType.Float, false), w3));
+                w1 => Assert.Equal(new Watch("v0", new VariableInfo(VariableType.Hex, 32), false), w1),
+                w2 => Assert.Equal(new Watch(" ", new VariableInfo(VariableType.Uint, 32), false), w2),
+                w3 => Assert.Equal(new Watch("v2", new VariableInfo(VariableType.Float, 32), false), w3));
 
             Assert.Equal(42u, imported.DebuggerOptions.Counter);
             Assert.Equal((uint)0x313313, imported.VisualizerOptions.MagicNumber);

--- a/VSRAD.PackageTests/ProjectSystem/Profiles/ObsoleteFormatProfileImportTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Profiles/ObsoleteFormatProfileImportTests.cs
@@ -26,9 +26,9 @@ namespace VSRAD.PackageTests.ProjectSystem.Profiles
             var imported = ProjectOptions.Read(_userOptionsPath, _profOptionsPath, _obsoleteConfPath);
 
             Assert.Collection(imported.DebuggerOptions.Watches,
-                w1 => Assert.Equal(new Watch("v0", new VariableInfo(VariableType.Hex, 32), false), w1),
-                w2 => Assert.Equal(new Watch(" ", new VariableInfo(VariableType.Uint, 32), false), w2),
-                w3 => Assert.Equal(new Watch("v2", new VariableInfo(VariableType.Float, 32), false), w3));
+                w1 => Assert.Equal(new Watch("v0", new VariableType(VariableRepresentation.Hex, 32), false), w1),
+                w2 => Assert.Equal(new Watch(" ", new VariableType(VariableRepresentation.Uint, 32), false), w2),
+                w3 => Assert.Equal(new Watch("v2", new VariableType(VariableRepresentation.Float, 32), false), w3));
 
             Assert.Equal(42u, imported.DebuggerOptions.Counter);
             Assert.Equal((uint)0x313313, imported.VisualizerOptions.MagicNumber);

--- a/VSRAD.PackageTests/VSRAD.PackageTests.csproj
+++ b/VSRAD.PackageTests/VSRAD.PackageTests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="BuildTools\Errors\ParserTests.cs" />
     <Compile Include="DebugVisualizer\ColumnSelectorTests.cs" />
     <Compile Include="DebugVisualizer\ColumnStylingTests.cs" />
+    <Compile Include="DebugVisualizer\DataFormattingTests.cs" />
     <Compile Include="DebugVisualizer\GroupIndexSelectorTests.cs" />
     <Compile Include="DebugVisualizer\ComputedColumnStylingTests.cs" />
     <Compile Include="DebugVisualizer\WavemapTests.cs" />


### PR DESCRIPTION
This PR adds new Int/UInt packed representations for Debug visualizer. One 32-bit value, two 16-bit values or four 8 bit values are supported.

![image](https://user-images.githubusercontent.com/39794543/217613693-f2091d75-3ce3-478d-9c89-6036644b81e9.png)

Notes:

* this PR strongly relies on https://github.com/vsrad/radeon-asm-tools/pull/289 with some extra functionality commented out, but not removed in case we would want to bring packed representations for types other than Int/UInt
* large chunks of code that deal with computing the relative values for Slice Visualizers heatmap view were commented out either, since it need to be refactored to work with packed representation and we do not have Slice Visualizer in current upstream and the details of it's realization are still under development
