### PR TITLE
Minor visualizer fixes

### DIFF
--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml.cs
@@ -209,7 +209,7 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                         }
                         else
                         {
-                            var label = (ListSize is uint listSize) ? $"<{listSize}>" : "";
+                            var label = (ListSize is uint listSize) ? $"[{listSize}]" : "";
                             for (var lane = 0; lane < _context.BreakData.WaveSize && tid < _context.BreakData.GroupSize; ++tid, ++lane)
                                 row.Cells[tid + VisualizerTable.DataColumnOffset].Value = label;
                         }
@@ -222,10 +222,10 @@ To switch to manual grid size selection, right-click on the space next to the Gr
                             && Enumerable.SequenceEqual(nextNameCell.ParentRows, nameCell.ParentRows.Append(row))))
                         {
                             _table.Rows.Insert(nextRowIndex);
-                            _table.Rows[nextRowIndex].Visible = nameCell.ListExpanded;
                             _table.Rows[nextRowIndex].HeaderCell.Value = VariableTypeUtils.ShortName(watchType); // Inherit watch type
                             ((WatchNameCell)_table.Rows[nextRowIndex].Cells[VisualizerTable.NameColumnIndex]).IndexInList = i;
                             ((WatchNameCell)_table.Rows[nextRowIndex].Cells[VisualizerTable.NameColumnIndex]).ParentRows.AddRange(nameCell.ParentRows.Append(row));
+                            ((WatchNameCell)_table.Rows[nextRowIndex].Cells[VisualizerTable.NameColumnIndex]).ExpandCollapse(nameCell.ListExpanded);
                         }
                         nChildRows += 1;
                         nChildRows += SetRowContentsFromBreakState(_table.Rows[nextRowIndex]);

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -626,6 +626,10 @@ namespace VSRAD.Package.DebugVisualizer
 
         private bool ShowColumnContextMenu(HitTestInfo hit, Point loc)
         {
+            EventHandler SelectPartialSubgroupsHandler(uint subgroupSize, uint displayedCount, bool displayLast)
+            {
+                return (s, e) => SelectPartialSubgroups(subgroupSize, displayedCount, displayLast);
+            }
             void SelectPartialSubgroups(uint subgroupSize, uint displayedCount, bool displayLast)
             {
                 string subgroupsSelector = ColumnSelector.PartialSubgroups(_options.DebuggerOptions.GroupSize, subgroupSize, displayedCount, displayLast);
@@ -649,32 +653,26 @@ namespace VSRAD.Package.DebugVisualizer
             {
                 var menu = new ContextMenu();
 
-                var groupSize = _options.DebuggerOptions.GroupSize;
+                var maxSubgroupSize = 512;
                 menu.MenuItems.Add(new MenuItem("Keep First") { Enabled = false });
-                for (uint keepFirst = 1; keepFirst <= groupSize / 2; keepFirst *= 2)
+                for (uint keepFirst = 1; keepFirst <= maxSubgroupSize / 2; keepFirst *= 2)
                 {
                     var submenu = new MenuItem($"{keepFirst}");
-                    for (uint subgroupSize = keepFirst * 2; subgroupSize <= groupSize; subgroupSize *= 2)
-                    {
-                        uint keepFirstCapture = keepFirst, subgroupSizeCapture = subgroupSize;
-                        submenu.MenuItems.Add(new MenuItem($"{subgroupSize}", (s, e) => SelectPartialSubgroups(subgroupSizeCapture, keepFirstCapture, displayLast: false)));
-                    }
+                    for (uint subgroupSize = keepFirst * 2; subgroupSize <= maxSubgroupSize; subgroupSize *= 2)
+                        submenu.MenuItems.Add(new MenuItem($"{subgroupSize}", SelectPartialSubgroupsHandler(subgroupSize, keepFirst, displayLast: false)));
                     menu.MenuItems.Add(submenu);
                 }
                 menu.MenuItems.Add(new MenuItem("-"));
                 var keepLastSubmenu = new MenuItem("Keep Last");
-                for (uint keepLast = 1; keepLast <= groupSize / 2; keepLast *= 2)
+                for (uint keepLast = 1; keepLast <= maxSubgroupSize / 2; keepLast *= 2)
                 {
                     var submenu = new MenuItem($"{keepLast}");
-                    for (uint subgroupSize = keepLast * 2; subgroupSize <= groupSize; subgroupSize *= 2)
-                    {
-                        uint keepLastCapture = keepLast, subgroupSizeCapture = subgroupSize;
-                        submenu.MenuItems.Add(new MenuItem($"{subgroupSize}", (s, e) => SelectPartialSubgroups(subgroupSizeCapture, keepLastCapture, displayLast: true)));
-                    }
+                    for (uint subgroupSize = keepLast * 2; subgroupSize <= maxSubgroupSize; subgroupSize *= 2)
+                        submenu.MenuItems.Add(new MenuItem($"{subgroupSize}", SelectPartialSubgroupsHandler(subgroupSize, keepLast, displayLast: true)));
                     keepLastSubmenu.MenuItems.Add(submenu);
                 }
                 menu.MenuItems.Add(keepLastSubmenu);
-                menu.MenuItems.Add(new MenuItem("Show All Columns", (s, e) => SetColumnSelector($"0-{groupSize - 1}")));
+                menu.MenuItems.Add(new MenuItem("Show All Columns", (s, e) => SetColumnSelector($"0-{_options.DebuggerOptions.GroupSize - 1}")));
                 menu.MenuItems.Add(new MenuItem("-"));
                 menu.MenuItems.Add(new MenuItem("Font Color", new[]
                 {

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -200,12 +200,6 @@ namespace VSRAD.Package.DebugVisualizer
             insertedRow.Cells[NameColumnIndex].Value = watch.Name;
             insertedRow.Cells[NameColumnIndex].ReadOnly = !canBeRemoved;
             insertedRow.HeaderCell.Value = watch.Info.ShortName();
-
-            var currentWidth = Columns[NameColumnIndex].Width;
-            var preferredWidth = Columns[NameColumnIndex].GetPreferredWidth(DataGridViewAutoSizeColumnMode.AllCells, true);
-            if (preferredWidth > currentWidth)
-                Columns[NameColumnIndex].Width = preferredWidth;
-
             return insertedRow;
         }
 
@@ -229,7 +223,7 @@ namespace VSRAD.Package.DebugVisualizer
                     var type = VariableTypeUtils.TypeFromShortName(row.HeaderCell.Value.ToString());
                     var parentIdxInUserRows = userWatchRows.IndexOf(nameCell.ParentRows[0]);
                     var rowIdxAfterParent = parentIdxInUserRows + 1 < userWatchRows.Count ? userWatchRows[parentIdxInUserRows + 1].Index : NewWatchRowIndex;
-                    insertedRows.Add(InsertUserWatchRow(new Watch(nameCell.FullWatchName, type), rowIdxAfterParent));
+                    insertedRows.Add(InsertUserWatchRow(new Watch((string)nameCell.Value, type), rowIdxAfterParent));
                 }
             }
             RaiseWatchStateChanged(insertedRows);

--- a/VSRAD.PackageTests/DebugVisualizer/VisualizerIntegrationTests.cs
+++ b/VSRAD.PackageTests/DebugVisualizer/VisualizerIntegrationTests.cs
@@ -87,36 +87,36 @@ namespace VSRAD.PackageTests.DebugVisualizer
 
             int c = 3, c0 = 4, c1 = 5, c10 = 6, c11 = 7, c2 = 8, c3 = 9, c30 = 10, c4 = 11, c5 = 12;
             Assert.Equal(("c", ""), (vis.GetNameCell(c).Value, vis.GetNameCellParentRowIndexes(c)));
-            Assert.Equal(("[0]", $"{c}"), (vis.GetNameCell(c0).Value, vis.GetNameCellParentRowIndexes(c0)));
-            Assert.Equal(("[1]", $"{c}"), (vis.GetNameCell(c1).Value, vis.GetNameCellParentRowIndexes(c1)));
-            Assert.Equal(("[0]", $"{c},{c1}"), (vis.GetNameCell(c10).Value, vis.GetNameCellParentRowIndexes(c10)));
-            Assert.Equal(("[1]", $"{c},{c1}"), (vis.GetNameCell(c11).Value, vis.GetNameCellParentRowIndexes(c11)));
-            Assert.Equal(("[2]", $"{c}"), (vis.GetNameCell(c2).Value, vis.GetNameCellParentRowIndexes(c2)));
-            Assert.Equal(("[3]", $"{c}"), (vis.GetNameCell(c3).Value, vis.GetNameCellParentRowIndexes(c3)));
-            Assert.Equal(("[0]", $"{c},{c3}"), (vis.GetNameCell(c30).Value, vis.GetNameCellParentRowIndexes(c30)));
-            Assert.Equal(("[4]", $"{c}"), (vis.GetNameCell(c4).Value, vis.GetNameCellParentRowIndexes(c4)));
-            Assert.Equal(("[5]", $"{c}"), (vis.GetNameCell(c5).Value, vis.GetNameCellParentRowIndexes(c5)));
+            Assert.Equal(("c[0]", $"{c}"), (vis.GetNameCell(c0).Value, vis.GetNameCellParentRowIndexes(c0)));
+            Assert.Equal(("c[1]", $"{c}"), (vis.GetNameCell(c1).Value, vis.GetNameCellParentRowIndexes(c1)));
+            Assert.Equal(("c[1][0]", $"{c},{c1}"), (vis.GetNameCell(c10).Value, vis.GetNameCellParentRowIndexes(c10)));
+            Assert.Equal(("c[1][1]", $"{c},{c1}"), (vis.GetNameCell(c11).Value, vis.GetNameCellParentRowIndexes(c11)));
+            Assert.Equal(("c[2]", $"{c}"), (vis.GetNameCell(c2).Value, vis.GetNameCellParentRowIndexes(c2)));
+            Assert.Equal(("c[3]", $"{c}"), (vis.GetNameCell(c3).Value, vis.GetNameCellParentRowIndexes(c3)));
+            Assert.Equal(("c[3][0]", $"{c},{c3}"), (vis.GetNameCell(c30).Value, vis.GetNameCellParentRowIndexes(c30)));
+            Assert.Equal(("c[4]", $"{c}"), (vis.GetNameCell(c4).Value, vis.GetNameCellParentRowIndexes(c4)));
+            Assert.Equal(("c[5]", $"{c}"), (vis.GetNameCell(c5).Value, vis.GetNameCellParentRowIndexes(c5)));
             for (var wave = 0; wave < breakState.Data.WavesPerGroup; ++wave)
             {
                 for (var tid = wave * breakState.Data.WaveSize; tid < (wave + 1) * breakState.Data.WaveSize; ++tid)
                 {
-                    Assert.Equal(wave % 2 == 0 ? $"{wave}" : "<6>", vis.GetDataCell(c, tid).Value);
+                    Assert.Equal(wave % 2 == 0 ? $"{wave}" : "[6]", vis.GetDataCell(c, tid).Value);
                     Assert.Equal(wave % 2 == 0 ? "" : "", vis.GetDataCell(c0, tid).Value);
-                    Assert.Equal(wave % 2 == 0 ? "" : "<2>", vis.GetDataCell(c1, tid).Value);
+                    Assert.Equal(wave % 2 == 0 ? "" : "[2]", vis.GetDataCell(c1, tid).Value);
                     Assert.Equal(wave % 2 == 0 ? "" : $"{tid % breakState.Data.WaveSize}", vis.GetDataCell(c10, tid).Value);
                     Assert.Equal(wave % 2 == 0 ? "" : $"{vis.Context.GroupIndex.X}", vis.GetDataCell(c11, tid).Value);
                     Assert.Equal(wave % 2 == 0 ? "" : "", vis.GetDataCell(c2, tid).Value);
-                    Assert.Equal(wave % 2 == 0 ? "" : "<1>", vis.GetDataCell(c3, tid).Value);
+                    Assert.Equal(wave % 2 == 0 ? "" : "[1]", vis.GetDataCell(c3, tid).Value);
                     Assert.Equal(wave % 2 == 0 ? "" : "", vis.GetDataCell(c30, tid).Value);
-                    Assert.Equal(wave % 2 == 0 ? "" : "<0>", vis.GetDataCell(c4, tid).Value);
+                    Assert.Equal(wave % 2 == 0 ? "" : "[0]", vis.GetDataCell(c4, tid).Value);
                     Assert.Equal(wave % 2 == 0 ? "" : $"{vis.Context.GroupIndex.DimX}", vis.GetDataCell(c5, tid).Value);
                 }
             }
 
             int c_1 = 13, c_10 = 14, c_11 = 15;
             Assert.Equal(("c[1]", ""), (vis.GetNameCell(c_1).Value, vis.GetNameCellParentRowIndexes(c_1)));
-            Assert.Equal(("[0]", $"{c_1}"), (vis.GetNameCell(c_10).Value, vis.GetNameCellParentRowIndexes(c_10)));
-            Assert.Equal(("[1]", $"{c_1}"), (vis.GetNameCell(c_11).Value, vis.GetNameCellParentRowIndexes(c_11)));
+            Assert.Equal(("c[1][0]", $"{c_1}"), (vis.GetNameCell(c_10).Value, vis.GetNameCellParentRowIndexes(c_10)));
+            Assert.Equal(("c[1][1]", $"{c_1}"), (vis.GetNameCell(c_11).Value, vis.GetNameCellParentRowIndexes(c_11)));
             for (var tid = 0; tid < breakState.Data.GroupSize; ++tid)
             {
                 Assert.Equal(vis.GetDataCell(c1, tid).Value, vis.GetDataCell(c_1, tid).Value);
@@ -136,9 +136,9 @@ namespace VSRAD.PackageTests.DebugVisualizer
 
             int lst = 18, lst0 = 19, lst1 = 20, lst2 = 21;
             Assert.Equal(("lst", ""), (vis.GetNameCell(lst).Value, vis.GetNameCellParentRowIndexes(lst)));
-            Assert.Equal(("[0]", $"{lst}"), (vis.GetNameCell(lst0).Value, vis.GetNameCellParentRowIndexes(lst0)));
-            Assert.Equal(("[1]", $"{lst}"), (vis.GetNameCell(lst1).Value, vis.GetNameCellParentRowIndexes(lst1)));
-            Assert.Equal(("[2]", $"{lst}"), (vis.GetNameCell(lst2).Value, vis.GetNameCellParentRowIndexes(lst2)));
+            Assert.Equal(("lst[0]", $"{lst}"), (vis.GetNameCell(lst0).Value, vis.GetNameCellParentRowIndexes(lst0)));
+            Assert.Equal(("lst[1]", $"{lst}"), (vis.GetNameCell(lst1).Value, vis.GetNameCellParentRowIndexes(lst1)));
+            Assert.Equal(("lst[2]", $"{lst}"), (vis.GetNameCell(lst2).Value, vis.GetNameCellParentRowIndexes(lst2)));
         }
     }
 }


### PR DESCRIPTION
* Restore group size independent ranges for Keep first/Keep last menus
* Show full identifiers for list elements (`[0]` -> `lst[0]`)
* Change list labels from `<N>` to `[N]`