### PR TITLE
Another round of minor visualizer fixes

### DIFF
--- a/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml
+++ b/VSRAD.Package/DebugVisualizer/VisualizerControl.xaml
@@ -8,6 +8,6 @@
              d:DesignHeight="450" d:DesignWidth="800">
     <DockPanel>
         <local:VisualizerHeaderControl DebugOptions="{Binding Options.DebuggerOptions}" DataContext="{Binding}" DockPanel.Dock="Top"  x:Name="HeaderHost"/>
-        <local:VisualizerTableHost DockPanel.Dock="Bottom" x:Name="TableHost"/>
+        <local:VisualizerTableHost TabIndex="0" DockPanel.Dock="Bottom" x:Name="TableHost" />
     </DockPanel>
 </UserControl>

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -49,7 +49,6 @@ namespace VSRAD.Package.DebugVisualizer
 
         private readonly TableState _state;
 
-        private bool _hostWindowHasFocus;
         private bool _enterPressedOnWatchEndEdit;
 
         public VisualizerTable(ProjectOptions options, IFontAndColorProvider fontAndColor) : base()
@@ -139,12 +138,20 @@ namespace VSRAD.Package.DebugVisualizer
 
         public void HostWindowFocusChanged(bool hasFocus)
         {
-            _hostWindowHasFocus = hasFocus;
-            if (hasFocus)
-            {
-                DefaultCellStyle.SelectionBackColor = SystemColors.Highlight;
-            }
-            else
+            if (!hasFocus)
+                EndEdit();
+        }
+
+        protected override void OnGotFocus(EventArgs e)
+        {
+            base.OnGotFocus(e);
+            DefaultCellStyle.SelectionBackColor = SystemColors.Highlight;
+        }
+
+        protected override void OnLostFocus(EventArgs e)
+        {
+            base.OnLostFocus(e);
+            if (!ContainsFocus)
             {
                 DefaultCellStyle.SelectionBackColor = Color.LightSteelBlue;
                 EndEdit();
@@ -270,7 +277,7 @@ namespace VSRAD.Package.DebugVisualizer
                 var rowWatchName = (string)row.Cells[NameColumnIndex].Value;
 
                 var nextWatchIndex = -1;
-                var shouldMoveCaretToNextWatch = _hostWindowHasFocus && _enterPressedOnWatchEndEdit;
+                var shouldMoveCaretToNextWatch = ContainsFocus && _enterPressedOnWatchEndEdit;
                 _enterPressedOnWatchEndEdit = false; // Don't move the focus again on successive WatchEndEdit invocations
 
                 if (e.RowIndex == NewWatchRowIndex) // Adding a new watch
@@ -303,7 +310,7 @@ namespace VSRAD.Package.DebugVisualizer
                     }
                 }
 
-                if (!_hostWindowHasFocus)
+                if (!ContainsFocus)
                 {
                     ClearSelection();
                 }
@@ -527,8 +534,11 @@ namespace VSRAD.Package.DebugVisualizer
         public override DataObject GetClipboardContent()
         {
             var content = base.GetClipboardContent();
-            content.SetData(DataFormats.Text, content.GetData(DataFormats.CommaSeparatedValue));
-            content.SetData(DataFormats.UnicodeText, content.GetData(DataFormats.CommaSeparatedValue));
+            if (content != null)
+            {
+                content.SetData(DataFormats.Text, content.GetData(DataFormats.CommaSeparatedValue));
+                content.SetData(DataFormats.UnicodeText, content.GetData(DataFormats.CommaSeparatedValue));
+            }
             return content;
         }
 

--- a/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
+++ b/VSRAD.Package/DebugVisualizer/VisualizerTable.cs
@@ -191,7 +191,9 @@ namespace VSRAD.Package.DebugVisualizer
 
         private void InsertSeparatorRow(int rowIndex, bool after)
         {
-            var index = after ? rowIndex + 1 : rowIndex;
+            int index = rowIndex;
+            if (after)
+                index = Rows.Cast<DataGridViewRow>().First(r => r.Index > rowIndex && !IsListItemRow(r)).Index; // at least one row (NewWatchRow) always satisfies this
             var separatorRow = InsertUserWatchRow(new Watch(" ", VariableType.Default), index);
             RaiseWatchStateChanged(new[] { separatorRow });
         }
@@ -596,10 +598,14 @@ namespace VSRAD.Package.DebugVisualizer
                 }));
                 menu.MenuItems.Add(new MenuItem("-"));
                 menu.MenuItems.Add(new MenuItem("Copy", (s, e) => CopySelectedValues()));
-                menu.MenuItems.Add(new MenuItem("-"));
-                menu.MenuItems.Add(new MenuItem("Insert Row Before", (s, e) => InsertSeparatorRow(hit.RowIndex, false)));
-                menu.MenuItems.Add(new MenuItem("Insert Row After", (s, e) => InsertSeparatorRow(hit.RowIndex, true)));
 
+                if (!IsListItemRow(Rows[hit.RowIndex]))
+                {
+                    menu.MenuItems.Add(new MenuItem("-"));
+                    if (hit.RowIndex != SystemRowIndex)
+                        menu.MenuItems.Add(new MenuItem("Insert Row Before", (s, e) => InsertSeparatorRow(hit.RowIndex, false)));
+                    menu.MenuItems.Add(new MenuItem("Insert Row After", (s, e) => InsertSeparatorRow(hit.RowIndex, true)));
+                }
                 if (hit.RowIndex != SystemRowIndex)
                 {
                     menu.MenuItems.Add(new MenuItem("-"));

--- a/VSRAD.Package/ToolWindows/BaseToolWindow.cs
+++ b/VSRAD.Package/ToolWindows/BaseToolWindow.cs
@@ -13,7 +13,7 @@ namespace VSRAD.Package.ToolWindows
 
         private readonly UIElement _projectStateMissingMessage = new TextBlock
         {
-            Text = "No active projects found.",
+            Text = "No supported projects open.",
             HorizontalAlignment = HorizontalAlignment.Center,
             VerticalAlignment = VerticalAlignment.Center
         };

--- a/VSRAD.Package/Utils/CollectionExtensions.cs
+++ b/VSRAD.Package/Utils/CollectionExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace VSRAD.Package.Utils
 {
@@ -10,6 +12,12 @@ namespace VSRAD.Package.Utils
             for (int i = collection.Count - 1; i >= 0; i--)
                 if (predicate(collection[i]))
                     collection.RemoveAt(i);
+        }
+
+        public static T ExclusiveOrDefault<T>(this IEnumerable<T> source)
+        {
+            var elements = source.Take(2).ToList();
+            return elements.Count == 1 ? elements[0] : default(T);
         }
     }
 }

--- a/VSRAD.Package/VSPackage.cs
+++ b/VSRAD.Package/VSPackage.cs
@@ -23,9 +23,9 @@ namespace VSRAD.Package
     [ProvideDebugPortSupplier(Deborgar.Constants.RemotePortSupplierName, Deborgar.Constants.RemotePortSupplierId,
         typeof(Deborgar.Remote.RemotePortSupplier))]
     [ProvideToolWindow(typeof(VisualizerWindow),
-        Style = VsDockStyle.Tabbed, MultiInstances = false, Transient = true)]
+        Style = VsDockStyle.Tabbed, MultiInstances = false)]
     [ProvideToolWindow(typeof(SliceVisualizerWindow),
-        Style = VsDockStyle.Tabbed, MultiInstances = false, Transient = true)]
+        Style = VsDockStyle.Tabbed, MultiInstances = false)]
     [ProvideToolWindow(typeof(OptionsWindow),
         Style = VsDockStyle.Tabbed, MultiInstances = false, Transient = true)]
     [ProvideMenuResource("Menus.ctmenu", 1)]


### PR DESCRIPTION
* Replace "Promote to Watches" with more general "Add to Watches"
* Fix confusing Visualizer table focus behavior
* Fix "Insert Row Before", "Insert Row After" breaking list watches
* Make sure that Visualizer window reopens after VS is restarted
* Collapse types context menu to single level, show check marks next to selected options