### PR TITLE
Name Column Handling Improvements

### DIFF
--- a/VSRAD.Package/DebugVisualizer/TableState.cs
+++ b/VSRAD.Package/DebugVisualizer/TableState.cs
@@ -16,6 +16,7 @@ namespace VSRAD.Package.DebugVisualizer
         public ScalingMode ScalingMode { get; set; } = ScalingMode.ResizeColumn;
         public bool NameColumnScalingEnabled { get; set; }
         public int NameColumnIndex { get; }
+        public bool AutoscaleName { get; set; }
 
         private readonly List<DataGridViewColumn> _dataColumns = new List<DataGridViewColumn>();
 
@@ -196,6 +197,10 @@ namespace VSRAD.Package.DebugVisualizer
 
             var n = CountVisibleDataColumns(clickedColumnIndex, false);
             var newScrollOffset = Math.Max(0, (n - 1) * (preferredWidth - ColumnWidth) + GetCurrentScroll());
+
+            if (AutoscaleName)
+                Table.Columns[NameColumnIndex].Width
+                    = Table.Columns[NameColumnIndex].GetPreferredWidth(DataGridViewAutoSizeColumnMode.AllCells, true);
 
             SetWidthAndScroll(preferredWidth, newScrollOffset);
         }

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -117,6 +117,7 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                     _context.Options.VisualizerAppearance.DataColumnAlignment,
                     _context.Options.VisualizerAppearance.HeadersAlignment
                 );
+            _table.SetAutoscaleName(_context.Options.VisualizerAppearance.AutoscaleNameColumn);
             foreach (var watch in _context.Options.DebuggerOptions.Watches)
                 _table.AppendVariableRow(watch);
             _table.PrepareNewWatchRow();
@@ -144,6 +145,9 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                 case nameof(Options.VisualizerAppearance.HiddenColumnSeparatorWidth):
                 case nameof(Options.VisualizerAppearance.DarkenAlternatingRowsBy):
                     RefreshDataStyling();
+                    break;
+                case nameof(Options.VisualizerAppearance.AutoscaleNameColumn):
+                    _table.SetAutoscaleName(_context.Options.VisualizerAppearance.AutoscaleNameColumn);
                     break;
                 case nameof(Options.DebuggerOptions.WaveSize):
                     RefreshDataStyling();

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -102,6 +102,8 @@ namespace VSRAD.Package.DebugVisualizer
             _selectionController = new SelectionController(this);
         }
 
+        public void SetAutoscaleName(bool value) => _state.AutoscaleName = value;
+
         public void AddWatch(string watchName)
         {
             RemoveNewWatchRow();

--- a/VSRAD.Package/Options/VisualizerAppearance.cs
+++ b/VSRAD.Package/Options/VisualizerAppearance.cs
@@ -66,6 +66,13 @@ namespace VSRAD.Package.Options
             set => SetField(ref _scalingMode, value);
         }
 
+        private bool _autoscaleNameColumn = false;
+        public bool AutoscaleNameColumn
+        {
+            get => _autoscaleNameColumn;
+            set => SetField(ref _autoscaleNameColumn, value);
+        }
+
         private int _darkenAlternatingRowsBy = 0;
         public int DarkenAlternatingRowsBy { get => _darkenAlternatingRowsBy; set => SetField(ref _darkenAlternatingRowsBy, value); }
     }

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -184,6 +184,10 @@
                                             Value="{Binding Options.VisualizerOptions.WavemapElementSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                             <TextBlock Text="px" VerticalAlignment="Center" Margin="5,0,0,0"/>
                         </StackPanel>
+                        <StackPanel Orientation="Horizontal" Height="25">
+                            <CheckBox Content="Autofit Name Column Width" VerticalAlignment="Center"
+                                      IsChecked="{Binding Options.VisualizerAppearance.AutoscaleNameColumn, UpdateSourceTrigger=PropertyChanged}"/>
+                        </StackPanel>
                     </StackPanel>
                 </Expander>
             </StackPanel>


### PR DESCRIPTION
This PR:

* adds new option `Autofit Name Column Width` to the `Visualizer Appearance` tab that enables autofitting name column with when using `Fit Width` feature;
* fixes behavior of the scrollbar when table area is to narrow to fit `Name` column. Before this changes table would be locked for scrolling, now scrollbar remains but Name column unfreezes.

Both features shown in the gif:

![name_impr](https://user-images.githubusercontent.com/39794543/220179871-ea307175-9761-4036-b81f-c0e4a516e670.gif)
