### PR TITLE
Support action cancellation when running locally

### DIFF
--- a/VSRAD.DebugServer/ObservableProcess.cs
+++ b/VSRAD.DebugServer/ObservableProcess.cs
@@ -91,7 +91,7 @@ namespace VSRAD.DebugServer
 
             if (completedTask.IsCanceled || completedTask == processTimeoutTcs.Task)
             {
-                TerminateProcessTree(_process);
+                await Task.Run(() => TerminateProcessTree(_process)); // This might take a few seconds, use Task.Run to avoid blocking the thread
                 if (completedTask.IsCanceled)
                     throw new OperationCanceledException(cancellationToken);
             }

--- a/VSRAD.DebugServer/ObservableProcess.cs
+++ b/VSRAD.DebugServer/ObservableProcess.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using VSRAD.DebugServer.IPC.Responses;
 
@@ -15,7 +17,6 @@ namespace VSRAD.DebugServer
         private readonly Process _process;
         private readonly bool _waitForCompletion;
         private readonly int _timeout;
-        private bool _stoppedByTimeout = false;
 
         public ObservableProcess(IPC.Commands.Execute command)
         {
@@ -46,13 +47,13 @@ namespace VSRAD.DebugServer
             _timeout = command.ExecutionTimeoutSecs;
         }
 
-        public async Task<ExecutionCompleted> StartAndObserveAsync()
+        public async Task<ExecutionCompleted> StartAndObserveAsync(CancellationToken cancellationToken = default)
         {
             if (!_waitForCompletion)
                 return RunWithoutAwaitingCompletion();
 
             var processExitedTcs = new TaskCompletionSource<bool>();
-            _process.Exited += (sender, args) => processExitedTcs.SetResult(true);
+            _process.Exited += (sender, args) => processExitedTcs.TrySetResult(true);
 
             var (stdoutTask, stderrTask) = InitializeOutputCapture();
 
@@ -66,9 +67,8 @@ namespace VSRAD.DebugServer
                     _process.BeginOutputReadLine();
                     _process.BeginErrorReadLine();
                 }
-                SetProcessTimeout();
             }
-            catch (System.ComponentModel.Win32Exception)
+            catch (Win32Exception)
             {
                 return new ExecutionCompleted { Status = ExecutionStatus.CouldNotLaunch };
             }
@@ -77,9 +77,26 @@ namespace VSRAD.DebugServer
                 return new ExecutionCompleted { Status = ExecutionStatus.CouldNotLaunch };
             }
 
-            await processExitedTcs.Task;
+            var processTimeoutTcs = new TaskCompletionSource<bool>();
+            if (_timeout != 0)
+            {
+                var timeoutTimer = new System.Timers.Timer { AutoReset = false, Interval = _timeout * 1000.0 /* ms */ };
+                timeoutTimer.Elapsed += (sender, e) => processTimeoutTcs.TrySetResult(true);
+                timeoutTimer.Start();
+            }
 
-            var status = _stoppedByTimeout ? ExecutionStatus.TimedOut : ExecutionStatus.Completed;
+            Task<bool> completedTask;
+            using (cancellationToken.Register(() => processExitedTcs.TrySetCanceled()))
+                completedTask = await Task.WhenAny(processExitedTcs.Task, processTimeoutTcs.Task);
+
+            if (completedTask.IsCanceled || completedTask == processTimeoutTcs.Task)
+            {
+                TerminateProcessTree(_process);
+                if (completedTask.IsCanceled)
+                    throw new OperationCanceledException(cancellationToken);
+            }
+
+            var status = completedTask == processTimeoutTcs.Task ? ExecutionStatus.TimedOut : ExecutionStatus.Completed;
 
             var stdout = await stdoutTask;
             var stderr = await stderrTask;
@@ -141,26 +158,31 @@ namespace VSRAD.DebugServer
             return (stdoutTcs.Task, stderrTcs.Task);
         }
 
-        private void SetProcessTimeout()
+        private static void TerminateProcessTree(Process parent)
         {
-            if (_timeout == 0)
-                return;
-
-            var timeoutTimer = new System.Timers.Timer()
-            {
-                AutoReset = false,
-                Interval = _timeout * 1000.0 // seconds -> milliseconds
-            };
-            timeoutTimer.Elapsed += (sender, e) =>
+#if NETCOREAPP
+            parent.Kill(entireProcessTree: true);
+#else
+            var searcher = new System.Management.ManagementObjectSearcher("SELECT ProcessID FROM Win32_Process WHERE ParentProcessID = " + parent.Id);
+            var processCollection = searcher.Get();
+            foreach (var p in processCollection)
             {
                 try
                 {
-                    _process.Kill();
-                    _stoppedByTimeout = true;
+                    var childPid = Convert.ToInt32(p["ProcessID"]);
+                    var child = Process.GetProcessById(childPid);
+                    if (parent.StartTime < child.StartTime) // PIDs may be reused
+                        TerminateProcessTree(child);
                 }
-                catch (InvalidOperationException) { /* Already stopped */ }
-            };
-            timeoutTimer.Start();
+                catch (ArgumentException) { /* already exited */ }
+            }
+            try
+            {
+                parent.Kill();
+            }
+            catch (Win32Exception) { /* cannot terminate */ }
+            catch (InvalidOperationException) { /* cannot terminate */ }
+#endif
         }
     }
 }

--- a/VSRAD.Package/Commands/ActionsMenuCommand.cs
+++ b/VSRAD.Package/Commands/ActionsMenuCommand.cs
@@ -68,13 +68,8 @@ namespace VSRAD.Package.Commands
                                      : commandId == Constants.DebugActionCommandId ? BreakTargetSelector.SingleNext
                                      : commandId == Constants.ReverseDebugCommandId ? BreakTargetSelector.SinglePrev
                                      : BreakTargetSelector.SingleRerun;
-                ThreadHelper.JoinableTaskFactory.RunAsyncWithErrorHandling(async () =>
-                {
-                    var result = await _actionController.RunActionAsync(actionName, debugBreakTarget);
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                    if (!result.TryGetResult(out _, out error))
-                        Errors.Show(error);
-                });
+                ThreadHelper.JoinableTaskFactory.RunAsyncWithErrorHandling(() =>
+                    _actionController.RunActionAsync(actionName, debugBreakTarget));
             }
             else
             {

--- a/VSRAD.Package/Options/ProfileOptions.cs
+++ b/VSRAD.Package/Options/ProfileOptions.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using VSRAD.Package.ProjectSystem.Macros;
 using VSRAD.Package.Utils;
@@ -32,6 +33,18 @@ namespace VSRAD.Package.Options
                 Errors.ShowWarning($"An error has occurred while cloning the profile: {e.Message} Proceeding with new profile.");
             }
             return clonedProfile;
+        }
+
+        public bool ActionReadsDebugData(ActionProfileOptions action)
+        {
+            foreach (var step in action.Steps)
+            {
+                if (step is ReadDebugDataStep)
+                    return true;
+                if (step is RunActionStep runOther && Actions.FirstOrDefault(a => a.Name == runOther.Name) is ActionProfileOptions other && ActionReadsDebugData(other))
+                    return true;
+            }
+            return false;
         }
     }
 

--- a/VSRAD.Package/ProjectSystem/ActionLogger.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLogger.cs
@@ -76,7 +76,7 @@ namespace VSRAD.Package.ProjectSystem
             }
             else
             {
-                await _outputWriter.PrintMessageAsync(actionName + " action FAILED");
+                await _outputWriter.PrintMessageAsync(actionName + " action ABORTED");
                 return error;
             }
         }

--- a/VSRAD.Package/ProjectSystem/ActionLogger.cs
+++ b/VSRAD.Package/ProjectSystem/ActionLogger.cs
@@ -6,14 +6,15 @@ using Microsoft.VisualStudio.Shell.Interop;
 using System.ComponentModel.Composition;
 using System.Globalization;
 using System.Text;
+using System.Threading.Tasks;
 using VSRAD.Package.Server;
-using Task = System.Threading.Tasks.Task;
+using VSRAD.Package.Utils;
 
 namespace VSRAD.Package.ProjectSystem
 {
     public interface IActionLogger
     {
-        Task LogActionRunAsync(ActionRunResult runResult);
+        Task<Error> LogActionRunAsync(string actionName, Result<ActionRunResult> actionRun);
     }
 
     [Export(typeof(IActionLogger))]
@@ -39,35 +40,44 @@ namespace VSRAD.Package.ProjectSystem
             });
         }
 
-        public async Task LogActionRunAsync(ActionRunResult runResult)
+        public async Task<Error> LogActionRunAsync(string actionName, Result<ActionRunResult> actionRun)
         {
             await _outputWriter.ClearAsync();
 
-            var title = runResult.ActionName + " action " + (runResult.Successful ? "SUCCEEDED" : "FAILED") + $" in {runResult.TotalMillis}ms";
-
-            var log = new StringBuilder();
-            var warnings = new StringBuilder();
-
-            var actionSucceeded = LogAction(log, warnings, runResult);
-
-            var logString = log.ToString();
-            await _outputWriter.PrintMessageAsync(title, logString);
-
-            var errorListOutput = runResult.GetStepOutputs();
-            var errors = await _errorList.AddToErrorListAsync(errorListOutput);
-
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            if (errors.ErrorCount != 0)
-                _dte.ToolWindows.ErrorList.Parent.Activate();
-            else if (!actionSucceeded)
-                _dte.ToolWindows.OutputWindow.Parent.Activate();
-
-            if (warnings.Length != 0)
+            if (actionRun.TryGetResult(out var runResult, out var error) && runResult != null)
             {
-                if (actionSucceeded)
-                    Errors.ShowWarning(warnings.ToString(), title: runResult.ActionName + " Warning");
-                else
-                    Errors.ShowCritical(warnings.ToString(), title: runResult.ActionName + " Error");
+                var title = runResult.ActionName + " action " + (runResult.Successful ? "SUCCEEDED" : "FAILED") + $" in {runResult.TotalMillis}ms";
+
+                var log = new StringBuilder();
+                var warnings = new StringBuilder();
+
+                var actionSucceeded = LogAction(log, warnings, runResult);
+
+                var logString = log.ToString();
+                await _outputWriter.PrintMessageAsync(title, logString);
+
+                var errorListOutput = runResult.GetStepOutputs();
+                var errors = await _errorList.AddToErrorListAsync(errorListOutput);
+
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                if (errors.ErrorCount != 0)
+                    _dte.ToolWindows.ErrorList.Parent.Activate();
+                else if (!actionSucceeded)
+                    _dte.ToolWindows.OutputWindow.Parent.Activate();
+
+                if (warnings.Length != 0)
+                {
+                    if (actionSucceeded)
+                        return new Error(warnings.ToString(), critical: false, title: runResult.ActionName + " Warning");
+                    else
+                        return new Error(warnings.ToString(), critical: true, title: runResult.ActionName + " Error");
+                }
+                return default;
+            }
+            else
+            {
+                await _outputWriter.PrintMessageAsync(actionName + " action FAILED");
+                return error;
             }
         }
 

--- a/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
+++ b/VSRAD.Package/ProjectSystem/DebuggerIntegration.cs
@@ -175,6 +175,7 @@ namespace VSRAD.Package.ProjectSystem
         void IEngineIntegration.CauseBreak()
         {
             _actionController.Value.AbortRunningAction();
+            NotifyDebugActionExecuted((ActionRunResult)null, BreakTargetSelector.SingleNext);
         }
     }
 }

--- a/VSRAD.Package/Server/ActionRunner.cs
+++ b/VSRAD.Package/Server/ActionRunner.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using VSRAD.DebugServer;
 using VSRAD.DebugServer.IPC.Commands;
@@ -52,7 +53,7 @@ namespace VSRAD.Package.Server
         public DateTime GetInitialFileTimestamp(string file) =>
             _initialTimestamps.TryGetValue(file, out var timestamp) ? timestamp : default;
 
-        public async Task<ActionRunResult> RunAsync(string actionName, IReadOnlyList<IActionStep> steps, bool continueOnError = true)
+        public async Task<ActionRunResult> RunAsync(string actionName, IReadOnlyList<IActionStep> steps, bool continueOnError = true, CancellationToken cancellationToken = default)
         {
             var runStats = new ActionRunResult(actionName, steps, continueOnError);
 

--- a/VSRAD.Package/Utils/VsInfoBar.cs
+++ b/VSRAD.Package/Utils/VsInfoBar.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+
+namespace VSRAD.Package.Utils
+{
+    public sealed class VsInfoBar : IVsInfoBarUIEvents
+    {
+        private readonly InfoBarModel _model;
+        private IVsInfoBarUIElement _uiElement;
+        private readonly uint _listenerCookie;
+        private readonly EventHandler<InfoBarActionItemEventArgs> _actionItemClickHandler;
+
+        public bool IsVisible => _uiElement != null;
+
+        public VsInfoBar(SVsServiceProvider serviceProvider, InfoBarModel model, EventHandler<InfoBarActionItemEventArgs> actionItemClickHandler)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var vsInfoBarFactory = (IVsInfoBarUIFactory)serviceProvider.GetService(typeof(SVsInfoBarUIFactory));
+            Assumes.Present(vsInfoBarFactory);
+
+            var vsShell = (IVsShell)serviceProvider.GetService(typeof(SVsShell));
+            Assumes.Present(vsShell);
+
+            ErrorHandler.ThrowOnFailure(vsShell.GetProperty((int)__VSSPROPID7.VSSPROPID_MainWindowInfoBarHost, out var host));
+            var vsInfoBarHost = (IVsInfoBarHost)host;
+
+            _model = model;
+            _uiElement = vsInfoBarFactory.CreateInfoBar(_model);
+            _uiElement.Advise(this, out _listenerCookie);
+            vsInfoBarHost.AddInfoBar(_uiElement);
+
+            _actionItemClickHandler = actionItemClickHandler;
+        }
+
+        public void Close()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            _uiElement?.Close();
+        }
+
+        void IVsInfoBarUIEvents.OnClosed(IVsInfoBarUIElement infoBarUIElement)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            _uiElement?.Unadvise(_listenerCookie);
+            _uiElement = null;
+        }
+
+        void IVsInfoBarUIEvents.OnActionItemClicked(IVsInfoBarUIElement infoBarUIElement, IVsInfoBarActionItem actionItem)
+        {
+            _actionItemClickHandler?.Invoke(this, new InfoBarActionItemEventArgs(infoBarUIElement, _model, actionItem));
+        }
+    }
+}

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -238,6 +238,7 @@
     <Compile Include="Utils\OleCommandText.cs" />
     <Compile Include="Utils\VsEditor.cs" />
     <Compile Include="Utils\VsEditorView.cs" />
+    <Compile Include="Utils\VsInfoBar.cs" />
     <Compile Include="Utils\VsStatusBarWriter.cs" />
     <Compile Include="Utils\WpfMruEditor.xaml.cs">
       <DependentUpon>WpfMruEditor.xaml</DependentUpon>

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -77,6 +77,7 @@
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Reflection" />

--- a/VSRAD.Package/VSRAD.Package.csproj
+++ b/VSRAD.Package/VSRAD.Package.csproj
@@ -191,7 +191,7 @@
     <Compile Include="Options\MacroItem.cs" />
     <Compile Include="Options\SliceVisualizerOptions.cs" />
     <Compile Include="Options\VisualizerAppearance.cs" />
-    <Compile Include="ProjectSystem\ActionLauncher.cs" />
+    <Compile Include="ProjectSystem\ActionController.cs" />
     <Compile Include="ProjectSystem\ActionLogger.cs" />
     <Compile Include="ProjectSystem\BreakpointTracker.cs" />
     <Compile Include="ProjectSystem\EditorExtensions\BreakLineGlyphFactory.cs" />

--- a/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
+++ b/VSRAD.PackageTests/ProjectSystem/DebuggerIntegrationTests.cs
@@ -73,9 +73,9 @@ namespace VSRAD.PackageTests.ProjectSystem
             serviceProvider.Setup(p => p.GetService(typeof(SVsStatusbar))).Returns(new Mock<IVsStatusbar>().Object);
 
             var channel = new MockCommunicationChannel();
-            var actionLauncher = new ActionLauncher(project, channel.Object, sourceManager.Object,
-                breakpointTracker.Object, serviceProvider.Object);
-            var debuggerIntegration = new DebuggerIntegration(project, actionLauncher, new Mock<IActionLogger>().Object, breakpointTracker.Object, sourceManager.Object);
+            DebuggerIntegration debuggerIntegration = null;
+            var actionController = new Lazy<IActionController>(() => new ActionController(project, new Mock<IActionLogger>().Object, channel.Object, sourceManager.Object, debuggerIntegration, breakpointTracker.Object, serviceProvider.Object));
+            debuggerIntegration = new DebuggerIntegration(project, actionController, breakpointTracker.Object, sourceManager.Object);
 
             /* Set up server responses */
 


### PR DESCRIPTION
Partially reapplying #194 to the current master, with minor changes to process termination code to speed it up and avoid blocking the UI thread. Remote action cancellation is not included in this PR, but should not be hard to add (just need to pass the cancellation token to `CommunicationChannel` and handle it there).