### PR TITLE
Minor watch editor fixes

### DIFF
--- a/VSRAD.Package/DebugVisualizer/CellStyling.cs
+++ b/VSRAD.Package/DebugVisualizer/CellStyling.cs
@@ -61,7 +61,7 @@ namespace VSRAD.Package.DebugVisualizer
 
         private void PaintInvalidWatchName(DataGridViewCellPaintingEventArgs e)
         {
-            if (e.ColumnIndex == VisualizerTable.NameColumnIndex && e.Value is string watchName && !string.IsNullOrEmpty(watchName) && !Watch.IsWatchNameValid(watchName))
+            if (e.ColumnIndex == VisualizerTable.NameColumnIndex && e.Value is string watchName && !string.IsNullOrWhiteSpace(watchName) && !Watch.IsWatchNameValid(watchName))
                 e.CellStyle.BackColor = Color.Red;
         }
 

--- a/VSRAD.Package/DebugVisualizer/VariableType.cs
+++ b/VSRAD.Package/DebugVisualizer/VariableType.cs
@@ -59,6 +59,9 @@ namespace VSRAD.Package.DebugVisualizer
 
         public static VariableType TypeFromShortName(string shortName)
         {
+            if (string.IsNullOrEmpty(shortName))
+                return new VariableType(VariableCategory.Hex, 32);
+
             switch (shortName[0])
             {
                 case 'B':

--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -157,9 +157,9 @@ To switch to manual grid size selection, right-click on the space next to the Gr
         private void SetRowContentsFromBreakState(System.Windows.Forms.DataGridViewRow row)
         {
             var watch = (string)row.Cells[VisualizerTable.NameColumnIndex].Value;
-            if (_context.BreakData != null && !string.IsNullOrEmpty(watch))
+            if (_context.BreakData != null && watch != null)
             {
-                var watchType = VariableTypeUtils.TypeFromShortName(row.HeaderCell.Value.ToString());
+                var watchType = VariableTypeUtils.TypeFromShortName((string)row.HeaderCell.Value);
                 var binHexSeparator = _context.Options.VisualizerAppearance.BinHexSeparator;
                 var intSeparator = _context.Options.VisualizerAppearance.IntUintSeparator;
                 var leadingZeroes = _context.Options.VisualizerAppearance.BinHexLeadingZeroes;


### PR DESCRIPTION
* Commit watch edits whenever the cell loses focus (previously Enter was required to be pressed, otherwise the edits were discarded)
* Fix the behavior of divider rows, which got broken by #358