### PR TITLE
Add a description for token with multiple definitions

### DIFF
--- a/VSRAD.Syntax/IntelliSense/Completion/Providers/CompletionItem.cs
+++ b/VSRAD.Syntax/IntelliSense/Completion/Providers/CompletionItem.cs
@@ -33,7 +33,7 @@ namespace VSRAD.Syntax.IntelliSense.Completion.Providers
         }
 
         public Task<object> GetDescriptionAsync(IIntellisenseDescriptionBuilder descriptionBuilder, CancellationToken cancellationToken) =>
-            descriptionBuilder.GetColorizedDescriptionAsync(_token, cancellationToken);
+            descriptionBuilder.GetColorizedDescriptionAsync(new[] { _token }, cancellationToken);
     }
 
     internal class MultipleCompletionItem : ICompletionItem


### PR DESCRIPTION
This PR adds a description (text specified in the comment next to the token) for the token with multiple definitions such as instructions. Users don't need to click on instructions in a quick-info tooltip anymore to get a description of the instruction.

Example:
![image](https://user-images.githubusercontent.com/40007198/220798193-0c041c7a-996f-4126-8fec-faf4aecd4b3b.png)


How it worked before:
![image](https://user-images.githubusercontent.com/40007198/220798941-1b8ccc2b-a7ee-4408-a89f-49bc771954b3.png)
