### PR TITLE
Support breakpoints with multiple instances

### DIFF
--- a/VSRAD.Package/DebugVisualizer/CellStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/CellStyling.cs
@@ -61,7 +61,7 @@ namespace VSRAD.Package.DebugVisualizer
 
         private void PaintInvalidWatchName(DataGridViewCellPaintingEventArgs e)
         {
-            if (e.ColumnIndex == VisualizerTable.NameColumnIndex && e.Value is string watchName && watchName.IndexOf(':') >= 0)
+            if (e.ColumnIndex == VisualizerTable.NameColumnIndex && e.Value is string watchName && !string.IsNullOrEmpty(watchName) && !Watch.IsWatchNameValid(watchName))
                 e.CellStyle.BackColor = Color.Red;
         }
 

--- a/VSRAD.Package/DebugVisualizer/CustomTableGraphics.cs
+++ b/VSRAD.Package/DebugVisualizer/CustomTableGraphics.cs
@@ -34,7 +34,7 @@ namespace VSRAD.Package.DebugVisualizer
                     //| DataGridViewPaintParts.ContentForeground // not needed because we are using custom string painter below
                 );
 
-            if (!selectedWatch.IsEmpty)
+            if (Watch.IsWatchNameValid(selectedWatch.Name))
             {
                 var typeTextPos = new PointF((float)e.RowBounds.Left + 7, (float)e.RowBounds.Top + 4);
                 e.Graphics.DrawString(selectedWatch.Info.ShortName(),

--- a/VSRAD.Package/DebugVisualizer/RowStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/RowStyling.cs
@@ -8,19 +8,10 @@ namespace VSRAD.Package.DebugVisualizer
 {
     public sealed class RowStyling
     {
-        public static void UpdateRowHighlight(DataGridViewRow row, FontAndColorState colors, ReadOnlyCollection<string> watches, DataHighlightColor? changeFg = null, DataHighlightColor? changeBg = null)
+        public static void UpdateRowHighlight(DataGridViewRow row, FontAndColorState colors, DataHighlightColor? changeFg = null, DataHighlightColor? changeBg = null)
         {
             var rowFg = DataHighlightColor.None;
             var rowBg = DataHighlightColor.None;
-            var inactiveBg = colors.HighlightBackground[(int)DataHighlightColor.Inactive];
-            var watch = (string)row.Cells[VisualizerTable.NameColumnIndex].Value;
-            var isUnevaluated = watches == null || !string.IsNullOrWhiteSpace(watch) && watch != "System" && !watches.Contains(watch);
-
-            if (isUnevaluated)
-            {
-                row.DefaultCellStyle.BackColor = inactiveBg;
-                return;
-            }
 
             if (row.DefaultCellStyle.Tag is ValueTuple<DataHighlightColor, DataHighlightColor> existingColors)
                 (rowFg, rowBg) = existingColors;

--- a/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerContext.cs
+++ b/VSRAD.Package/DebugVisualizer/SliceVisualizer/SliceVisualizerContext.cs
@@ -40,12 +40,14 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
         public SliceVisualizerContext(Options.ProjectOptions options, VisualizerContext visualizerContext, EnvDTE80.WindowVisibilityEvents visibilityEvents)
         {
             Options = options;
+#if false
             _visualizerContext = visualizerContext;
             _visualizerContext.GroupFetching += SetupDataFetch;
             _visualizerContext.GroupFetched += DisplayFetchedData;
             _windowVisibilityEvents = visibilityEvents;
             _windowVisibilityEvents.WindowShowing += OnToolWindowVisibilityChanged;
             _windowVisibilityEvents.WindowHiding += OnToolWindowVisibilityChanged;
+#endif
         }
 
         private void SetupDataFetch(object sender, GroupFetchingEventArgs e)
@@ -55,6 +57,7 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
 
         private void DisplayFetchedData(object sender, GroupFetchedEventArgs e)
         {
+#if false
             if (!Watches.SequenceEqual(_visualizerContext.BreakData.Watches))
             {
                 Watches.Clear();
@@ -69,6 +72,7 @@ namespace VSRAD.Package.DebugVisualizer.SliceVisualizer
                 var typedView = new TypedSliceWatchView(watchView, SelectedType);
                 WatchSelected(this, typedView);
             }
+#endif
         }
 
         private void WatchSelectionChanged()

--- a/VSRAD.Package/DebugVisualizer/Watch.cs
+++ b/VSRAD.Package/DebugVisualizer/Watch.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace VSRAD.Package.DebugVisualizer
 {
@@ -7,13 +6,9 @@ namespace VSRAD.Package.DebugVisualizer
     {
         public string Name { get; }
 
-        //[JsonConverter(typeof(StringEnumConverter))]
         public VariableType Info { get; }
 
         public bool IsAVGPR { get; }
-
-        [JsonIgnore]
-        public bool IsEmpty => string.IsNullOrWhiteSpace(Name);
 
         [JsonConstructor]
         public Watch(string name, VariableType type, bool isAVGPR)
@@ -22,6 +17,9 @@ namespace VSRAD.Package.DebugVisualizer
             Info = type;
             IsAVGPR = isAVGPR;
         }
+
+        public static bool IsWatchNameValid(string name) =>
+            !string.IsNullOrWhiteSpace(name) && !name.Contains(ProjectSystem.Macros.RadMacros.WatchSeparator);
 
         public bool Equals(Watch w) => Name == w.Name && Info == w.Info && IsAVGPR == w.IsAVGPR;
         public override bool Equals(object o) => o is Watch w && Equals(w);

--- a/VSRAD.Package/Options/Actions.cs
+++ b/VSRAD.Package/Options/Actions.cs
@@ -314,6 +314,8 @@ namespace VSRAD.Package.Options
             var watchesResult = await WatchesFile.EvaluateAsync(evaluator);
             if (!watchesResult.TryGetResult(out var watchesFile, out error))
                 return EvaluationError(sourceAction, "Read Debug Data", error.Message);
+            if (string.IsNullOrEmpty(outputFile.Path))
+                return EvaluationError(sourceAction, "Read Debug Data", "Watches path is not specified");
 
             var dispatchParamsResult = await DispatchParamsFile.EvaluateAsync(evaluator);
             if (!dispatchParamsResult.TryGetResult(out var dispatchParamsFile, out error))

--- a/VSRAD.Package/Options/DebuggerOptions.cs
+++ b/VSRAD.Package/Options/DebuggerOptions.cs
@@ -22,10 +22,7 @@ namespace VSRAD.Package.Options
         public PinnableMruCollection<string> LastAppArgs { get; } = new PinnableMruCollection<string>();
 
         public ReadOnlyCollection<string> GetWatchSnapshot() =>
-            new ReadOnlyCollection<string>(Watches.Where(w => !w.IsEmpty).Select(w => w.Name).Distinct().ToList());
-
-        public ReadOnlyCollection<string> GetAWatchSnapshot() =>
-            new ReadOnlyCollection<string>(Watches.Where(w => w.IsAVGPR).Select(w => w.Name).Distinct().ToList());
+            new ReadOnlyCollection<string>(Watches.Select(w => w.Name).Where(Watch.IsWatchNameValid).Distinct().ToList());
 
         private uint _nGroups;
         public uint NGroups { get => _nGroups; set => SetField(ref _nGroups, (uint)0); } // always 0 for now as it should be refactored (see ce37993)

--- a/VSRAD.Package/Options/DefaultOptionValues.cs
+++ b/VSRAD.Package/Options/DefaultOptionValues.cs
@@ -14,7 +14,7 @@ namespace VSRAD.Package.Options
         #endregion
         #region Debugger
         public const string DebuggerExecutable = "python.exe";
-        public const string DebuggerArguments = "script.py -w $(" + RadMacros.Watches + ") -l $(" + RadMacros.BreakLine + ") -v \"$(" + RadMacros.DebugAppArgs + ")\" -t $(" + RadMacros.Counter + ") -p \"$(" + RadMacros.DebugBreakArgs + ")\" -f \"$(" + RadMacros.ActiveSourceFile + ")\" -o \"$(" + RadMacros.DebuggerOutputPath + ")\"";
+        public const string DebuggerArguments = "script.py -w $(" + RadMacros.Watches + ") -l $(" + RadMacros.BreakLines + ") -v \"$(" + RadMacros.DebugAppArgs + ")\" -t $(" + RadMacros.Counter + ") -p \"$(" + RadMacros.DebugBreakArgs + ")\" -f \"$(" + RadMacros.ActiveSourceFile + ")\" -o \"$(" + RadMacros.DebuggerOutputPath + ")\"";
         public const string DebuggerWorkingDirectory = "$(" + RadMacros.DeployDirectory + ")";
         public const string DebuggerOutputPath = "";
         public const bool DebuggerBinaryOutput = false;

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
@@ -76,13 +76,15 @@ namespace VSRAD.Package.ProjectSystem.Macros
         public const string ActiveSourceFile = "RadActiveSourceFile";
         public const string ActiveSourceFileLine = "RadActiveSourceFileLine";
         public const string Watches = "RadWatches";
-        public const string AWatches = "RadAWatches";
-        public const string BreakLine = "RadBreakLine";
+        public const string BreakLines = "RadBreakLines";
         public const string DebugAppArgs = "RadDebugAppArgs";
         public const string DebugBreakArgs = "RadDebugBreakArgs";
         public const string Counter = "RadCounter";
         public const string NGroups = "RadNGroups";
         public const string GroupSize = "RadGroupSize";
+
+        public const string WatchSeparator = ";";
+        public const string BreakLineSeparator = ";";
 
         public const string BuildExecutable = "RadBuildExe";
         public const string BuildArguments = "RadBuildArgs";
@@ -151,16 +153,15 @@ namespace VSRAD.Package.ProjectSystem.Macros
                 case RadMacros.ActiveSourceDir: value = _transientValues.ActiveSourceDir; break;
                 case RadMacros.ActiveSourceFile: value = _transientValues.ActiveSourceFile; break;
                 case RadMacros.ActiveSourceFileLine: value = _transientValues.ActiveSourceLine.ToString(); break;
-                case RadMacros.Watches: value = string.Join(":", _transientValues.Watches); break;
-                case RadMacros.AWatches: value = string.Join(":", _debuggerOptions.GetAWatchSnapshot()); break;
+                case RadMacros.Watches: value = string.Join(RadMacros.WatchSeparator, _transientValues.Watches); break;
                 case RadMacros.DebugAppArgs: value = _debuggerOptions.AppArgs; break;
                 case RadMacros.DebugBreakArgs: value = _debuggerOptions.BreakArgs; break;
                 case RadMacros.Counter: value = _debuggerOptions.Counter.ToString(); break;
                 case RadMacros.NGroups: value = _debuggerOptions.NGroups.ToString(); break;
                 case RadMacros.GroupSize: value = _debuggerOptions.GroupSize.ToString(); break;
-                case RadMacros.BreakLine:
+                case RadMacros.BreakLines:
                     if (_transientValues.BreakLines.TryGetResult(out var breakLines, out var error))
-                        value = string.Join(":", breakLines);
+                        value = string.Join(RadMacros.BreakLineSeparator, breakLines);
                     else
                         return error;
                     break;

--- a/VSRAD.Package/ProjectSystem/Macros/MacroListEditor.xaml.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroListEditor.xaml.cs
@@ -18,7 +18,7 @@ namespace VSRAD.Package.ProjectSystem.Macros
     {
         public MacroListDesignTimeCollection()
         {
-            Add(new MacroItem("RadBreakLine", "<next breakpoint line>", userDefined: false));
+            Add(new MacroItem("RadBreakLines", "<next breakpoint line>", userDefined: false));
             Add(new MacroItem("RadDeployDir", "/home/rad/deploy", userDefined: true));
             Add(new MacroItem("RadDebugOutputPath", "$(RadDeployDir)/out.bin", userDefined: true));
         }
@@ -45,8 +45,8 @@ namespace VSRAD.Package.ProjectSystem.Macros
             new MacroItem(RadMacros.ActiveSourceDir, "<current source dir name>", userDefined: false),
             new MacroItem(RadMacros.ActiveSourceFile, "<current source file name>", userDefined: false),
             new MacroItem(RadMacros.ActiveSourceFileLine, "<line number under the cursor>", userDefined: false),
-            new MacroItem(RadMacros.Watches, "<visualizer watches, colon-separated>", userDefined: false),
-            new MacroItem(RadMacros.BreakLine, "<next breakpoint line(s), colon-separated>", userDefined: false),
+            new MacroItem(RadMacros.Watches, "<visualizer watches, semicolon-separated>", userDefined: false),
+            new MacroItem(RadMacros.BreakLines, "<next breakpoint line(s), semicolon-separated>", userDefined: false),
             new MacroItem(RadMacros.DebugAppArgs, "<app args, set in visualizer>", userDefined: false),
             new MacroItem(RadMacros.DebugBreakArgs, "<break args, set in visualizer>", userDefined: false),
             new MacroItem(RadMacros.Counter, "<counter, set in visualizer>", userDefined: false),

--- a/VSRAD.Package/Server/ActionRunResult.cs
+++ b/VSRAD.Package/Server/ActionRunResult.cs
@@ -18,7 +18,19 @@ namespace VSRAD.Package.Server
         public StepResult[] StepResults { get; }
 
         /// <summary>Non-null if the action includes a <c>ReadDebugData</c> step and it was executed successfully.</summary>
-        public BreakState BreakState { get; set; }
+        public BreakState BreakState
+        {
+            get
+            {
+                foreach (var result in StepResults)
+                    if (result.BreakState != null)
+                        return result.BreakState;
+                foreach (var result in StepResults)
+                    if (result.SubAction?.BreakState is BreakState breakState)
+                        return breakState;
+                return null;
+            }
+        }
 
         public bool Successful => StepResults.All(r => r.Successful);
 
@@ -79,14 +91,16 @@ namespace VSRAD.Package.Server
         public string Log { get; }
         public string[] ErrorListOutput { get; }
         public ActionRunResult SubAction { get; }
+        public BreakState BreakState { get; }
 
-        public StepResult(bool successful, string warning, string log, ActionRunResult subAction = null, string[] errorListOutput = null)
+        public StepResult(bool successful, string warning, string log, string[] errorListOutput = null, ActionRunResult subAction = null, BreakState breakState = null)
         {
             Successful = successful;
             Warning = warning;
             Log = log;
-            SubAction = subAction;
             ErrorListOutput = errorListOutput;
+            SubAction = subAction;
+            BreakState = breakState;
         }
 
         public bool Equals(StepResult result) =>

--- a/VSRAD.Package/Server/BreakState.cs
+++ b/VSRAD.Package/Server/BreakState.cs
@@ -1,9 +1,14 @@
 ﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using VSRAD.Package.Utils;
 
 namespace VSRAD.Package.Server
 {
     public sealed class BreakState
     {
+        private static readonly Regex _watchesRegex = new Regex(@"\s*(?:Instance (?<instances>\d+):(?<instance_watches>[^\r\n]*)[\r\n]*)*", RegexOptions.Compiled);
+
         public BreakStateData Data { get; }
         public BreakStateDispatchParameters DispatchParameters { get; }
         public DateTime ExecutedAt { get; } = DateTime.Now;
@@ -12,6 +17,46 @@ namespace VSRAD.Package.Server
         {
             Data = breakStateData;
             DispatchParameters = dispatchParameters;
+        }
+
+        public static Result<BreakState> CreateBreakState(string validWatchesString, string dispatchParamsString, BreakStateOutputFile outputFile, byte[] localOutputData)
+        {
+            var watchesMatch = _watchesRegex.Match(validWatchesString);
+            if (!watchesMatch.Success)
+                return new Error($@"Could not read the valid watches file.
+
+The following is an example of the expected file contents:
+
+Instance 0:a;b
+Instance 1:
+Instance 2:b;c;d
+
+While the actual contents are:
+
+{validWatchesString}");
+
+            var instances = watchesMatch.Groups["instances"].Captures.Cast<Capture>().Select(c => uint.Parse(c.Value));
+            var watches = watchesMatch.Groups["instance_watches"].Captures.Cast<Capture>().Select(c => c.Value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
+            var instanceWatches = instances.Zip(watches, (i, w) => (i, w)).ToDictionary(p => p.i, p => p.w);
+
+            BreakStateDispatchParameters dispatchParams = null;
+            if (dispatchParamsString != null && !BreakStateDispatchParameters.Parse(dispatchParamsString).TryGetResult(out dispatchParams, out var error))
+                return error;
+
+            if (dispatchParams != null)
+            {
+                var dispatchLaneCount = dispatchParams.GridSizeX * dispatchParams.GridSizeY * dispatchParams.GridSizeZ;
+                var dwordsPerLane = BreakStateData.GetDwordsPerLane(instanceWatches);
+                var expectedDwordCount = (int)dispatchLaneCount * dwordsPerLane;
+                if (outputFile.DwordCount != expectedDwordCount)
+                    return new Error($"Output file does not match the expected size.\r\n\r\n" +
+                        $"Grid size as specified in the dispatch parameters file is ({dispatchParams.GridSizeX}, {dispatchParams.GridSizeY}, {dispatchParams.GridSizeZ}), " +
+                        $"or {dispatchLaneCount} lanes in total. With {dwordsPerLane} DWORDs per lane, the output file is expected to be {expectedDwordCount} DWORDs long, " +
+                        $"but the actual size is {outputFile.DwordCount} DWORDs.");
+            }
+
+            var breakData = new BreakStateData(instanceWatches, outputFile, localOutputData);
+            return new BreakState(breakData, dispatchParams);
         }
     }
 }

--- a/VSRAD.PackageTests/DebugVisualizer/ColumnStylingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/ColumnStylingTests.cs
@@ -28,7 +28,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             var columns = GenerateTestColumns();
 
             var computedStyling = new ComputedColumnStyling();
-            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance(), options, groupSize: 32, waveSize: 32, system: null);
+            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance(), options, groupSize: 32, waveSize: 32, breakData: null);
 
             new ColumnStyling(new VisualizerAppearance(), options, computedStyling, MakeColorState()).Apply(columns);
 
@@ -57,7 +57,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             var computedStyling = new ComputedColumnStyling();
             var options = new ColumnStylingOptions { BackgroundColors = null, ForegroundColors = "" };
 
-            computedStyling.Recompute(visualizerOptions, new VisualizerAppearance(), options, groupSize: 8, waveSize: 8, system: null);
+            computedStyling.Recompute(visualizerOptions, new VisualizerAppearance(), options, groupSize: 8, waveSize: 8, breakData: null);
             new ColumnStyling(appearance, options, computedStyling, MakeColorState()).Apply(columns);
             for (int i = 0; i < 8; ++i)
             {
@@ -67,7 +67,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
 
             columns = GenerateTestColumns();
             options = new ColumnStylingOptions { BackgroundColors = null, ForegroundColors = "rgbJKFJ" + new string(' ', 512 - "rgbJKFJ".Length) };
-            computedStyling.Recompute(visualizerOptions, new VisualizerAppearance(), options, groupSize: 8, waveSize: 8, system: null);
+            computedStyling.Recompute(visualizerOptions, new VisualizerAppearance(), options, groupSize: 8, waveSize: 8, breakData: null);
             new ColumnStyling(appearance, options, computedStyling, MakeColorState()).Apply(columns);
 
             for (int i = 0; i < 8; ++i)
@@ -88,7 +88,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
 
             options = new ColumnStylingOptions { BackgroundColors = bgString, ForegroundColors = fgString };
 
-            computedStyling.Recompute(visualizerOptions, new VisualizerAppearance(), options, groupSize: 8, waveSize: 8, system: null);
+            computedStyling.Recompute(visualizerOptions, new VisualizerAppearance(), options, groupSize: 8, waveSize: 8, breakData: null);
             new ColumnStyling(appearance, options, computedStyling, MakeColorState()).Apply(columns);
 
             for (int i = 0; i < 8; ++i)
@@ -114,7 +114,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             var columns = GenerateTestColumns();
 
             var computedStyling = new ComputedColumnStyling();
-            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 4 }, options, groupSize: 32, waveSize: 32, system: null);
+            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 4 }, options, groupSize: 32, waveSize: 32, breakData: null);
             new ColumnStyling(appearance, options, computedStyling, MakeColorState()).Apply(columns);
 
             // 2 3 | 4 5 6 || 8 9 || 11 | 12 || 14 15 | 16
@@ -137,15 +137,15 @@ namespace VSRAD.PackageTests.DebugVisualizer
             Assert.Equal(laneSep, columns[15].DividerWidth);
 
             options.VisibleColumns = "0-511";
-            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 3}, options, groupSize: 512, waveSize: 32, system: null);
+            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 3}, options, groupSize: 512, waveSize: 32, breakData: null);
             new ColumnStyling(new VisualizerAppearance(), options, computedStyling, MakeColorState()).Apply(columns);
             // no assertions here, this is just to trigger an index out of bounds if we're not careful with grouping
 
-            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 1 }, options, groupSize: 512, waveSize: 32, system: null);
+            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 1 }, options, groupSize: 512, waveSize: 32, breakData: null);
             new ColumnStyling(new VisualizerAppearance(), options, computedStyling, MakeColorState()).Apply(columns);
             Assert.NotEqual(0, columns[0].DividerWidth); // 0 should be separated
 
-            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 0 }, options, groupSize: 512, waveSize: 32, system: null);
+            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 0 }, options, groupSize: 512, waveSize: 32, breakData: null);
             new ColumnStyling(new VisualizerAppearance(), options, computedStyling, MakeColorState()).Apply(columns);
             for (int i = 0; i < 256; i++)
                 Assert.Equal(0, columns[i].DividerWidth);
@@ -160,7 +160,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             options.VisibleColumns = "0,111111111111111111111,34-111111111111111111111,111111111111111111111-34,1-2";
 
             var computedStyling = new ComputedColumnStyling();
-            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 1 }, options, groupSize: 512, waveSize: 32, system: null);
+            computedStyling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 1 }, options, groupSize: 512, waveSize: 32, breakData: null);
             new ColumnStyling(new VisualizerAppearance(), options, computedStyling, MakeColorState()).Apply(columns);
 
             Assert.True(columns[0].Visible);

--- a/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/ComputedColumnStylingTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using VSRAD.Package.DebugVisualizer;
 using VSRAD.Package.Options;
 using VSRAD.Package.Server;
@@ -11,109 +9,62 @@ namespace VSRAD.PackageTests.DebugVisualizer
 {
     public class ComputedColumnStylingTests
     {
-        private WatchView GetSystemView(uint[] system, int groupSize, int waveSize, int groupIndex = 0)
+        private BreakStateData GetBreakData(uint[] system, int groupSize, int waveSize, int groupIndex = 0)
         {
             byte[] systemBytes = new byte[system.Length * 4];
             Buffer.BlockCopy(system, 0, systemBytes, 0, systemBytes.Length);
-            var data = new BreakStateData(new ReadOnlyCollection<string>(new List<string>()),
+            var data = new BreakStateData(new Dictionary<uint, string[]>(),
                 new BreakStateOutputFile(Array.Empty<string>(), false, 0, default, dwordCount: system.Length), systemBytes);
             _ = data.ChangeGroupWithWarningsAsync(null, groupIndex: groupIndex, groupSize: groupSize, waveSize: waveSize, nGroups: 0).Result;
-            var view = data.GetSystem();
-            Assert.NotNull(view);
-            return view;
+            return data;
         }
 
-        [Fact]
-        public void LaneMaskingTest()
+        [Theory]
+        [InlineData(256, 64)]
+        [InlineData(256, 32)]
+        [InlineData(96, 64)] // Incomplete group
+        public void LaneMaskingTest(int groupSize, int waveSize)
         {
-            var maskLowBits = new bool[32];
-            for (int i = 5; i < 23; i++)
-                maskLowBits[i] = true;
-            var maskHighBits = new bool[32];
-            maskHighBits[13] = true;
-
-            var system = new uint[64];
-
-            var tmp = new int[1];
-            new BitArray(maskLowBits).CopyTo(tmp, 0);
-            system[8] = (uint)tmp[0];
-            new BitArray(maskHighBits).CopyTo(tmp, 0);
-            system[9] = (uint)tmp[0];
+            var system = new uint[(groupSize + waveSize - 1) / waveSize * waveSize];
+            // EXEC mask = 1s for multiple of 4 lane ids
+            for (var tid = 0; tid < system.Length; ++tid)
+            {
+                var wave = tid / waveSize;
+                var lane = tid % waveSize;
+                if (lane < 32)
+                    system[wave * waveSize + 8] |= ((tid % 4 == 0) ? 1u : 0u) << lane;
+                else
+                    system[wave * waveSize + 9] |= ((tid % 4 == 0) ? 1u : 0u) << (lane - 32);
+            }
 
             var styling = new ComputedColumnStyling();
             styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = false }, new VisualizerAppearance(), new ColumnStylingOptions(),
-                groupSize: 64, waveSize: 64, system: GetSystemView(system, groupSize: 64, waveSize: 64));
+                groupSize: (uint)groupSize, waveSize: (uint)waveSize, breakData: GetBreakData(system, groupSize: groupSize, waveSize: waveSize));
 
-            for (int i = 0; i < 5; i++)
-                Assert.True((styling.ColumnState[i] & ColumnStates.Inactive) != 0);
-            for (int i = 5; i < 23; i++)
-                Assert.False((styling.ColumnState[i] & ColumnStates.Inactive) != 0);
-            for (int i = 24; i < 45; i++)
-                Assert.True((styling.ColumnState[i] & ColumnStates.Inactive) != 0);
-
-            Assert.False((styling.ColumnState[45] & ColumnStates.Inactive) != 0);
-
-            for (int i = 46; i < 64; i++)
-                Assert.True((styling.ColumnState[i] & ColumnStates.Inactive) != 0);
+            for (var tid = 0; tid < groupSize; ++tid)
+            {
+                if (tid % 4 == 0)
+                    Assert.False((styling.ColumnState[tid] & ColumnStates.Inactive) != 0);
+                else
+                    Assert.True((styling.ColumnState[tid] & ColumnStates.Inactive) != 0);
+            }
 
             styling.Recompute(new VisualizerOptions { MaskLanes = false, CheckMagicNumber = false }, new VisualizerAppearance(), new ColumnStylingOptions(),
-                groupSize: 64, waveSize: 64, system: GetSystemView(system, groupSize: 64, waveSize: 64));
+                groupSize: (uint)groupSize, waveSize: (uint)waveSize, breakData: GetBreakData(system, groupSize: groupSize, waveSize: waveSize));
 
-            for (int i = 0; i < 64; i++)
-                Assert.False((styling.ColumnState[45] & ColumnStates.Inactive) != 0);
+            for (var tid = 0; tid < groupSize; ++tid)
+                Assert.False((styling.ColumnState[tid] & ColumnStates.Inactive) != 0);
         }
 
         [Theory]
-        [InlineData(1)] // wave size is too small
-        [InlineData(9)] // wave size is too small
-        [InlineData(65)] // wave size is too large
-        [InlineData(128)] // wave size is too large
-        public void LaneMaskingInvalidWaveSizeTest(int waveSize)
-        {
-            var system = new uint[waveSize];
-            var styling = new ComputedColumnStyling();
-            styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = false }, new VisualizerAppearance(), new ColumnStylingOptions(),
-                groupSize: (uint)waveSize, waveSize: (uint)waveSize, system: GetSystemView(system, groupSize: waveSize, waveSize: waveSize));
-
-            for (int i = 0; i < waveSize; ++i)
-                Assert.True((styling.ColumnState[i] & ColumnStates.Inactive) == 0); // lane masking does not apply, all columns are active
-        }
-
-        [Fact]
-        public void LaneMaskingIncompleteGroupTest()
-        {
-            var system = new uint[12];
-            system[8] = 0b11_0111_0111;
-
-            var styling = new ComputedColumnStyling();
-            styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = false }, new VisualizerAppearance(), new ColumnStylingOptions(),
-                groupSize: 12, waveSize: 10, system: GetSystemView(system, groupSize: 12, waveSize: 10));
-
-            Assert.True((styling.ColumnState[0] & ColumnStates.Inactive) == 0); // 1 = active
-            Assert.True((styling.ColumnState[1] & ColumnStates.Inactive) == 0); // 1 = active
-            Assert.True((styling.ColumnState[2] & ColumnStates.Inactive) == 0); // 1 = active
-            Assert.False((styling.ColumnState[3] & ColumnStates.Inactive) == 0); // 0 = inactive
-            Assert.True((styling.ColumnState[4] & ColumnStates.Inactive) == 0); // 1 = active
-            Assert.True((styling.ColumnState[5] & ColumnStates.Inactive) == 0); // 1 = active
-            Assert.True((styling.ColumnState[6] & ColumnStates.Inactive) == 0); // 1 = active
-            Assert.False((styling.ColumnState[7] & ColumnStates.Inactive) == 0); // 0 = inactive
-            Assert.True((styling.ColumnState[8] & ColumnStates.Inactive) == 0); // 1 = active
-            Assert.True((styling.ColumnState[9] & ColumnStates.Inactive) == 0); // 1 = active
-            Assert.True((styling.ColumnState[10] & ColumnStates.Inactive) == 0); // active (wave offset + 8 is out of bounds, masking does not apply)
-            Assert.True((styling.ColumnState[11] & ColumnStates.Inactive) == 0); // active (wave offset + 8 is out of bounds, masking does not apply)
-        }
-
-        [Theory]
-        [InlineData(12, 24, 12, 0)] // group size exceeds data size
-        [InlineData(36, 24, 12, 1)] // some of the items in the last group are out of bounds
-        [InlineData(60, 24, 10, 1)] // display group size is 24, data group size is 30 (check that we don't exceed the bounds of ColumnState[])
+        [InlineData(32, 64, 32, 0)] // group size exceeds data size
         public void LaneMaskingOutputSizeNotDivisibleByGroupSizeTest(int dataSize, int groupSize, int waveSize, int groupIndex)
         {
             var system = new uint[dataSize];
 
             var styling = new ComputedColumnStyling();
             styling.Recompute(new VisualizerOptions { MaskLanes = true, CheckMagicNumber = true, MagicNumber = 0 }, new VisualizerAppearance(), new ColumnStylingOptions(),
-                groupSize: (uint)groupSize, waveSize: (uint)waveSize, system: GetSystemView(system, groupSize: groupSize, waveSize: waveSize, groupIndex: groupIndex));
+                groupSize: (uint)groupSize, waveSize: (uint)waveSize, breakData: GetBreakData(system, groupSize: groupSize, waveSize: waveSize, groupIndex: groupIndex));
 
             for (int i = 0; i < 12; ++i)
                 Assert.True((styling.ColumnState[i] & ColumnStates.Inactive) != 0); // all lanes are inactive (exec mask = 0)
@@ -124,7 +75,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
         {
             // No assertions, this test simply hangs if we don't handle groupSize < laneGrouping in the code
             var styling = new ComputedColumnStyling();
-            styling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 4 }, new ColumnStylingOptions(), groupSize: 3, waveSize: 3, system: null);
+            styling.Recompute(new VisualizerOptions(), new VisualizerAppearance { LaneGrouping = 4 }, new ColumnStylingOptions(), groupSize: 3, waveSize: 3, breakData: null);
         }
 
         [Fact]
@@ -138,7 +89,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             var visualizerOptions = new VisualizerOptions { MaskLanes = false, CheckMagicNumber = true, MagicNumber = 0x7 };
             var styling = new ComputedColumnStyling();
             styling.Recompute(visualizerOptions, new VisualizerAppearance(), new ColumnStylingOptions(),
-                groupSize: 256, waveSize: 64, system: GetSystemView(system, groupSize: 256, waveSize: 64));
+                groupSize: 256, waveSize: 64, breakData: GetBreakData(system, groupSize: 256, waveSize: 64));
 
             for (int i = 0; i < 63; i++)
                 Assert.False((styling.ColumnState[i] & ColumnStates.Inactive) != 0);
@@ -163,7 +114,7 @@ namespace VSRAD.PackageTests.DebugVisualizer
             var visualizerOptions = new VisualizerOptions { MaskLanes = false, CheckMagicNumber = true, MagicNumber = 0x7 };
             var styling = new ComputedColumnStyling();
             styling.Recompute(visualizerOptions, new VisualizerAppearance(), new ColumnStylingOptions(),
-                groupSize: 144, waveSize: 32, system: GetSystemView(system, groupSize: 144, waveSize: 32));
+                groupSize: 144, waveSize: 32, breakData: GetBreakData(system, groupSize: 144, waveSize: 32));
 
             for (int i = 0; i < 32; i++)
                 Assert.False((styling.ColumnState[i] & ColumnStates.Inactive) != 0);

--- a/VSRAD.PackageTests/ProjectSystem/ActionLoggerTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/ActionLoggerTests.cs
@@ -44,13 +44,13 @@ namespace VSRAD.PackageTests.ProjectSystem
             TestHelper.SetReadOnlyProp(level2Result, nameof(level2Result.TotalMillis), 40);
             level2Result.StepResults[0] = new StepResult(true, "Some Message Indicating Contract Obtained", "Captured stdout (exit code 1):\r\ncontract obtained\r\n");
             level2Result.StepRunMillis[0] = 20;
-            level2Result.StepResults[1] = new StepResult(true, "", "", level3Result);
+            level2Result.StepResults[1] = new StepResult(true, "", "", subAction: level3Result);
             level2Result.StepRunMillis[1] = 20;
 
             var level1Result = new ActionRunResult(level1action.Name, level1action.Steps, false);
             TestHelper.SetReadOnlyProp(level1Result, nameof(level1Result.InitTimestampFetchMillis), 10);
             TestHelper.SetReadOnlyProp(level1Result, nameof(level1Result.TotalMillis), 70);
-            level1Result.StepResults[0] = new StepResult(true, "", "", level2Result);
+            level1Result.StepResults[0] = new StepResult(true, "", "", subAction: level2Result);
             level1Result.StepRunMillis[0] = 40;
             level1Result.StepResults[1] = new StepResult(true, "", "");
             level1Result.StepRunMillis[1] = 20;

--- a/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
@@ -54,7 +54,7 @@ namespace VSRAD.PackageTests.ProjectSystem
             readDebugDataStep.DispatchParamsFile.Path = "dispatch-params-path";
 
             project.Options.Profile.Actions[0].Steps.Add(new ExecuteStep
-            { Executable = "ohmu", Arguments = "-break-line $(RadBreakLine) -source $(RadActiveSourceFile) -source-line $(RadActiveSourceFileLine) -watch $(RadWatches)" });
+            { Executable = "ohmu", Arguments = "-break-line $(RadBreakLines) -source $(RadActiveSourceFile) -source-line $(RadActiveSourceFileLine) -watch $(RadWatches)" });
             project.Options.Profile.Actions[0].Steps.Add(readDebugDataStep);
 
             var codeEditor = new Mock<IActiveCodeEditor>();
@@ -88,7 +88,7 @@ wave_size 64
             channel.ThenRespond(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0 }, (Execute execute) =>
             {
                 Assert.Equal("ohmu", execute.Executable);
-                Assert.Equal(@"-break-line 666 -source JATO.s -source-line 13 -watch a:c:tide", execute.Arguments);
+                Assert.Equal(@"-break-line 666 -source JATO.s -source-line 13 -watch a;c;tide", execute.Arguments);
             });
             channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Encoding.UTF8.GetBytes(validWatchesString) }, (FetchResultRange watchesFetch) =>
                 Assert.Equal(new[] { "/periphery/votw", "watches-path" }, watchesFetch.FilePath));

--- a/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.Text.Tagging;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using VSRAD.Deborgar;
 using VSRAD.DebugServer.IPC.Commands;
@@ -44,9 +45,13 @@ namespace VSRAD.PackageTests.ProjectSystem
             project.Options.DebuggerOptions.Watches.Add(new Watch("c", new VariableType(VariableCategory.Hex, 32), false));
             project.Options.DebuggerOptions.Watches.Add(new Watch("tide", new VariableType(VariableCategory.Hex, 32), false));
 
-            var readDebugDataStep = new ReadDebugDataStep { BinaryOutput = false, OutputOffset = 1 };
+            var readDebugDataStep = new ReadDebugDataStep { BinaryOutput = true, OutputOffset = 0 };
             readDebugDataStep.OutputFile.CheckTimestamp = true;
             readDebugDataStep.OutputFile.Path = "output-path";
+            readDebugDataStep.WatchesFile.CheckTimestamp = false;
+            readDebugDataStep.WatchesFile.Path = "watches-path";
+            readDebugDataStep.DispatchParamsFile.CheckTimestamp = false;
+            readDebugDataStep.DispatchParamsFile.Path = "dispatch-params-path";
 
             project.Options.Profile.Actions[0].Steps.Add(new ExecuteStep
             { Executable = "ohmu", Arguments = "-break-line $(RadBreakLine) -source $(RadActiveSourceFile) -source-line $(RadActiveSourceFileLine) -watch $(RadWatches)" });
@@ -69,6 +74,15 @@ namespace VSRAD.PackageTests.ProjectSystem
 
             /* Set up server responses */
 
+            var validWatchesString = @"Instance 0:a;tide
+Instance 1:
+Instance 2:a;c;tide
+";
+            var dispatchParamsString = @"
+grid_size (1024, 1, 1)
+group_size (256, 1, 1)
+wave_size 64
+";
             channel.ThenRespond(new MetadataFetched { Status = FetchStatus.FileNotFound }, (FetchMetadata timestampFetch) =>
                 Assert.Equal(new[] { "/periphery/votw", "output-path" }, timestampFetch.FilePath));
             channel.ThenRespond(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0 }, (Execute execute) =>
@@ -76,7 +90,11 @@ namespace VSRAD.PackageTests.ProjectSystem
                 Assert.Equal("ohmu", execute.Executable);
                 Assert.Equal(@"-break-line 666 -source JATO.s -source-line 13 -watch a:c:tide", execute.Arguments);
             });
-            channel.ThenRespond(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.Now });
+            channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Encoding.UTF8.GetBytes(validWatchesString) }, (FetchResultRange watchesFetch) =>
+                Assert.Equal(new[] { "/periphery/votw", "watches-path" }, watchesFetch.FilePath));
+            channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Encoding.UTF8.GetBytes(dispatchParamsString) }, (FetchResultRange dispatchParamsFetch) =>
+                Assert.Equal(new[] { "/periphery/votw", "dispatch-params-path" }, dispatchParamsFetch.FilePath));
+            channel.ThenRespond(new MetadataFetched { Status = FetchStatus.Successful, Timestamp = DateTime.Now, ByteCount = 1024 /* lanes */ * 4 /* dwords/lane */ * sizeof(uint) });
 
             /* Start debugging */
 
@@ -98,10 +116,10 @@ namespace VSRAD.PackageTests.ProjectSystem
             sourceManager.Verify(s => s.SaveProjectState(), Times.Once);
 
             Assert.NotNull(breakState);
-            Assert.Equal(3, breakState.Data.Watches.Count);
-            Assert.Equal("a", breakState.Data.Watches[0]);
-            Assert.Equal("c", breakState.Data.Watches[1]);
-            Assert.Equal("tide", breakState.Data.Watches[2]);
+            Assert.Equal(1024u, breakState.DispatchParameters.GridSizeX);
+            Assert.Equal(256u, breakState.DispatchParameters.GroupSizeX);
+            Assert.Equal(64u, breakState.DispatchParameters.WaveSize);
+            Assert.Equal(new Dictionary<uint, string[]> { { 0, new[] { "a", "tide" } }, { 1, Array.Empty<string>() }, { 2, new[] { "a", "c", "tide" } } }, breakState.Data.InstanceWatches);
 
             breakLineTagger.Verify(t => t.OnExecutionCompleted(execCompletedEvent));
         }

--- a/VSRAD.PackageTests/ProjectSystem/Macros/MacroEvaluatorTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Macros/MacroEvaluatorTests.cs
@@ -54,17 +54,17 @@ namespace VSRAD.PackageTests.ProjectSystem.Macros
 
             var result = await evaluator.GetMacroValueAsync(RadMacros.Watches);
             Assert.True(result.TryGetResult(out var evaluated, out _));
-            Assert.Equal("m:c:ride", evaluated);
+            Assert.Equal("m;c;ride", evaluated);
 
-            result = await evaluator.EvaluateAsync($"$({RadMacros.ActiveSourceDir})\\$({RadMacros.ActiveSourceFile}):$({RadMacros.ActiveSourceFileLine}), stop at $({RadMacros.BreakLine})");
+            result = await evaluator.EvaluateAsync($"$({RadMacros.ActiveSourceDir})\\$({RadMacros.ActiveSourceFile}):$({RadMacros.ActiveSourceFileLine}), stop at $({RadMacros.BreakLines})");
             Assert.True(result.TryGetResult(out evaluated, out _));
             Assert.Equal(@"B:\welcome\home:666, stop at 13", evaluated);
 
             transients = new MacroEvaluatorTransientValues(0, "nofile", new[] { 20u, 1u, 9u }, new ReadOnlyCollection<string>(new[] { "watch" }));
             evaluator = new MacroEvaluator(props.Object, transients, EmptyRemoteEnv, new DebuggerOptions(), new ProfileOptions());
-            result = await evaluator.EvaluateAsync($"-l $({RadMacros.BreakLine})");
+            result = await evaluator.EvaluateAsync($"-l $({RadMacros.BreakLines})");
             Assert.True(result.TryGetResult(out evaluated, out _));
-            Assert.Equal("-l 20:1:9", evaluated);
+            Assert.Equal("-l 20;1;9", evaluated);
         }
 
         [Fact]

--- a/VSRAD.PackageTests/Server/BreakStateTests.cs
+++ b/VSRAD.PackageTests/Server/BreakStateTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using VSRAD.DebugServer.IPC.Commands;
 using VSRAD.DebugServer.IPC.Responses;
@@ -11,144 +11,116 @@ namespace VSRAD.PackageTests.Server
 {
     public class BreakStateTests
     {
-        [Fact]
-        public async Task WatchViewTestAsync()
+        [Theory]
+        [InlineData(2, 64, 32)]
+        [InlineData(2, 128, 64)]
+        [InlineData(2, 96, 64)] // Incomplete group: group size % wave size != 0
+        public async Task WaveViewTestAsync(int groupCount, int groupSize, int waveSize)
         {
             var channel = new MockCommunicationChannel();
-            var watches = new ReadOnlyCollection<string>(new[] { "local_id", "group_id", "group_size" });
-            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "madoka" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
-            var breakStateData = new BreakStateData(watches, file);
+            var instanceWatches = new Dictionary<uint, string[]> {
+                { 0, new[] { "ThreadID", "GlobalID", "GlobalID<<2" } },
+                { 1, new[] { "GlobalID<<8", "GlobalID<<4", "GlobalID", "ThreadID" } },
+            };
+            var dwordsPerLane = 5; // max watches per instance + 1
+            var wavesPerGroup = (groupSize + waveSize - 1) / waveSize;
+            var dwordsPerGroup = wavesPerGroup * waveSize * dwordsPerLane;
+            var dwordsInBuffer = groupCount * dwordsPerGroup;
 
-            var data = new int[1024]; // 2 groups by 2 waves (1 wave = 64 lanes), each containing 1 system dword and 3 watch dwords
-            for (int group = 0; group < 2; ++group)
+            var file = new BreakStateOutputFile(new[] { "/working/dir", "debug_buffer.bin" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: dwordsInBuffer);
+            var breakStateData = new BreakStateData(instanceWatches, file);
+            Assert.Equal(dwordsPerLane, BreakStateData.GetDwordsPerLane(instanceWatches));
+
+            var data = new int[dwordsInBuffer];
+            for (int group = 0; group < groupCount; ++group)
             {
-                for (int wave = 0; wave < 2; ++wave)
+                for (int wave = 0; wave < wavesPerGroup; ++wave)
                 {
-                    for (int lane = 0; lane < 64; ++lane)
+                    for (int lane = 0; lane < waveSize; ++lane)
                     {
-                        int flatLaneIdx = group * 128 + wave * 64 + lane;
-                        int laneDataOffset = 4 * flatLaneIdx;
-                        data[laneDataOffset + 0] = flatLaneIdx; // system = global id
-                        data[laneDataOffset + 1] = lane;        // first watch = local id
-                        data[laneDataOffset + 2] = group;       // second watch = group id
-                        data[laneDataOffset + 3] = 128;         // third watch = group size (constant 128)
+                        int instanceId = group; // group 0 is instance 0, group 1 is instance 1
+                        int globalId = (group * wavesPerGroup + wave) * waveSize + lane;
+                        int threadId = wave * waveSize + lane;
+                        int laneDataOffset = dwordsPerLane * globalId;
+                        data[laneDataOffset + 0] = instanceId; // system = instance id
+                        switch (instanceId)
+                        {
+                            case 0:
+                                data[laneDataOffset + 1] = threadId;
+                                data[laneDataOffset + 2] = globalId;
+                                data[laneDataOffset + 3] = globalId << 2;
+                                break;
+                            case 1:
+                                data[laneDataOffset + 1] = globalId << 8;
+                                data[laneDataOffset + 2] = globalId << 4;
+                                data[laneDataOffset + 3] = globalId;
+                                data[laneDataOffset + 4] = threadId;
+                                break;
+                        }
                     }
                 }
             }
-            var group1Bin = new byte[sizeof(int) * 512];
-            Buffer.BlockCopy(data, 0, group1Bin, 0, group1Bin.Length);
-            var group2Bin = new byte[sizeof(int) * 512];
-            Buffer.BlockCopy(data, group1Bin.Length, group2Bin, 0, group2Bin.Length);
-
-            // Group 1
-            channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful, Data = group1Bin },
-                (command) =>
-                {
-                    Assert.Equal(0, command.ByteOffset);
-                    Assert.Equal(2048, command.ByteCount);
-                });
-            var warning = await breakStateData.ChangeGroupWithWarningsAsync(channel.Object, groupIndex: 0, groupSize: 128, waveSize: 64, nGroups: 2);
-            Assert.Null(warning);
-
-            var system = breakStateData.GetSystem();
-            for (var i = 0; i < 128; ++i)
-                Assert.Equal(i, (int)system[i]);
-            var watchLocalId = breakStateData.GetWatch("local_id");
-            for (var i = 0; i < 128; ++i)
-                Assert.Equal(i % 64, (int)watchLocalId[i]);
-            var watchGroupId = breakStateData.GetWatch("group_id");
-            for (var i = 0; i < 128; ++i)
-                Assert.Equal(0, (int)watchGroupId[i]);
-            var watchGroupSize = breakStateData.GetWatch("group_size");
-            for (var i = 0; i < 128; ++i)
-                Assert.Equal(128, (int)watchGroupSize[i]);
-
-            // Group 2
-            channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful, Data = group2Bin },
-                (command) =>
-                {
-                    Assert.Equal(2048, command.ByteOffset);
-                    Assert.Equal(2048, command.ByteCount);
-                });
-            warning = await breakStateData.ChangeGroupWithWarningsAsync(channel.Object, groupIndex: 1, groupSize: 128, waveSize: 64, nGroups: 2);
-            Assert.Null(warning);
-
-            system = breakStateData.GetSystem();
-            for (var i = 0; i < 128; ++i)
-                Assert.Equal(128 + i, (int)system[i]);
-            watchLocalId = breakStateData.GetWatch("local_id");
-            for (var i = 0; i < 128; ++i)
-                Assert.Equal(i % 64, (int)watchLocalId[i]);
-            watchGroupId = breakStateData.GetWatch("group_id");
-            for (var i = 0; i < 128; ++i)
-                Assert.Equal(1, (int)watchGroupId[i]);
-            watchGroupSize = breakStateData.GetWatch("group_size");
-            for (var i = 0; i < 128; ++i)
-                Assert.Equal(128, (int)watchGroupSize[i]);
-
-            // Switching to a smaller group that was already fetched doesn't send any requests
-            // Group 1 of size 64 = second half of group 1 of size 128
-            warning = await breakStateData.ChangeGroupWithWarningsAsync(channel.Object, groupIndex: 1, groupSize: 64, waveSize: 64, nGroups: 2);
-            Assert.Null(warning);
-
-            system = breakStateData.GetSystem();
-            for (var i = 0; i < 64; ++i)
-                Assert.Equal(64 + i, (int)system[i]);
-            watchLocalId = breakStateData.GetWatch("local_id");
-            for (var i = 0; i < 64; ++i)
-                Assert.Equal(i % 64, (int)watchLocalId[i]);
-            watchGroupId = breakStateData.GetWatch("group_id");
-            for (var i = 0; i < 64; ++i)
-                Assert.Equal(0, (int)watchGroupId[i]);
-            watchGroupSize = breakStateData.GetWatch("group_size");
-            for (var i = 0; i < 64; ++i)
-                Assert.Equal(128, (int)watchGroupSize[i]);
-        }
-
-        [Fact]
-        public async Task IncompleteGroupTestAsync() /* Incomplete group: group size % wave size != 0 */
-        {
-            var waveSize = 64;
-            var groupSize = 65;
-            var groupCount = 3;
-            var paddedGroupSize = 128; // two waves per group
-            var laneCount = 384; // groupCount * paddedGroupSize
-            var watchCount = 2; // system + 1 watch
-
-            var channel = new MockCommunicationChannel();
-            var watches = new ReadOnlyCollection<string>(new[] { "local_id" });
-            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "madoka" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: watchCount * laneCount);
-            var breakStateData = new BreakStateData(watches, file);
-
-            Assert.Equal(groupCount, breakStateData.GetGroupCount(groupSize, waveSize, 0));
-
-            var data = new int[watchCount * laneCount];
-            for (int i = 0; i < laneCount; ++i)
+            for (int group = 0; group < groupCount; ++group)
             {
-                data[watchCount * i + 0] = i; // system = global id
-                data[watchCount * i + 1] = i % paddedGroupSize; // first watch = local id
+                var groupByteSize = sizeof(int) * dwordsPerGroup;
+                var groupBin = new byte[groupByteSize];
+                Buffer.BlockCopy(data, group * groupByteSize, groupBin, 0, groupByteSize);
+                channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful, Data = groupBin },
+                    (command) =>
+                    {
+                        Assert.Equal(group * groupByteSize, command.ByteOffset);
+                        Assert.Equal(groupByteSize, command.ByteCount);
+                    });
+                var warning = await breakStateData.ChangeGroupWithWarningsAsync(channel.Object, groupIndex: group, groupSize: groupSize, waveSize: waveSize, nGroups: groupCount);
+                Assert.Null(warning);
+
+                var waves = breakStateData.GetWaveViews().ToArray();
+                Assert.Equal(wavesPerGroup, waves.Length);
+                for (var wave = 0; wave < wavesPerGroup; ++wave)
+                {
+                    Assert.Equal(waveSize, waves[wave].WaveSize);
+                    Assert.Equal(wave * waveSize, waves[wave].StartThreadId);
+                    Assert.Equal(Math.Min((wave + 1) * waveSize, groupSize), waves[wave].EndThreadId);
+                    for (var lane = 0; lane < waveSize; ++lane)
+                    {
+                        int globalId = (group * wavesPerGroup + wave) * waveSize + lane, threadId = wave * waveSize + lane;
+
+                        var systemData = waves[wave].GetSystem().ToArray();
+                        Assert.Equal((uint)group, systemData[lane]);
+
+                        var globalIdData = waves[wave].GetWatchOrNull("GlobalID").ToArray();
+                        Assert.Equal((uint)globalId, globalIdData[lane]);
+
+                        var threadIdData = waves[wave].GetWatchOrNull("ThreadID").ToArray();
+                        Assert.Equal((uint)threadId, threadIdData[lane]);
+
+                        switch (group)
+                        {
+                            case 0:
+                                var globalIdShl2Data = waves[wave].GetWatchOrNull("GlobalID<<2").ToArray();
+                                Assert.Equal((uint)globalId << 2, globalIdShl2Data[lane]);
+
+                                Assert.Null(waves[wave].GetWatchOrNull("GlobalID<<4"));
+
+                                Assert.Null(waves[wave].GetWatchOrNull("GlobalID<<8"));
+                                break;
+                            case 1:
+                                Assert.Null(waves[wave].GetWatchOrNull("GlobalID<<2"));
+
+                                var globalIdShl4Data = waves[wave].GetWatchOrNull("GlobalID<<4").ToArray();
+                                Assert.Equal((uint)globalId << 4, globalIdShl4Data[lane]);
+
+                                var globalIdShl8Data = waves[wave].GetWatchOrNull("GlobalID<<8").ToArray();
+                                Assert.Equal((uint)globalId << 8, globalIdShl8Data[lane]);
+                                break;
+                        }
+                    }
+                }
             }
-
-            // Group #2 starts at 256
-            var requestedGroupIndex = 2;
-
-            var requestedData = new byte[watchCount * paddedGroupSize * sizeof(int)];
-            Buffer.BlockCopy(data, watchCount * paddedGroupSize * requestedGroupIndex * sizeof(int), requestedData, 0, requestedData.Length);
-            channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful, Data = requestedData },
-                (command) =>
-                {
-                    Assert.Equal(2 * 128 * 2 * 4, command.ByteOffset);
-                    Assert.Equal(2 * 128 * 4, command.ByteCount);
-                });
-            var warning = await breakStateData.ChangeGroupWithWarningsAsync(channel.Object, groupIndex: requestedGroupIndex, groupSize: groupSize, waveSize: waveSize, nGroups: groupCount);
-            Assert.Null(warning);
-
-            var system = breakStateData.GetSystem();
-            var watch = breakStateData.GetWatch("local_id");
-            for (var i = 0; i < groupSize; ++i)
             {
-                Assert.Equal(paddedGroupSize * requestedGroupIndex + i, (int)system[i]);
-                Assert.Equal(i, (int)watch[i]);
+                // Switching to a smaller group that was already fetched doesn't send any requests
+                var warning = await breakStateData.ChangeGroupWithWarningsAsync(channel.Object, groupIndex: 1, groupSize: groupSize / 2, waveSize: waveSize, nGroups: wavesPerGroup);
+                Assert.Null(warning);
             }
         }
 
@@ -156,9 +128,9 @@ namespace VSRAD.PackageTests.Server
         public async Task EmptyResultRangeTestAsync()
         {
             var channel = new MockCommunicationChannel();
-            var watches = new ReadOnlyCollection<string>(new[] { "F16" });
+            var instanceWatches = new Dictionary<uint, string[]> { { 0, new[] { "ThreadID" } } };
             var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "log.tar" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
-            var breakStateData = new BreakStateData(watches, file);
+            var breakStateData = new BreakStateData(instanceWatches, file);
 
             channel.ThenRespond<FetchResultRange, ResultRangeFetched>(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Array.Empty<byte>() },
             (command) =>
@@ -168,16 +140,23 @@ namespace VSRAD.PackageTests.Server
             var warning = await breakStateData.ChangeGroupWithWarningsAsync(channel.Object, groupIndex: 0, groupSize: 512, waveSize: 64, nGroups: 1);
             Assert.Equal("Group #0 is incomplete: expected to read 4096 bytes but the output file contains 0.", warning);
             // Data is set to 0 if unavailable
-            Assert.Equal(0u, breakStateData.GetSystem()[0]);
+            foreach (var wave in breakStateData.GetWaveViews())
+            {
+                for (var i = 0; i < breakStateData.WaveSize; ++i)
+                {
+                    Assert.Equal(0u, wave.GetSystem().ElementAt(i));
+                    Assert.Equal(0u, wave.GetWatchOrNull("ThreadID").ElementAt(i));
+                }
+            }
         }
 
         [Fact]
         public async Task NGroupViolationProducesAWarningButFetchesResultsTestAsync()
         {
             var channel = new MockCommunicationChannel();
-            var watches = new ReadOnlyCollection<string>(new[] { "F16" });
+            var instanceWatches = new Dictionary<uint, string[]> { { 0, new[] { "ThreadID" } } };
             var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "log.tar" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: 1024);
-            var breakStateData = new BreakStateData(watches, file);
+            var breakStateData = new BreakStateData(instanceWatches, file);
 
             Assert.Equal(2, breakStateData.GetGroupCount(groupSize: 256, waveSize: 64, nGroups: 4));
 
@@ -190,29 +169,37 @@ namespace VSRAD.PackageTests.Server
         [Fact]
         public async Task BreakStateWithLocalDataTestAsync()
         {
-            var data = new int[2 * 256];
-            for (int i = 0; i < 256; ++i)
+            int instanceId = 123456;
+            int waveSize = 32, groupSize = 64, nGroups = 2, dwordsPerLane = 3;
+
+            var data = new int[groupSize * nGroups * dwordsPerLane];
+            for (var gid = 0; gid < nGroups; ++gid)
             {
-                data[2 * i + 0] = i; // system = global id
-                data[2 * i + 1] = i % 32; // first watch = local id
+                for (var tid = 0; tid < groupSize; ++tid)
+                {
+                    data[(gid * groupSize + tid) * dwordsPerLane + 0] = instanceId;
+                    data[(gid * groupSize + tid) * dwordsPerLane + 1] = gid * groupSize + tid;
+                    data[(gid * groupSize + tid) * dwordsPerLane + 2] = tid;
+                }
             }
 
-            var localData = new byte[2 * 256 * sizeof(int)];
+            var localData = new byte[data.Length * sizeof(int)];
             Buffer.BlockCopy(data, 0, localData, 0, localData.Length);
 
-            var watches = new ReadOnlyCollection<string>(new[] { "local_id" });
-            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "madoka" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: 2 * 256);
-            var breakStateData = new BreakStateData(watches, file, localData);
+            var instanceWatches = new Dictionary<uint, string[]> { { (uint)instanceId, new[] { "GlobalID", "ThreadID" } } };
+            var file = new BreakStateOutputFile(new[] { "/home/kyubey/projects", "log.tar" }, binaryOutput: true, offset: 0, timestamp: default, dwordCount: data.Length);
+            var breakStateData = new BreakStateData(instanceWatches, file, localData);
 
-            var warning = await breakStateData.ChangeGroupWithWarningsAsync(channel: null, groupIndex: 1, groupSize: 64, waveSize: 32, nGroups: 2);
+            var groupId = 1;
+            var warning = await breakStateData.ChangeGroupWithWarningsAsync(channel: null, groupIndex: groupId, groupSize: groupSize, waveSize: waveSize, nGroups: nGroups);
             Assert.Null(warning);
 
-            var system = breakStateData.GetSystem();
-            var localIdWatch = breakStateData.GetWatch("local_id");
-            for (var i = 0; i < 64; ++i)
+            for (var tid = 0; tid < groupSize; ++tid)
             {
-                Assert.Equal(64 + i, (int)system[i]);
-                Assert.Equal(i % 32, (int)localIdWatch[i]);
+                var wave = breakStateData.GetWaveViews().ElementAt(tid / waveSize);
+                Assert.Equal(instanceId, (int)wave.GetSystem().ElementAt(tid % waveSize));
+                Assert.Equal(groupId * groupSize + tid, (int)wave.GetWatchOrNull("GlobalID").ElementAt(tid % waveSize));
+                Assert.Equal(tid, (int)wave.GetWatchOrNull("ThreadID").ElementAt(tid % waveSize));
             }
         }
 

--- a/VSRAD.ProjectTemplate/RADProject.radproj.user.json
+++ b/VSRAD.ProjectTemplate/RADProject.radproj.user.json
@@ -53,7 +53,7 @@
             },
             "Debugger": {
                 "Executable": "bash",
-                "Arguments": "$(RadDebugWorkDir)/common/debugger/vadd_debug.sh -l $(RadBreakLine) -f $(RadDeployDir)/$(RadActiveSourceFile) -w $(RadWatches) -t $(RadCounter) -o $(RadDebugDataOutputPath)",
+                "Arguments": "$(RadDebugWorkDir)/common/debugger/vadd_debug.sh -l $(RadBreakLines) -f $(RadDeployDir)/$(RadActiveSourceFile) -w $(RadWatches) -t $(RadCounter) -o $(RadDebugDataOutputPath)",
                 "WorkingDirectory": "/home/stud/radeon-asm-debugger-example",
                 "OutputPath": "$(RadDebugWorkDir)/tmp_dir/debug_result",
                 "BinaryOutput": true,


### PR DESCRIPTION
* Breakpoints can have multiple instances, valid watches are different between instances
* Different waves can break at different instances, so each wave now has its own set of watches
* Waves are allocated the same number of dwords (equal to the maximum number of watches per instance). The same watch may have different offsets in different instances
* Watch and break line separator in macros is changed from a colon to a semicolon
* Nested ReadDebugData steps in actions now work properly