### PR TITLE
Breakpoint tracking fixes

### DIFF
--- a/VSRAD.Deborgar/IEngineIntegration.cs
+++ b/VSRAD.Deborgar/IEngineIntegration.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft;
+using System;
 
 namespace VSRAD.Deborgar
 {
@@ -7,12 +8,16 @@ namespace VSRAD.Deborgar
         public string File { get; }
         public uint[] Lines { get; }
         public bool IsStepping { get; }
+        public bool IsSuccessful { get; }
 
-        public ExecutionCompletedEventArgs(string file, uint[] lines, bool isStepping)
+        public ExecutionCompletedEventArgs(string file, uint[] lines, bool isStepping, bool isSuccessful)
         {
+            Assumes.True(lines != null && lines.Length != 0, "At least one break line must be provided for the VS debugger.");
+
             File = file;
             Lines = lines;
             IsStepping = isStepping;
+            IsSuccessful = isSuccessful;
         }
     }
 

--- a/VSRAD.DeborgarTests/ProgramTests.cs
+++ b/VSRAD.DeborgarTests/ProgramTests.cs
@@ -22,7 +22,7 @@ namespace VSRAD.DeborgarTests
 
             integration.Setup((i) => i.Execute(false)).Callback(() =>
                 integration.Raise((i) => i.ExecutionCompleted += null, null,
-                new ExecutionCompletedEventArgs("h.s", new[] { 7u }, isStepping: false)));
+                new ExecutionCompletedEventArgs("h.s", new[] { 7u }, isStepping: false, isSuccessful: true)));
 
             program.ExecuteOnThread(null);
             integration.Verify((i) => i.Execute(false), Times.Once);
@@ -38,7 +38,7 @@ namespace VSRAD.DeborgarTests
 
             integration.Setup((i) => i.Execute(false)).Callback(() =>
                 integration.Raise((i) => i.ExecutionCompleted += null, null,
-                new ExecutionCompletedEventArgs("h.s", new[] { 7u }, isStepping: true)));
+                new ExecutionCompletedEventArgs("h.s", new[] { 7u }, isStepping: true, isSuccessful: true)));
 
             program.ExecuteOnThread(null);
             integration.Verify((i) => i.Execute(false), Times.Once);

--- a/VSRAD.Package/Errors.cs
+++ b/VSRAD.Package/Errors.cs
@@ -62,8 +62,15 @@ namespace VSRAD.Package
                 catch (Exception e)
                 {
                     await VSPackage.TaskFactory.SwitchToMainThreadAsync();
-                    exceptionCallbackOnMainThread?.Invoke();
-                    ShowException(e);
+                    try
+                    {
+                        exceptionCallbackOnMainThread?.Invoke();
+                        ShowException(e);
+                    }
+                    catch (Exception callbackExc)
+                    {
+                        ShowCritical(e.Message + "\r\n\r\nAn exception has occurred during the handling of this error. Exception message and stack trace are provided below:\r\n\r\n" + callbackExc.Message + "\r\n\r\n" + callbackExc.StackTrace);
+                    }
                 }
             });
 

--- a/VSRAD.Package/ProjectSystem/ActionLauncher.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLauncher.cs
@@ -91,18 +91,9 @@ namespace VSRAD.Package.ProjectSystem
             var activeFile = _codeEditor.GetAbsoluteSourcePath();
             var activeFileLine = _codeEditor.GetCurrentLine();
             var watches = _project.Options.DebuggerOptions.GetWatchSnapshot();
-
-            var nextBreakTargetResult = moveToNextDebugTarget
+            var breakLines = moveToNextDebugTarget
                 ? _breakpointTracker.MoveToNextBreakTarget(activeFile, isDebugSteppingEnabled)
                 : _breakpointTracker.GetBreakTarget(activeFile, isDebugSteppingEnabled);
-            if (!nextBreakTargetResult.TryGetResult(out var breakLines, out var breakpointError))
-            {
-                if (moveToNextDebugTarget)
-                    return new ActionExecution(breakpointError);
-                else
-                    breakLines = new[] { 0u };
-            }
-
             var transients = new MacroEvaluatorTransientValues(activeFileLine, activeFile, breakLines, watches);
 
             try

--- a/VSRAD.Package/ProjectSystem/BreakpointTracker.cs
+++ b/VSRAD.Package/ProjectSystem/BreakpointTracker.cs
@@ -5,16 +5,15 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.IO;
-using System.Linq;
 using VSRAD.Package.Options;
+using VSRAD.Package.Utils;
 
 namespace VSRAD.Package.ProjectSystem
 {
     public interface IBreakpointTracker
     {
-        (string, uint[]) MoveToNextBreakTarget(bool step);
-        (string, uint[]) GetBreakTarget();
+        Result<uint[]> MoveToNextBreakTarget(string file, bool step);
+        Result<uint[]> GetBreakTarget(string file, bool step);
         void SetRunToLine(string file, uint line);
         void ResetToFirstBreakTarget();
     }
@@ -23,18 +22,14 @@ namespace VSRAD.Package.ProjectSystem
     [AppliesTo(Constants.RadOrVisualCProjectCapability)]
     public sealed class BreakpointTracker : IBreakpointTracker
     {
-        private readonly Dictionary<string, uint[]> _breakTargets = new Dictionary<string, uint[]>();
-        private readonly IActiveCodeEditor _codeEditor;
+        private readonly Dictionary<string, (uint Line, bool ForceRunToLine)> _breakTargetPerFile = new Dictionary<string, (uint, bool)>();
 
         private DTE _dte;
         private ProjectOptions _projectOptions;
 
-        private (string, uint[])? _runToLine;
-
         [ImportingConstructor]
-        public BreakpointTracker(IProject project, IActiveCodeEditor codeEditor, SVsServiceProvider serviceProvider)
+        public BreakpointTracker(IProject project, SVsServiceProvider serviceProvider)
         {
-            _codeEditor = codeEditor;
             project.RunWhenLoaded((options) =>
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
@@ -48,78 +43,76 @@ namespace VSRAD.Package.ProjectSystem
 
         public void SetRunToLine(string file, uint line)
         {
-            _runToLine = (file, new[] { line });
+            _breakTargetPerFile[file] = (Line: line, ForceRunToLine: true);
         }
 
         public void ResetToFirstBreakTarget()
         {
-            _breakTargets.Clear();
+            _breakTargetPerFile.Clear();
         }
 
-        public (string, uint[]) MoveToNextBreakTarget(bool step)
+        public Result<uint[]> MoveToNextBreakTarget(string file, bool step)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            (string, uint[]) target;
-
-            if (step && _projectOptions.DebuggerOptions.BreakMode != BreakMode.Multiple)
+            var nextTargetResult = GetBreakTarget(file, step);
+            if (nextTargetResult.TryGetResult(out var nextTarget, out _))
             {
-                var file = _codeEditor.GetAbsoluteSourcePath();
-                if (_breakTargets.TryGetValue(file, out var prevTarget))
-                    target = (file, new[] { prevTarget[0] + 1 });
+                if (_projectOptions.DebuggerOptions.BreakMode == BreakMode.Multiple)
+                    _breakTargetPerFile.Remove(file);
                 else
-                    target = (file, new[] { 0u });
+                    _breakTargetPerFile[file] = (Line: nextTarget[0], ForceRunToLine: false);
+            }
+            return nextTargetResult;
+        }
+
+        public Result<uint[]> GetBreakTarget(string file, bool step)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (_breakTargetPerFile.TryGetValue(file, out var target) && target.ForceRunToLine)
+            {
+                return new[] { target.Line };
+            }
+            else if (step)
+            {
+                if (_projectOptions.DebuggerOptions.BreakMode == BreakMode.Multiple)
+                    return new Error("Stepping is not supported in multiple breakpoints mode.");
+
+                if (_breakTargetPerFile.TryGetValue(file, out var prevTarget))
+                    return new[] { prevTarget.Line + 1 };
+                else
+                    return new Error($"Stepping is not available until a breakpoint has been hit in the current file ({file}).");
             }
             else
             {
-                target = GetBreakTarget();
-                _runToLine = null;
-            }
+                var breakpointLines = new List<uint>();
+                foreach (Breakpoint bp in _dte.Debugger.Breakpoints)
+                    if (bp.Enabled && bp.File == file)
+                        breakpointLines.Add((uint)bp.FileLine - 1);
+                breakpointLines.Sort();
 
-            _breakTargets[target.Item1] = target.Item2;
-            return target;
-        }
+                if (breakpointLines.Count == 0)
+                    return new Error($"No breakpoints are set in the current file ({file}).");
 
-        public (string, uint[]) GetBreakTarget()
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            if (_runToLine.HasValue)
-                return _runToLine.Value;
-
-            var file = _codeEditor.GetAbsoluteSourcePath();
-
-            var breakpointLines = new List<uint>();
-            foreach (Breakpoint bp in _dte.Debugger.Breakpoints)
-                if (bp.Enabled && bp.File == file)
-                    breakpointLines.Add((uint)bp.FileLine - 1);
-            breakpointLines.Sort();
-
-            if (breakpointLines.Count == 0)
-            {
-                // No breakpoints set but we need to pass one to the debugger anyway,
-                // so we pick the end of the source file as the implicit "default" breakpoint
-                var lastLine = (uint)(File.ReadLines(file).Count() - 1);
-                breakpointLines.Add(lastLine);
-            }
-
-            switch (_projectOptions.DebuggerOptions.BreakMode)
-            {
-                case BreakMode.Multiple:
-                    return (file, breakpointLines.ToArray());
-                case BreakMode.SingleRerun:
-                    if (_breakTargets.TryGetValue(file, out var prevTarget))
-                        return (file, prevTarget);
-
-                    return (file, new[] { breakpointLines[0] });
-                default:
-                    var previousBreakLine = _breakTargets.TryGetValue(file, out prevTarget) ? prevTarget[0] : 0;
-
-                    foreach (var breakLine in breakpointLines)
-                        if (breakLine > previousBreakLine)
-                            return (file, new[] { breakLine });
-
-                    return (file, new[] { breakpointLines[0] });
+                switch (_projectOptions.DebuggerOptions.BreakMode)
+                {
+                    case BreakMode.Multiple:
+                        return breakpointLines.ToArray();
+                    case BreakMode.SingleRerun:
+                        if (_breakTargetPerFile.TryGetValue(file, out var prevTarget) && breakpointLines.Contains(prevTarget.Line))
+                            return new[] { prevTarget.Line };
+                        else
+                            goto case BreakMode.SingleRoundRobin;
+                    case BreakMode.SingleRoundRobin:
+                        var previousBreakLine = _breakTargetPerFile.TryGetValue(file, out prevTarget) ? prevTarget.Line : 0;
+                        foreach (var breakLine in breakpointLines)
+                            if (breakLine > previousBreakLine)
+                                return new[] { breakLine };
+                        return new[] { breakpointLines[0] };
+                    default:
+                        return new Error("Undefined breakpoint mode.");
+                }
             }
         }
     }

--- a/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
+++ b/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
@@ -79,10 +79,16 @@ namespace VSRAD.Package.ProjectSystem
         public void NotifyDebugActionExecuted(ActionRunResult runResult, MacroEvaluatorTransientValues transients)
         {
             if (runResult != null)
-                RaiseExecutionCompleted(transients?.ActiveSourceFullPath ?? "", transients?.BreakLines ?? new[] { 0u }, isStepping: false, runResult.BreakState);
+            {
+                var sourcePath = transients?.ActiveSourceFullPath ?? "";
+                var breakLines = transients != null && transients.BreakLines.TryGetResult(out var lines, out _) ? lines : Array.Empty<uint>();
+                RaiseExecutionCompleted(sourcePath, breakLines, isStepping: false, runResult.BreakState);
+            }
             else
+            {
                 // If RunResult is null, the action was not launched due to some error, so the break line markers should be removed
                 _breakLineTagger.RemoveBreakLineMarkers();
+            }
         }
 
         public void Execute(bool step)

--- a/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
+++ b/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
@@ -78,8 +78,11 @@ namespace VSRAD.Package.ProjectSystem
 
         public void NotifyDebugActionExecuted(ActionRunResult runResult, MacroEvaluatorTransientValues transients)
         {
-            if (runResult != null) // If RunResult is null, the action was not launched (e.g. because another action is already running)
+            if (runResult != null)
                 RaiseExecutionCompleted(transients?.ActiveSourceFullPath ?? "", transients?.BreakLines ?? new[] { 0u }, isStepping: false, runResult.BreakState);
+            else
+                // If RunResult is null, the action was not launched due to some error, so the break line markers should be removed
+                _breakLineTagger.RemoveBreakLineMarkers();
         }
 
         public void Execute(bool step)

--- a/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphTagger.cs
+++ b/VSRAD.Package/ProjectSystem/EditorExtensions/BreakLineGlyphTagger.cs
@@ -94,7 +94,7 @@ namespace VSRAD.Package.ProjectSystem.EditorExtensions
         {
             _tagSpans.Clear();
 
-            if (e != null && e.File == _document.FilePath)
+            if (e != null && e.IsSuccessful && e.File == _document.FilePath)
             {
                 var toolTip = "Last RAD debugger break " + (e.Lines.Length == 1
                             ? $"line: {e.Lines[0]}"

--- a/VSRAD.Package/ProjectSystem/Macros/DirtyProfileMacroEditor.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/DirtyProfileMacroEditor.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows;
@@ -101,31 +100,14 @@ namespace VSRAD.Package.ProjectSystem.Macros
             }
         }
 
-        private IActiveCodeEditor _codeEditor;
-        private IBreakpointTracker _breakpointTracker;
-
         private MacroEvaluatorTransientValues GetMacroTransients()
         {
-            if (_codeEditor == null)
-                _codeEditor = _project.UnconfiguredProject.Services.ExportProvider.GetExportedValue<IActiveCodeEditor>();
-            if (_breakpointTracker == null)
-                _breakpointTracker = _project.UnconfiguredProject.Services.ExportProvider.GetExportedValue<IBreakpointTracker>();
-            try
-            {
-                var (file, breakLines) = _breakpointTracker.GetBreakTarget();
-                var sourceLine = _codeEditor.GetCurrentLine();
-                var watches = _project.Options.DebuggerOptions.GetWatchSnapshot();
-                return new MacroEvaluatorTransientValues(sourceLine, file, breakLines, watches);
-            }
-            catch (InvalidOperationException e) when (e.Message == ActiveCodeEditor.NoFilesOpenError)
-            {
-                return new MacroEvaluatorTransientValues(0,
-                    sourcePath: "<current source full path>",
-                    new[] { 0u },
-                    _project.Options.DebuggerOptions.GetWatchSnapshot(),
-                    sourceDir: "<current source dir name>",
-                    sourceFile: "<current source file name>");
-            }
+            return new MacroEvaluatorTransientValues(0,
+                sourcePath: "<active editor tab full path>",
+                new[] { 0u },
+                _project.Options.DebuggerOptions.GetWatchSnapshot(),
+                sourceDir: "<active editor tab dir name>",
+                sourceFile: "<active editor tab file name>");
         }
     }
 }

--- a/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
@@ -53,9 +53,10 @@ namespace VSRAD.PackageTests.ProjectSystem
             project.Options.Profile.Actions[0].Steps.Add(readDebugDataStep);
 
             var codeEditor = new Mock<IActiveCodeEditor>();
+            codeEditor.Setup(e => e.GetAbsoluteSourcePath()).Returns(@"C:\MEHVE\JATO.s");
             codeEditor.Setup(e => e.GetCurrentLine()).Returns(13);
             var breakpointTracker = new Mock<IBreakpointTracker>();
-            breakpointTracker.Setup(t => t.MoveToNextBreakTarget(false)).Returns((@"C:\MEHVE\JATO.s", new[] { 666u }));
+            breakpointTracker.Setup(t => t.MoveToNextBreakTarget(@"C:\MEHVE\JATO.s", false)).Returns((new[] { 666u }));
 
             var serviceProvider = new Mock<SVsServiceProvider>();
             serviceProvider.Setup(p => p.GetService(typeof(SVsStatusbar))).Returns(new Mock<IVsStatusbar>().Object);

--- a/VSRAD.PackageTests/Server/ActionMacroEvaluationTests.cs
+++ b/VSRAD.PackageTests/Server/ActionMacroEvaluationTests.cs
@@ -96,7 +96,8 @@ namespace VSRAD.PackageTests.Server
             profile.Actions.Add(b);
 
             Assert.False((await a.EvaluateAsync(MakeIdentityEvaluator(), profile)).TryGetResult(out _, out var error));
-            Assert.Equal(@"Encountered a circular dependency: ""A"" -> ""A_nested"" -> ""B"" -> ""A""", error.Message);
+            Assert.Equal(@"Run Action step failed in ""A"" <- ""B"" <- ""A_nested"" <- ""A""", error.Title);
+            Assert.Equal(@"Circular dependency between actions", error.Message);
         }
 
         [Fact]
@@ -108,7 +109,8 @@ namespace VSRAD.PackageTests.Server
             profile.Actions.Add(a);
 
             Assert.False((await a.EvaluateAsync(MakeIdentityEvaluator(), profile)).TryGetResult(out _, out var error));
-            Assert.Equal(@"Encountered a circular dependency: ""A"" -> ""A""", error.Message);
+            Assert.Equal(@"Run Action step failed in ""A"" <- ""A""", error.Title);
+            Assert.Equal(@"Circular dependency between actions", error.Message);
         }
 
         [Fact]
@@ -127,11 +129,11 @@ namespace VSRAD.PackageTests.Server
             profile.Actions.Add(c);
 
             Assert.False((await a.EvaluateAsync(MakeIdentityEvaluator(), profile)).TryGetResult(out _, out var error));
-            Assert.Equal(@"Action ""A"" could not be run due to a misconfigured Run Action step", error.Title);
-            Assert.Equal(@"Action ""D"" is not found, required by ""A"" -> ""B"" -> ""C""", error.Message);
+            Assert.Equal(@"Run Action step failed in ""C"" <- ""B"" <- ""A""", error.Title);
+            Assert.Equal(@"Action ""D"" is not found", error.Message);
 
             Assert.False((await c.EvaluateAsync(MakeIdentityEvaluator(), profile)).TryGetResult(out _, out error));
-            Assert.Equal(@"Action ""C"" could not be run due to a misconfigured Run Action step", error.Title);
+            Assert.Equal(@"Run Action step failed in ""C""", error.Title);
             Assert.Equal(@"Action ""D"" is not found", error.Message);
         }
 
@@ -147,11 +149,11 @@ namespace VSRAD.PackageTests.Server
             profile.Actions.Add(b);
 
             Assert.False((await a.EvaluateAsync(MakeIdentityEvaluator(), profile)).TryGetResult(out _, out var error));
-            Assert.Equal(@"Action ""A"" could not be run due to a misconfigured Run Action step", error.Title);
-            Assert.Equal(@"No action specified, required by ""A"" -> ""B""", error.Message);
+            Assert.Equal(@"Run Action step failed in ""B"" <- ""A""", error.Title);
+            Assert.Equal(@"No action specified", error.Message);
 
             Assert.False((await b.EvaluateAsync(MakeIdentityEvaluator(), profile)).TryGetResult(out _, out error));
-            Assert.Equal(@"Action ""B"" could not be run due to a misconfigured Run Action step", error.Title);
+            Assert.Equal(@"Run Action step failed in ""B""", error.Title);
             Assert.Equal(@"No action specified", error.Message);
         }
 
@@ -170,10 +172,12 @@ namespace VSRAD.PackageTests.Server
             profile.Actions.Add(c);
 
             Assert.False((await a.EvaluateAsync(MakeIdentityEvaluator(), profile)).TryGetResult(out _, out var error));
-            Assert.Equal(@"Action ""C"" is misconfigured, required by ""A"" -> ""B""", error.Message);
+            Assert.Equal(@"Copy File step failed in ""C"" <- ""B"" <- ""A""", error.Title);
+            Assert.Equal(@"No source path specified", error.Message);
 
             Assert.False((await b.EvaluateAsync(MakeIdentityEvaluator(), profile)).TryGetResult(out _, out error));
-            Assert.Equal(@"Action ""C"" is misconfigured", error.Message);
+            Assert.Equal(@"Copy File step failed in ""C"" <- ""B""", error.Title);
+            Assert.Equal(@"No source path specified", error.Message);
         }
 
         [Fact]
@@ -184,7 +188,7 @@ namespace VSRAD.PackageTests.Server
 
             a.Steps.Add(new ReadDebugDataStep());
             Assert.False((await a.EvaluateAsync(MakeIdentityEvaluator(), profile)).TryGetResult(out _, out var error));
-            Assert.Equal(@"Action ""A"" could not be run due to a misconfigured Read Debug Data step", error.Title);
+            Assert.Equal(@"Read Debug Data step failed in ""A""", error.Title);
             Assert.Equal("Debug data path is not specified", error.Message);
         }
 


### PR DESCRIPTION
* "Rerun single line" breakpoint mode now moves to the next breakpoint if the current one is removed.
* If no breakpoints are set, and we launch an action that uses `$(RadBreakLine)`, an error message is now shown. If the action does not use `$(RadBreakLine)` (e.g. "Disassemble"), no error message is shown.

The large diff is mostly due to the fact that predefined macros like `$(RadBreakLine)` were assumed to be always available, and if the real value was missing (say, if there are no breakpoints), a hardcoded default was picked instead. Such design is undesirable as it results in seemingly random behavior that hides the real problem, so the code had to be refactored to allow for errors during evaluation of predefined macros.