### PR TITLE
Added support for resumable breakpoints

### DIFF
--- a/VSRAD.Package/Commands/BreakpointMenuCommand.cs
+++ b/VSRAD.Package/Commands/BreakpointMenuCommand.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.Shell;
 using System;
 using System.ComponentModel.Composition;
 using VSRAD.Package.Utils;
+using VSRAD.Package.ProjectSystem;
 
 namespace VSRAD.Package.Commands
 {
@@ -14,11 +15,16 @@ namespace VSRAD.Package.Commands
     public sealed class BreakpointMenuCommand : ICommandHandler
     {
         private readonly SVsServiceProvider _serviceProvider;
+        private readonly IActiveCodeEditor _codeEditor;
+        private readonly IBreakpointTracker _breakpointTracker;
 
         [ImportingConstructor]
-        public BreakpointMenuCommand(SVsServiceProvider serviceProvider)
+        public BreakpointMenuCommand(SVsServiceProvider serviceProvider, IActiveCodeEditor codeEditor, IBreakpointTracker breakpointTracker)
         {
             _serviceProvider = serviceProvider;
+            _codeEditor = codeEditor;
+            _breakpointTracker = breakpointTracker;
+
         }
 
         public Guid CommandSet => Constants.BreakpointMenuCommandSet;
@@ -32,16 +38,40 @@ namespace VSRAD.Package.Commands
             var flags = OleCommandText.GetFlags(commandText);
 
             if (commandId == Constants.BreakpointMenuToggleResumable)
-                return OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED | OLECMDF.OLECMDF_LATCHED;
-
+            {
+                var line = _codeEditor.GetCurrentLine() + 1;
+                var file = _codeEditor.GetAbsoluteSourcePath();
+                var resumable = _breakpointTracker.GetResumableState(file, line) ? OLECMDF.OLECMDF_LATCHED : 0;
+                return OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED | resumable;
+            }
+                
             return OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED;
         }
 
         public void Execute(uint commandId, uint commandExecOpt, IntPtr variantIn, IntPtr variantOut)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            var file = _codeEditor.GetAbsoluteSourcePath();
+            var line = _codeEditor.GetCurrentLine() + 1;
             if (commandId == Constants.BreakpointMenuToggleResumable)
             {
+                var resumable = _breakpointTracker.GetResumableState(file, line);
+                _breakpointTracker.SetResumableState(file, line, !resumable);
+            }
+            else if (commandId == Constants.BreakpointMenuAllToResumable || commandId == Constants.BreakpointMenuAllToUnresumable) 
+            {
+                var dte = _serviceProvider.GetService(typeof(DTE)) as DTE;
+                Assumes.Present(dte);
 
+                bool state = commandId == Constants.BreakpointMenuAllToResumable ? true : false;
+                foreach (Breakpoint br in dte.Debugger.Breakpoints)
+                {
+                    if (br.File == file)
+                    {
+                        _breakpointTracker.SetResumableState(br.File, (uint)br.FileLine, state);
+                    }
+                }
+               
             }
         }
     }

--- a/VSRAD.Package/Commands/BreakpointMenuCommand.cs
+++ b/VSRAD.Package/Commands/BreakpointMenuCommand.cs
@@ -1,0 +1,48 @@
+﻿using EnvDTE;
+using Microsoft;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.ComponentModel.Composition;
+using VSRAD.Package.Utils;
+
+namespace VSRAD.Package.Commands
+{
+    [Export(typeof(ICommandHandler))]
+    [AppliesTo(Constants.RadOrVisualCProjectCapability)]
+    public sealed class BreakpointMenuCommand : ICommandHandler
+    {
+        private readonly SVsServiceProvider _serviceProvider;
+
+        [ImportingConstructor]
+        public BreakpointMenuCommand(SVsServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public Guid CommandSet => Constants.BreakpointMenuCommandSet;
+
+        public OLECMDF GetCommandStatus(uint commandId, IntPtr commandText)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            var dte = _serviceProvider.GetService(typeof(DTE)) as DTE;
+            Assumes.Present(dte);
+
+            var flags = OleCommandText.GetFlags(commandText);
+
+            if (commandId == Constants.BreakpointMenuToggleResumable)
+                return OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED | OLECMDF.OLECMDF_LATCHED;
+
+            return OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED;
+        }
+
+        public void Execute(uint commandId, uint commandExecOpt, IntPtr variantIn, IntPtr variantOut)
+        {
+            if (commandId == Constants.BreakpointMenuToggleResumable)
+            {
+
+            }
+        }
+    }
+}

--- a/VSRAD.Package/Constants.cs
+++ b/VSRAD.Package/Constants.cs
@@ -42,6 +42,7 @@ namespace VSRAD.Package
         public const int ProfileTargetMachineDropdownListId = 0x100;
         public const int BreakModeDropdownId = 0x11;
         public const int BreakModeDropdownListId = 0x101;
+        public const int BreakpointMenuToggleResumable = 0x1020;
         public static readonly Guid ToolWindowCommandSet = new Guid("03c8f3ba-2e44-4159-ac37-b08fc295a0cc");
         public static readonly Guid ForceRunToCursorCommandSet = new Guid("cefc8250-7cd1-46c1-b4f6-46a0a22a1c81");
         public static readonly Guid AddToWatchesCommandSet = new Guid("8560BD12-1D31-40BA-B300-1A31FC901E93");
@@ -50,6 +51,7 @@ namespace VSRAD.Package
         public static readonly Guid ActionsMenuCommandSet = new Guid("7CF54FFE-BCAC-4751-BEEC-D103FD953C8B");
         public static readonly Guid ProfileDropdownCommandSet = new Guid("912C011A-EDAA-4922-85F2-74436F2265CA");
         public static readonly Guid BreakModeDropdownCommandSet = new Guid("EADE0887-3138-4DBF-8A14-FCEB0017E5E8");
+        public static readonly Guid BreakpointMenuCommandSet = new Guid("D0D94348-11C2-4ED2-8A89-D8D10862DABA");
 
         public const string OutputPaneServerTitle = "RAD Debug Server";
         public const string OutputPaneServerId = "A183AE1B-765F-4804-B188-9E1543C4B954";

--- a/VSRAD.Package/Constants.cs
+++ b/VSRAD.Package/Constants.cs
@@ -43,6 +43,8 @@ namespace VSRAD.Package
         public const int BreakModeDropdownId = 0x11;
         public const int BreakModeDropdownListId = 0x101;
         public const int BreakpointMenuToggleResumable = 0x1020;
+        public const int BreakpointMenuAllToResumable = 0x1021;
+        public const int BreakpointMenuAllToUnresumable = 0x1022;
         public static readonly Guid ToolWindowCommandSet = new Guid("03c8f3ba-2e44-4159-ac37-b08fc295a0cc");
         public static readonly Guid ForceRunToCursorCommandSet = new Guid("cefc8250-7cd1-46c1-b4f6-46a0a22a1c81");
         public static readonly Guid AddToWatchesCommandSet = new Guid("8560BD12-1D31-40BA-B300-1A31FC901E93");

--- a/VSRAD.Package/DebugVisualizer/Breakpoint.cs
+++ b/VSRAD.Package/DebugVisualizer/Breakpoint.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+
+namespace VSRAD.Package.DebugVisualizer
+{
+    public struct Breakpoint : System.IEquatable<Breakpoint>
+    {
+        public string File { get; }
+
+        public uint Line { get; }
+
+        public bool Resumable { get; set; }
+
+        [JsonConstructor]
+        public Breakpoint(string file, uint line, bool resumable)
+        {
+            File = file;
+            Line = line;
+            Resumable = resumable;
+        }
+
+        public bool Equals(Breakpoint br) => File == br.File && Line == br.Line && Resumable == br.Resumable;
+        public override bool Equals(object o) => o is Breakpoint br && Equals(br);
+        public override int GetHashCode() => (File, Line, Resumable).GetHashCode();
+        public static bool operator ==(Breakpoint left, Breakpoint right) => left.Equals(right);
+        public static bool operator !=(Breakpoint left, Breakpoint right) => !(left == right);
+    }
+}

--- a/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
+++ b/VSRAD.Package/ProjectSystem/Macros/MacroEvaluator.cs
@@ -85,6 +85,7 @@ namespace VSRAD.Package.ProjectSystem.Macros
 
         public const string WatchSeparator = ";";
         public const string BreakLineSeparator = ";";
+        public const string BreakStateSeparator = ":";
 
         public const string BuildExecutable = "RadBuildExe";
         public const string BuildArguments = "RadBuildArgs";
@@ -161,7 +162,16 @@ namespace VSRAD.Package.ProjectSystem.Macros
                 case RadMacros.GroupSize: value = _debuggerOptions.GroupSize.ToString(); break;
                 case RadMacros.BreakLines:
                     if (_transientValues.BreakLines.TryGetResult(out var breakLines, out var error))
-                        value = string.Join(RadMacros.BreakLineSeparator, breakLines);
+                    {
+                        List<string> breakpoints = new List<string>();
+
+                        foreach (var line in breakLines)
+                        {
+                            bool resumeState = _debuggerOptions.FindBreakpoint(_transientValues.ActiveSourceFullPath, line + 1).Resumable;
+                            breakpoints.Add(line + RadMacros.BreakStateSeparator + (resumeState ? 1 : 0));
+                        }
+                        value = string.Join(RadMacros.BreakLineSeparator, breakpoints);
+                    }
                     else
                         return error;
                     break;

--- a/VSRAD.Package/ToolWindows/OptionsControl.xaml
+++ b/VSRAD.Package/ToolWindows/OptionsControl.xaml
@@ -105,6 +105,13 @@
                     <CheckBox Content="Open in Editor: Preserve active document" VerticalAlignment="Center" Padding="4,0,0,0"
                                 IsChecked="{Binding Options.DebuggerOptions.PreserveActiveDoc, UpdateSourceTrigger=PropertyChanged}"/>
                 </StackPanel>
+                <StackPanel Orientation="Horizontal" Height="25">
+                    <TextBlock Text="Default state for new breakpoints:" VerticalAlignment="Center"/>
+                    <ComboBox VerticalAlignment="Center" Margin="5,0,0,0">
+                        <ComboBoxItem Content="Resumable" IsSelected="{Binding Options.DebuggerOptions.ResumableDefaultValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                        <ComboBoxItem Content="Non-resumable" IsSelected="{Binding !Options.DebuggerOptions.ResumableDefaultValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                    </ComboBox>
+                </StackPanel>
                 <Expander Header="Visualizer Appearance" Margin="0,8,0,0">
                     <StackPanel Margin="0,6,0,0">
                         <StackPanel Orientation="Horizontal" Height="25">

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Commands\BaseCommand.cs" />
     <Compile Include="Commands\BaseRemoteCommand.cs" />
     <Compile Include="Commands\BreakModeDropdownCommand.cs" />
+    <Compile Include="Commands\BreakpointMenuCommand.cs" />
     <Compile Include="Commands\CommandRouter.cs" />
     <Compile Include="Commands\ProfileDropdownCommand.cs" />
     <Compile Include="Commands\ToolWindowCommand.cs" />

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -183,6 +183,7 @@
       <DependentUpon>VisualizerHeaderControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="DebugVisualizer\VisualizerTableHost.cs" />
+    <Compile Include="DebugVisualizer\Breakpoint.cs" />
     <Compile Include="DebugVisualizer\Watch.cs" />
     <Compile Include="BuildTools\BuildToolsServer.cs" />
     <Compile Include="DebugVisualizer\Wavemap\WavemapOffsetInput.xaml.cs">

--- a/VSRAD.Package/VSRAD.Package.tt
+++ b/VSRAD.Package/VSRAD.Package.tt
@@ -9,6 +9,10 @@
   <!--This header contains the command ids for the menus provided by the shell. -->
   <Extern href="vsshlids.h" />
 
+  <!--These headers contain the GUIDs and command ids for the debug menus provided by the shell. -->
+  <Extern href="VSDbgCmd.h"/>
+  <Extern href="VsDebugGuids.h"/>
+
   <Commands package="guidVSPackage">
     <Menus>
       <!-- Tools -> RAD Debug -->
@@ -208,6 +212,13 @@
           <ButtonText>Evaluate Selected</ButtonText>
         </Strings>
       </Button>-->
+      <Button guid="guidCmdSetBreakpointMenu" id="BreakpointMenuToggleResumable" priority="0x10">
+        <Parent guid="guidVSDebugGroup" id="IDG_BREAKPOINT_CONTEXT_MODIFY" />
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Resume execution after break</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
 
     <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->
@@ -342,6 +353,10 @@
       <IDSymbol value="0x<#= (0x1400 + i * 0x100 + j).ToString("x") #>" name="AddArrayToWatchesFrom<#=i #>To<#= j #>Id" />
 <# } #>
 <# } #>
+    </GuidSymbol>
+
+    <GuidSymbol name="guidCmdSetBreakpointMenu" value="{D0D94348-11C2-4ED2-8A89-D8D10862DABA}">
+	  <IDSymbol value="0x1020" name="BreakpointMenuToggleResumable" />
     </GuidSymbol>
 
     <!--<GuidSymbol name="guidCmdEvaluateSelected" value="{6624A31D-4C20-4675-84D7-67D140842579}">

--- a/VSRAD.Package/VSRAD.Package.tt
+++ b/VSRAD.Package/VSRAD.Package.tt
@@ -219,6 +219,20 @@
           <ButtonText>Resume execution after break</ButtonText>
         </Strings>
       </Button>
+	 <Button guid="guidCmdSetBreakpointMenu" id="BreakpointMenuAllToResumable" priority="0x10">
+		<Parent guid="guidVSDebugGroup" id="IDG_BREAKPOINT_CONTEXT_MODIFY" />
+		<CommandFlag>DynamicVisibility</CommandFlag>
+		<Strings>
+			<ButtonText>Set all breakpoints to resumable</ButtonText>
+		</Strings>
+	 </Button>
+	 <Button guid="guidCmdSetBreakpointMenu" id="BreakpointMenuAllToUnresumable" priority="0x10">
+		<Parent guid="guidVSDebugGroup" id="IDG_BREAKPOINT_CONTEXT_MODIFY" />
+		<CommandFlag>DynamicVisibility</CommandFlag>
+		<Strings>
+			<ButtonText>Set all breakpoints to non-resumable</ButtonText>
+		</Strings>
+	 </Button>
     </Buttons>
 
     <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->
@@ -357,6 +371,8 @@
 
     <GuidSymbol name="guidCmdSetBreakpointMenu" value="{D0D94348-11C2-4ED2-8A89-D8D10862DABA}">
 	  <IDSymbol value="0x1020" name="BreakpointMenuToggleResumable" />
+	  <IDSymbol value="0x1021" name="BreakpointMenuAllToResumable" />
+	  <IDSymbol value="0x1022" name="BreakpointMenuAllToUnresumable" />
     </GuidSymbol>
 
     <!--<GuidSymbol name="guidCmdEvaluateSelected" value="{6624A31D-4C20-4675-84D7-67D140842579}">

--- a/VSRAD.Package/VSRAD.Package.vsct
+++ b/VSRAD.Package/VSRAD.Package.vsct
@@ -1366,6 +1366,20 @@
           <ButtonText>Resume execution after break</ButtonText>
         </Strings>
       </Button>
+	 <Button guid="guidCmdSetBreakpointMenu" id="BreakpointMenuAllToResumable" priority="0x10">
+		<Parent guid="guidVSDebugGroup" id="IDG_BREAKPOINT_CONTEXT_MODIFY" />
+		<CommandFlag>DynamicVisibility</CommandFlag>
+		<Strings>
+			<ButtonText>Set all breakpoints to resumable</ButtonText>
+		</Strings>
+	 </Button>
+	 <Button guid="guidCmdSetBreakpointMenu" id="BreakpointMenuAllToUnresumable" priority="0x10">
+		<Parent guid="guidVSDebugGroup" id="IDG_BREAKPOINT_CONTEXT_MODIFY" />
+		<CommandFlag>DynamicVisibility</CommandFlag>
+		<Strings>
+			<ButtonText>Set all breakpoints to non-resumable</ButtonText>
+		</Strings>
+	 </Button>
     </Buttons>
 
     <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->
@@ -1723,6 +1737,8 @@
 
     <GuidSymbol name="guidCmdSetBreakpointMenu" value="{D0D94348-11C2-4ED2-8A89-D8D10862DABA}">
 	  <IDSymbol value="0x1020" name="BreakpointMenuToggleResumable" />
+	  <IDSymbol value="0x1021" name="BreakpointMenuAllToResumable" />
+	  <IDSymbol value="0x1022" name="BreakpointMenuAllToUnresumable" />
     </GuidSymbol>
 
     <!--<GuidSymbol name="guidCmdEvaluateSelected" value="{6624A31D-4C20-4675-84D7-67D140842579}">

--- a/VSRAD.Package/VSRAD.Package.vsct
+++ b/VSRAD.Package/VSRAD.Package.vsct
@@ -7,6 +7,10 @@
   <!--This header contains the command ids for the menus provided by the shell. -->
   <Extern href="vsshlids.h" />
 
+  <!--These headers contain the GUIDs and command ids for the debug menus provided by the shell. -->
+  <Extern href="VSDbgCmd.h"/>
+  <Extern href="VsDebugGuids.h"/>
+
   <Commands package="guidVSPackage">
     <Menus>
       <!-- Tools -> RAD Debug -->
@@ -1355,6 +1359,13 @@
           <ButtonText>Evaluate Selected</ButtonText>
         </Strings>
       </Button>-->
+      <Button guid="guidCmdSetBreakpointMenu" id="BreakpointMenuToggleResumable" priority="0x10">
+        <Parent guid="guidVSDebugGroup" id="IDG_BREAKPOINT_CONTEXT_MODIFY" />
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Resume execution after break</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
 
     <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->
@@ -1708,6 +1719,10 @@
       <IDSymbol value="0x410f" name="AddArrayToWatchesMenuFrom15Group" />
       <IDSymbol value="0x120f" name="AddArrayToWatchesFrom15ToHeaderId" />
       <IDSymbol value="0x230f" name="AddArrayToWatchesFrom15To15Id" />
+    </GuidSymbol>
+
+    <GuidSymbol name="guidCmdSetBreakpointMenu" value="{D0D94348-11C2-4ED2-8A89-D8D10862DABA}">
+	  <IDSymbol value="0x1020" name="BreakpointMenuToggleResumable" />
     </GuidSymbol>
 
     <!--<GuidSymbol name="guidCmdEvaluateSelected" value="{6624A31D-4C20-4675-84D7-67D140842579}">

--- a/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
@@ -88,7 +88,7 @@ wave_size 64
             channel.ThenRespond(new ExecutionCompleted { Status = ExecutionStatus.Completed, ExitCode = 0 }, (Execute execute) =>
             {
                 Assert.Equal("ohmu", execute.Executable);
-                Assert.Equal(@"-break-line 666 -source JATO.s -source-line 13 -watch a;c;tide", execute.Arguments);
+                Assert.Equal(@"-break-line 666:0 -source JATO.s -source-line 13 -watch a;c;tide", execute.Arguments);
             });
             channel.ThenRespond(new ResultRangeFetched { Status = FetchStatus.Successful, Data = Encoding.UTF8.GetBytes(validWatchesString) }, (FetchResultRange watchesFetch) =>
                 Assert.Equal(new[] { "/periphery/votw", "watches-path" }, watchesFetch.FilePath));

--- a/VSRAD.PackageTests/ProjectSystem/Macros/MacroEvaluatorTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/Macros/MacroEvaluatorTests.cs
@@ -58,13 +58,13 @@ namespace VSRAD.PackageTests.ProjectSystem.Macros
 
             result = await evaluator.EvaluateAsync($"$({RadMacros.ActiveSourceDir})\\$({RadMacros.ActiveSourceFile}):$({RadMacros.ActiveSourceFileLine}), stop at $({RadMacros.BreakLines})");
             Assert.True(result.TryGetResult(out evaluated, out _));
-            Assert.Equal(@"B:\welcome\home:666, stop at 13", evaluated);
+            Assert.Equal(@"B:\welcome\home:666, stop at 13:0", evaluated);
 
             transients = new MacroEvaluatorTransientValues(0, "nofile", new[] { 20u, 1u, 9u }, new ReadOnlyCollection<string>(new[] { "watch" }));
             evaluator = new MacroEvaluator(props.Object, transients, EmptyRemoteEnv, new DebuggerOptions(), new ProfileOptions());
             result = await evaluator.EvaluateAsync($"-l $({RadMacros.BreakLines})");
             Assert.True(result.TryGetResult(out evaluated, out _));
-            Assert.Equal("-l 20;1;9", evaluated);
+            Assert.Equal("-l 20:0;1:0;9:0", evaluated);
         }
 
         [Fact]


### PR DESCRIPTION
* Added BreakpointMenu with three buttons
  * Resume execution after break
  * Set all breakpoints to resumable
  * Set all breakpoints to non-resumable
* Added a checkbox to the settings that sets the default resumable value for new breakpoints
* Updated RadBreakLines macro
 * Now it returns this format `-l line0:resumable0;line1:resumable1`
 * The breakpoints state is now saved in the json config
 * Updated tests for the new RadBreakLines macro